### PR TITLE
Fix "broken" links

### DIFF
--- a/versions/latest/modules/en/pages/cluster-deployment/register-existing-clusters.adoc
+++ b/versions/latest/modules/en/pages/cluster-deployment/register-existing-clusters.adoc
@@ -198,7 +198,9 @@ Rancher supports Authorized Cluster Endpoints (ACE) for registered RKE2 and K3s 
 ====== *Manual steps to be taken on the control plane of each downstream cluster to enable ACE:*
 
 . Create a file at `/var/lib/rancher/{rke2,k3s}/kube-api-authn-webhook.yaml` with the following contents:
- ```yaml
++
+[,yaml]
+----
  apiVersion: v1
  kind: Config
  clusters:
@@ -216,7 +218,8 @@ user:
 context:
   user: Default
   cluster: Default
- ```
+----
+
 . Add the following to the config file (or create one if it doesn't exist); note that the default location is `/etc/rancher/{rke2,k3s}/config.yaml`:
 +
 [,yaml]

--- a/versions/latest/modules/en/pages/installation-and-upgrade/references/helm-chart-options.adoc
+++ b/versions/latest/modules/en/pages/installation-and-upgrade/references/helm-chart-options.adoc
@@ -196,7 +196,7 @@ For information on enabling experimental features, refer to xref:rancher-admin/e
 
 | `systemDefaultRegistry`
 | ""
-| `string` - private registry to be used for all system container images, e.g., http://registry.example.com/
+| `string` - private registry to be used for all system container images, e.g., `+https://registry.example.com/+`
 |
 
 | `tls`

--- a/versions/latest/modules/zh/pages/cluster-deployment/register-existing-clusters.adoc
+++ b/versions/latest/modules/zh/pages/cluster-deployment/register-existing-clusters.adoc
@@ -196,7 +196,9 @@ _从 v2.6.3 起可用_
 ====== *在每个下游集群的 controlplane 上启用 ACE 的手动执行步骤*：
 
 . 在 `/var/lib/rancher/{rke2,k3s}/kube-api-authn-webhook.yaml` 创建一个文件，内容如下：
-```yaml
++
+[,yaml]
+----
 apiVersion: v1
 kind: Config
 clusters:
@@ -214,7 +216,8 @@ contexts:
 context:
   user: Default
   cluster: Default
-```
+----
+
 . 将以下内容添加到配置文件中（如果文件不存在，则创建一个）。请注意，默认位置是 `/etc/rancher/{rke2,k3s}/config.yaml`：
 +
 [,yaml]

--- a/versions/latest/modules/zh/pages/installation-and-upgrade/references/helm-chart-options.adoc
+++ b/versions/latest/modules/zh/pages/installation-and-upgrade/references/helm-chart-options.adoc
@@ -191,7 +191,7 @@
 
 | `systemDefaultRegistry`
 | ""
-| `string` - 用于所有系统容器镜像的私有仓库，例如 http://registry.example.com/
+| `string` - 用于所有系统容器镜像的私有仓库，例如 `+https://registry.example.com/+`
 |
 
 | `tls`

--- a/versions/v2.8/modules/en/pages/cluster-deployment/register-existing-clusters.adoc
+++ b/versions/v2.8/modules/en/pages/cluster-deployment/register-existing-clusters.adoc
@@ -198,7 +198,9 @@ Rancher supports Authorized Cluster Endpoints (ACE) for registered RKE2 and K3s 
 ====== *Manual steps to be taken on the control plane of each downstream cluster to enable ACE:*
 
 . Create a file at `/var/lib/rancher/{rke2,k3s}/kube-api-authn-webhook.yaml` with the following contents:
- ```yaml
++
+[,yaml]
+----
  apiVersion: v1
  kind: Config
  clusters:
@@ -216,7 +218,8 @@ user:
 context:
   user: Default
   cluster: Default
- ```
+----
+
 . Add the following to the config file (or create one if it doesn't exist); note that the default location is `/etc/rancher/{rke2,k3s}/config.yaml`:
 +
 [,yaml]

--- a/versions/v2.8/modules/en/pages/installation-and-upgrade/references/helm-chart-options.adoc
+++ b/versions/v2.8/modules/en/pages/installation-and-upgrade/references/helm-chart-options.adoc
@@ -196,7 +196,7 @@ For information on enabling experimental features, refer to xref:rancher-admin/e
 
 | `systemDefaultRegistry`
 | ""
-| `string` - private registry to be used for all system container images, e.g., http://registry.example.com/
+| `string` - private registry to be used for all system container images, e.g., `+https://registry.example.com/+`
 |
 
 | `tls`

--- a/versions/v2.8/modules/zh/pages/cluster-deployment/register-existing-clusters.adoc
+++ b/versions/v2.8/modules/zh/pages/cluster-deployment/register-existing-clusters.adoc
@@ -196,7 +196,9 @@ _从 v2.6.3 起可用_
 ====== *在每个下游集群的 controlplane 上启用 ACE 的手动执行步骤*：
 
 . 在 `/var/lib/rancher/{rke2,k3s}/kube-api-authn-webhook.yaml` 创建一个文件，内容如下：
-```yaml
++
+[,yaml]
+----
 apiVersion: v1
 kind: Config
 clusters:
@@ -214,7 +216,8 @@ contexts:
 context:
   user: Default
   cluster: Default
-```
+----
+
 . 将以下内容添加到配置文件中（如果文件不存在，则创建一个）。请注意，默认位置是 `/etc/rancher/{rke2,k3s}/config.yaml`：
 +
 [,yaml]

--- a/versions/v2.8/modules/zh/pages/installation-and-upgrade/references/helm-chart-options.adoc
+++ b/versions/v2.8/modules/zh/pages/installation-and-upgrade/references/helm-chart-options.adoc
@@ -191,7 +191,7 @@
 
 | `systemDefaultRegistry`
 | ""
-| `string` - 用于所有系统容器镜像的私有仓库，例如 http://registry.example.com/
+| `string` - 用于所有系统容器镜像的私有仓库，例如 `+https://registry.example.com/+`
 |
 
 | `tls`

--- a/versions/v2.9/modules/en/pages/cluster-deployment/register-existing-clusters.adoc
+++ b/versions/v2.9/modules/en/pages/cluster-deployment/register-existing-clusters.adoc
@@ -198,7 +198,9 @@ Rancher supports Authorized Cluster Endpoints (ACE) for registered RKE2 and K3s 
 ====== *Manual steps to be taken on the control plane of each downstream cluster to enable ACE:*
 
 . Create a file at `/var/lib/rancher/{rke2,k3s}/kube-api-authn-webhook.yaml` with the following contents:
- ```yaml
++
+[,yaml]
+----
  apiVersion: v1
  kind: Config
  clusters:
@@ -216,7 +218,8 @@ user:
 context:
   user: Default
   cluster: Default
- ```
+----
+
 . Add the following to the config file (or create one if it doesn't exist); note that the default location is `/etc/rancher/{rke2,k3s}/config.yaml`:
 +
 [,yaml]

--- a/versions/v2.9/modules/en/pages/installation-and-upgrade/references/helm-chart-options.adoc
+++ b/versions/v2.9/modules/en/pages/installation-and-upgrade/references/helm-chart-options.adoc
@@ -196,7 +196,7 @@ For information on enabling experimental features, refer to xref:rancher-admin/e
 
 | `systemDefaultRegistry`
 | ""
-| `string` - private registry to be used for all system container images, e.g., http://registry.example.com/
+| `string` - private registry to be used for all system container images, e.g., `+https://registry.example.com/+`
 |
 
 | `tls`

--- a/versions/v2.9/modules/zh/pages/cluster-deployment/register-existing-clusters.adoc
+++ b/versions/v2.9/modules/zh/pages/cluster-deployment/register-existing-clusters.adoc
@@ -196,7 +196,9 @@ _从 v2.6.3 起可用_
 ====== *在每个下游集群的 controlplane 上启用 ACE 的手动执行步骤*：
 
 . 在 `/var/lib/rancher/{rke2,k3s}/kube-api-authn-webhook.yaml` 创建一个文件，内容如下：
-```yaml
++
+[,yaml]
+----
 apiVersion: v1
 kind: Config
 clusters:
@@ -214,7 +216,8 @@ contexts:
 context:
   user: Default
   cluster: Default
-```
+----
+
 . 将以下内容添加到配置文件中（如果文件不存在，则创建一个）。请注意，默认位置是 `/etc/rancher/{rke2,k3s}/config.yaml`：
 +
 [,yaml]

--- a/versions/v2.9/modules/zh/pages/installation-and-upgrade/references/helm-chart-options.adoc
+++ b/versions/v2.9/modules/zh/pages/installation-and-upgrade/references/helm-chart-options.adoc
@@ -191,7 +191,7 @@
 
 | `systemDefaultRegistry`
 | ""
-| `string` - 用于所有系统容器镜像的私有仓库，例如 http://registry.example.com/
+| `string` - 用于所有系统容器镜像的私有仓库，例如 `+https://registry.example.com/+`
 |
 
 | `tls`


### PR DESCRIPTION
Our content contain some example values that take the form of a URL, but due to some examples not being formatted correctly they're being flagged as broken external links by our site monitoring tool.

For example URLs in:
- Code blocks
- Inline/monospace formatted text that occurs within the flow of regular text