### PR TITLE
Typo: missing 'https://' (#72 amendment)

### DIFF
--- a/versions/latest/modules/en/pages/cluster-deployment/cluster-deployment.adoc
+++ b/versions/latest/modules/en/pages/cluster-deployment/cluster-deployment.adoc
@@ -27,7 +27,7 @@ Rancher uses the https://rancher.com/docs/rke/latest/en/[Rancher Kubernetes Engi
 
 In RKE clusters, Rancher manages the deployment of Kubernetes. These clusters can be deployed on any bare metal server, cloud provider, or virtualization platform.
 
-These nodes can be dynamically provisioned through Rancher's UI, which calls github.com/docker/docs/blob/vnext-engine/machine/overview.md[Docker Machine] to launch nodes on various cloud providers.
+These nodes can be dynamically provisioned through Rancher's UI, which calls https://github.com/docker/docs/blob/vnext-engine/machine/overview.md[Docker Machine] to launch nodes on various cloud providers.
 
 If you already have a node that you want to add to an RKE cluster, you can add it to the cluster by running a Rancher agent container on it.
 

--- a/versions/latest/modules/en/pages/cluster-deployment/infra-providers/infra-providers.adoc
+++ b/versions/latest/modules/en/pages/cluster-deployment/infra-providers/infra-providers.adoc
@@ -16,7 +16,7 @@ The available cloud providers to create a node template are decided based on act
 
 === Node Templates
 
-A node template is the saved configuration for the parameters to use when provisioning nodes in a specific cloud provider. These nodes can be launched from the UI. Rancher uses github.com/docker/docs/blob/vnext-engine/machine/overview.md[Docker Machine] to provision these nodes. The available cloud providers to create node templates are based on the active node drivers in Rancher.
+A node template is the saved configuration for the parameters to use when provisioning nodes in a specific cloud provider. These nodes can be launched from the UI. Rancher uses https://github.com/docker/docs/blob/vnext-engine/machine/overview.md[Docker Machine] to provision these nodes. The available cloud providers to create node templates are based on the active node drivers in Rancher.
 
 After you create a node template in Rancher, it's saved so that you can use this template again to create node pools. Node templates are bound to your login. After you add a template, you can remove them from your user profile.
 

--- a/versions/latest/modules/zh/pages/cluster-deployment/cluster-deployment.adoc
+++ b/versions/latest/modules/zh/pages/cluster-deployment/cluster-deployment.adoc
@@ -27,7 +27,7 @@ include::shared:ROOT:partial$zh/cluster-capabilities-table.adoc[]
 
 在 RKE 集群中，Rancher 管理 Kubernetes 的部署。这些集群可以部署在任何裸机服务器、云提供商或虚拟化平台上。
 
-这些节点可以通过 Rancher 的 UI 动态配置，该 UI 调用 github.com/docker/docs/blob/vnext-engine/machine/overview.md[Docker Machine] 在各种云提供商上启动节点。
+这些节点可以通过 Rancher 的 UI 动态配置，该 UI 调用 https://github.com/docker/docs/blob/vnext-engine/machine/overview.md[Docker Machine] 在各种云提供商上启动节点。
 
 如果你已经有一个想要添加到 RKE 集群的节点，你可以通过在节点上运行 Rancher Agent 容器将节点添加到集群中。
 

--- a/versions/latest/modules/zh/pages/cluster-deployment/infra-providers/infra-providers.adoc
+++ b/versions/latest/modules/zh/pages/cluster-deployment/infra-providers/infra-providers.adoc
@@ -16,7 +16,7 @@
 
 === 节点模板
 
-节点模板保存了用于在特定云提供商中配置节点时要使用的参数。这些节点可以从 UI 启动。Rancher 使用 github.com/docker/docs/blob/vnext-engine/machine/overview.md[Docker Machine] 来配置这些节点。可用于创建节点模板的云提供商取决于 Rancher 中状态是 Active 的主机驱动。
+节点模板保存了用于在特定云提供商中配置节点时要使用的参数。这些节点可以从 UI 启动。Rancher 使用 https://github.com/docker/docs/blob/vnext-engine/machine/overview.md[Docker Machine] 来配置这些节点。可用于创建节点模板的云提供商取决于 Rancher 中状态是 Active 的主机驱动。
 
 在 Rancher 中创建节点模板后，模板会被保存，以便你可以再次使用该模板来创建节点池。节点模板绑定到你的登录名。添加模板后，你可以将其从用户配置文件中删除。
 

--- a/versions/latest/modules/zh/pages/rancher-admin/global-configuration/provisioning-drivers/manage-node-drivers.adoc
+++ b/versions/latest/modules/zh/pages/rancher-admin/global-configuration/provisioning-drivers/manage-node-drivers.adoc
@@ -36,4 +36,4 @@
 
 == 开发自己的主机驱动
 
-主机驱动使用 github.com/docker/docs/blob/vnext-engine/machine/overview.md[Docker Machine] 来实现。
+主机驱动使用 https://github.com/docker/docs/blob/vnext-engine/machine/overview.md[Docker Machine] 来实现。

--- a/versions/v2.8/modules/en/pages/cluster-deployment/cluster-deployment.adoc
+++ b/versions/v2.8/modules/en/pages/cluster-deployment/cluster-deployment.adoc
@@ -27,7 +27,7 @@ Rancher uses the https://rancher.com/docs/rke/latest/en/[Rancher Kubernetes Engi
 
 In RKE clusters, Rancher manages the deployment of Kubernetes. These clusters can be deployed on any bare metal server, cloud provider, or virtualization platform.
 
-These nodes can be dynamically provisioned through Rancher's UI, which calls github.com/docker/docs/blob/vnext-engine/machine/overview.md[Docker Machine] to launch nodes on various cloud providers.
+These nodes can be dynamically provisioned through Rancher's UI, which calls https://github.com/docker/docs/blob/vnext-engine/machine/overview.md[Docker Machine] to launch nodes on various cloud providers.
 
 If you already have a node that you want to add to an RKE cluster, you can add it to the cluster by running a Rancher agent container on it.
 

--- a/versions/v2.8/modules/en/pages/cluster-deployment/infra-providers/infra-providers.adoc
+++ b/versions/v2.8/modules/en/pages/cluster-deployment/infra-providers/infra-providers.adoc
@@ -16,7 +16,7 @@ The available cloud providers to create a node template are decided based on act
 
 === Node Templates
 
-A node template is the saved configuration for the parameters to use when provisioning nodes in a specific cloud provider. These nodes can be launched from the UI. Rancher uses github.com/docker/docs/blob/vnext-engine/machine/overview.md[Docker Machine] to provision these nodes. The available cloud providers to create node templates are based on the active node drivers in Rancher.
+A node template is the saved configuration for the parameters to use when provisioning nodes in a specific cloud provider. These nodes can be launched from the UI. Rancher uses https://github.com/docker/docs/blob/vnext-engine/machine/overview.md[Docker Machine] to provision these nodes. The available cloud providers to create node templates are based on the active node drivers in Rancher.
 
 After you create a node template in Rancher, it's saved so that you can use this template again to create node pools. Node templates are bound to your login. After you add a template, you can remove them from your user profile.
 

--- a/versions/v2.8/modules/zh/pages/cluster-deployment/cluster-deployment.adoc
+++ b/versions/v2.8/modules/zh/pages/cluster-deployment/cluster-deployment.adoc
@@ -27,7 +27,7 @@ include::shared:ROOT:partial$zh/cluster-capabilities-table.adoc[]
 
 在 RKE 集群中，Rancher 负责管理 Kubernetes 的部署。这些集群可以部署在任何裸机服务器、云提供商或虚拟化平台上。
 
-这些节点可以通过 Rancher 的用户界面动态配置，它可以调用 github.com/docker/docs/blob/vnext-engine/machine/overview.md[Docker Machine] 在各种云提供商上启动节点。
+这些节点可以通过 Rancher 的用户界面动态配置，它可以调用 https://github.com/docker/docs/blob/vnext-engine/machine/overview.md[Docker Machine] 在各种云提供商上启动节点。
 
 如果你已经有了一个要添加到 RKE 集群的节点，可以通过在该节点上运行 Rancher 代理容器将其添加到集群中。
 

--- a/versions/v2.8/modules/zh/pages/cluster-deployment/infra-providers/infra-providers.adoc
+++ b/versions/v2.8/modules/zh/pages/cluster-deployment/infra-providers/infra-providers.adoc
@@ -16,7 +16,7 @@
 
 === 节点模板
 
-节点模板保存了用于在特定云提供商中配置节点时要使用的参数。这些节点可以从 UI 启动。Rancher 使用 github.com/docker/docs/blob/vnext-engine/machine/overview.md[Docker Machine] 来配置这些节点。可用于创建节点模板的云提供商取决于 Rancher 中状态是 Active 的主机驱动。
+节点模板保存了用于在特定云提供商中配置节点时要使用的参数。这些节点可以从 UI 启动。Rancher 使用 https://github.com/docker/docs/blob/vnext-engine/machine/overview.md[Docker Machine] 来配置这些节点。可用于创建节点模板的云提供商取决于 Rancher 中状态是 Active 的主机驱动。
 
 在 Rancher 中创建节点模板后，模板会被保存，以便你可以再次使用该模板来创建节点池。节点模板绑定到你的登录名。添加模板后，你可以将其从用户配置文件中删除。
 

--- a/versions/v2.8/modules/zh/pages/rancher-admin/global-configuration/provisioning-drivers/manage-node-drivers.adoc
+++ b/versions/v2.8/modules/zh/pages/rancher-admin/global-configuration/provisioning-drivers/manage-node-drivers.adoc
@@ -36,4 +36,4 @@
 
 == 开发自己的主机驱动
 
-主机驱动使用 github.com/docker/docs/blob/vnext-engine/machine/overview.md[Docker Machine] 来实现。
+主机驱动使用 https://github.com/docker/docs/blob/vnext-engine/machine/overview.md[Docker Machine] 来实现。

--- a/versions/v2.9/modules/en/pages/cluster-deployment/cluster-deployment.adoc
+++ b/versions/v2.9/modules/en/pages/cluster-deployment/cluster-deployment.adoc
@@ -27,7 +27,7 @@ Rancher uses the https://rancher.com/docs/rke/latest/en/[Rancher Kubernetes Engi
 
 In RKE clusters, Rancher manages the deployment of Kubernetes. These clusters can be deployed on any bare metal server, cloud provider, or virtualization platform.
 
-These nodes can be dynamically provisioned through Rancher's UI, which calls github.com/docker/docs/blob/vnext-engine/machine/overview.md[Docker Machine] to launch nodes on various cloud providers.
+These nodes can be dynamically provisioned through Rancher's UI, which calls https://github.com/docker/docs/blob/vnext-engine/machine/overview.md[Docker Machine] to launch nodes on various cloud providers.
 
 If you already have a node that you want to add to an RKE cluster, you can add it to the cluster by running a Rancher agent container on it.
 

--- a/versions/v2.9/modules/en/pages/cluster-deployment/infra-providers/infra-providers.adoc
+++ b/versions/v2.9/modules/en/pages/cluster-deployment/infra-providers/infra-providers.adoc
@@ -16,7 +16,7 @@ The available cloud providers to create a node template are decided based on act
 
 === Node Templates
 
-A node template is the saved configuration for the parameters to use when provisioning nodes in a specific cloud provider. These nodes can be launched from the UI. Rancher uses github.com/docker/docs/blob/vnext-engine/machine/overview.md[Docker Machine] to provision these nodes. The available cloud providers to create node templates are based on the active node drivers in Rancher.
+A node template is the saved configuration for the parameters to use when provisioning nodes in a specific cloud provider. These nodes can be launched from the UI. Rancher uses https://github.com/docker/docs/blob/vnext-engine/machine/overview.md[Docker Machine] to provision these nodes. The available cloud providers to create node templates are based on the active node drivers in Rancher.
 
 After you create a node template in Rancher, it's saved so that you can use this template again to create node pools. Node templates are bound to your login. After you add a template, you can remove them from your user profile.
 

--- a/versions/v2.9/modules/zh/pages/cluster-deployment/cluster-deployment.adoc
+++ b/versions/v2.9/modules/zh/pages/cluster-deployment/cluster-deployment.adoc
@@ -27,7 +27,7 @@ include::shared:ROOT:partial$zh/cluster-capabilities-table.adoc[]
 
 在 RKE 集群中，Rancher 管理 Kubernetes 的部署。这些集群可以部署在任何裸机服务器、云提供商或虚拟化平台上。
 
-这些节点可以通过 Rancher 的 UI 动态配置，该 UI 调用 github.com/docker/docs/blob/vnext-engine/machine/overview.md[Docker Machine] 在各种云提供商上启动节点。
+这些节点可以通过 Rancher 的 UI 动态配置，该 UI 调用 https://github.com/docker/docs/blob/vnext-engine/machine/overview.md[Docker Machine] 在各种云提供商上启动节点。
 
 如果你已经有一个想要添加到 RKE 集群的节点，你可以通过在节点上运行 Rancher Agent 容器将节点添加到集群中。
 

--- a/versions/v2.9/modules/zh/pages/cluster-deployment/infra-providers/infra-providers.adoc
+++ b/versions/v2.9/modules/zh/pages/cluster-deployment/infra-providers/infra-providers.adoc
@@ -16,7 +16,7 @@
 
 === 节点模板
 
-节点模板保存了用于在特定云提供商中配置节点时要使用的参数。这些节点可以从 UI 启动。Rancher 使用 github.com/docker/docs/blob/vnext-engine/machine/overview.md[Docker Machine] 来配置这些节点。可用于创建节点模板的云提供商取决于 Rancher 中状态是 Active 的主机驱动。
+节点模板保存了用于在特定云提供商中配置节点时要使用的参数。这些节点可以从 UI 启动。Rancher 使用 https://github.com/docker/docs/blob/vnext-engine/machine/overview.md[Docker Machine] 来配置这些节点。可用于创建节点模板的云提供商取决于 Rancher 中状态是 Active 的主机驱动。
 
 在 Rancher 中创建节点模板后，模板会被保存，以便你可以再次使用该模板来创建节点池。节点模板绑定到你的登录名。添加模板后，你可以将其从用户配置文件中删除。
 

--- a/versions/v2.9/modules/zh/pages/rancher-admin/global-configuration/provisioning-drivers/manage-node-drivers.adoc
+++ b/versions/v2.9/modules/zh/pages/rancher-admin/global-configuration/provisioning-drivers/manage-node-drivers.adoc
@@ -36,4 +36,4 @@
 
 == 开发自己的主机驱动
 
-主机驱动使用 github.com/docker/docs/blob/vnext-engine/machine/overview.md[Docker Machine] 来实现。
+主机驱动使用 https://github.com/docker/docs/blob/vnext-engine/machine/overview.md[Docker Machine] 来实现。


### PR DESCRIPTION
Fixes typo introduced in #72 .