### PR TITLE
Update gitmodules url to be compatible with dependabot

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "product-docs-supplemental-files"]
 	path = product-docs-supplemental-files
-	url = https://github.com/rancher/product-docs-supplemental-files
+	url = https://github.com/rancher/product-docs-supplemental-files.git


### PR DESCRIPTION
It seems dependabot doesn't like when the url of a submodule doesn't have .git at the end.