### PR TITLE
Sync PR #1542 (Add managed system upgrade controller feature flag) from Community docs

### DIFF
--- a/versions/latest/modules/en/pages/installation-and-upgrade/references/feature-flags.adoc
+++ b/versions/latest/modules/en/pages/installation-and-upgrade/references/feature-flags.adoc
@@ -18,6 +18,7 @@ The following is a list of feature flags available in Rancher. If you've upgrade
 * `harvester`: Manages access to the Virtualization Management page, where users can navigate directly to Harvester clusters and access the Harvester UI. See xref:integrations/harvester/overview.adoc[Harvester Integration Overview] for more information.
 * `istio-virtual-service-ui`: Enables a xref:rancher-admin/experimental-features/istio-traffic-management-features.adoc[visual interface] to create, read, update, and delete Istio virtual services and destination rules, which are Istio traffic management features.
 * `legacy`: Enables a set of features from 2.5.x and earlier, that are slowly being phased out in favor of newer implementations. These are a mix of deprecated features as well as features that will eventually be available to newer versions. This flag is disabled by default on new Rancher installations. If you're upgrading from a previous version of Rancher, this flag is enabled.
+* `managed-system-upgrade-controller`: Enables the installation of the system-upgrade-controller app in downstream RKE2/K3s clusters, currently limited to imported clusters and the local cluster, with plans to expand support to node-driver clusters.
 * `multi-cluster-management`: Allows multi-cluster provisioning and management of Kubernetes clusters. This flag can only be set at install time. It can't be enabled or disabled later.
 * `rke1-custom-node-cleanup`: Enables cleanup of deleted RKE1 custom nodes. We recommend that you keep this flag enabled, to prevent removed nodes from attempting to rejoin the cluster.
 * `rke2`: Enables provisioning RKE2 clusters. This flag is enabled by default.
@@ -65,6 +66,12 @@ The following table shows the availability and default values for some feature f
 | `false` for new installs, `true` for upgrades
 | GA
 | v2.6.0
+|
+
+| `managed-system-upgrade-controller`
+| `true`
+| GA
+| v2.10.0
 |
 
 | `rke1-custom-node-cleanup`

--- a/versions/latest/modules/zh/pages/installation-and-upgrade/references/feature-flags.adoc
+++ b/versions/latest/modules/zh/pages/installation-and-upgrade/references/feature-flags.adoc
@@ -18,6 +18,7 @@
 * `harvester`：管理 Virtualization Management 页面的访问。用户可以在该页面直接导航到 Harvester 集群并访问 Harvester UI。有关详细信息，请参阅 xref:integrations/harvester/overview.adoc[Harvester 集成]。
 * `istio-virtual-service-ui`：启用xref:rancher-admin/experimental-features/istio-traffic-management-features.adoc[可视界面]来创建、读取、更新和删除 Istio 虚拟服务和目标规则，这些都是 Istio 流量管理功能。
 * `legacy`：启用 2.5.x 及更早版本的一组功能，这些功能正逐渐被新的实现淘汰。它们是已弃用以及后续可用于新版本的功能组合。新的 Rancher 安装会默认禁用此标志。如果你从以前版本的 Rancher 升级，此标志会启用。
+* `managed-system-upgrade-controller`: Enables the installation of the system-upgrade-controller app in downstream RKE2/K3s clusters, currently limited to imported clusters and the local cluster, with plans to expand support to node-driver clusters.
 * `multi-cluster-management`：允许配置和管理多个 Kubernetes 集群。此标志只能在安装时设置。后续无法启用或禁用它。
 * `rke1-custom-node-cleanup`：清除已删除的 RKE1 自定义节点。建议你启用此标志，以防止已删除的节点尝试重新加入集群。
 * `rke2`：启用配置 RKE2 集群。此标志默认启用。
@@ -27,45 +28,77 @@
 下表介绍了 Rancher 中功能开关的可用性和默认值。标记为"`GA`"的功能已普遍可用：
 
 |===
-| 功能开关名称 | 默认值 | 状态 | 可用于
+| 功能开关名称 | 默认值 | 状态 | 可用于 | Additional Information
 
 | `continuous-delivery`
 | `true`
 | GA
 | v2.6.0
+|
+
+| `external-rules`
+| v2.7.14: `false`, v2.8.5: `true`
+| Removed
+| v2.7.14, v2.8.5
+| This flag affected xref:rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/cluster-and-project-roles.adoc#_external_roletemplate_behavior[external `RoleTemplate` behavior]. It is removed in Rancher v2.9.0 and later as the behavior is enabled by default.
 
 | `fleet`
 | `true`
 | 不能禁用
 | v2.6.0
+|
 
 | `fleet`
 | `true`
 | GA
 | v2.5.0
+|
 
 | `harvester`
 | `true`
 | 实验功能
 | v2.6.1
+|
 
 | `legacy`
 | 新安装：`false`；升级：`true`
 | GA
 | v2.6.0
+|
+
+| `managed-system-upgrade-controller`
+| `true`
+| GA
+| v2.10.0
+|
 
 | `rke1-custom-node-cleanup`
 | `true`
 | GA
 | v2.6.0
+|
 
 | `rke2`
 | `true`
 | 实验功能
 | v2.6.0
+|
 
 | `token-hashing`
 | 新安装：`false`；升级：`true`
 | GA
 | v2.6.0
+|
+
+| `uiextension`
+| `true`
+| GA
+| v2.9.0
+|
+
+| `ui-sql-cache`
+| `false`
+| Highly experimental
+| v2.9.0
+|
 |===

--- a/versions/v2.10/modules/en/pages/installation-and-upgrade/references/feature-flags.adoc
+++ b/versions/v2.10/modules/en/pages/installation-and-upgrade/references/feature-flags.adoc
@@ -18,6 +18,7 @@ The following is a list of feature flags available in Rancher. If you've upgrade
 * `harvester`: Manages access to the Virtualization Management page, where users can navigate directly to Harvester clusters and access the Harvester UI. See xref:integrations/harvester/overview.adoc[Harvester Integration Overview] for more information.
 * `istio-virtual-service-ui`: Enables a xref:rancher-admin/experimental-features/istio-traffic-management-features.adoc[visual interface] to create, read, update, and delete Istio virtual services and destination rules, which are Istio traffic management features.
 * `legacy`: Enables a set of features from 2.5.x and earlier, that are slowly being phased out in favor of newer implementations. These are a mix of deprecated features as well as features that will eventually be available to newer versions. This flag is disabled by default on new Rancher installations. If you're upgrading from a previous version of Rancher, this flag is enabled.
+* `managed-system-upgrade-controller`: Enables the installation of the system-upgrade-controller app in downstream RKE2/K3s clusters, currently limited to imported clusters and the local cluster, with plans to expand support to node-driver clusters.
 * `multi-cluster-management`: Allows multi-cluster provisioning and management of Kubernetes clusters. This flag can only be set at install time. It can't be enabled or disabled later.
 * `rke1-custom-node-cleanup`: Enables cleanup of deleted RKE1 custom nodes. We recommend that you keep this flag enabled, to prevent removed nodes from attempting to rejoin the cluster.
 * `rke2`: Enables provisioning RKE2 clusters. This flag is enabled by default.
@@ -65,6 +66,12 @@ The following table shows the availability and default values for some feature f
 | `false` for new installs, `true` for upgrades
 | GA
 | v2.6.0
+|
+
+| `managed-system-upgrade-controller`
+| `true`
+| GA
+| v2.10.0
 |
 
 | `rke1-custom-node-cleanup`

--- a/versions/v2.10/modules/zh/pages/installation-and-upgrade/references/feature-flags.adoc
+++ b/versions/v2.10/modules/zh/pages/installation-and-upgrade/references/feature-flags.adoc
@@ -18,6 +18,7 @@
 * `harvester`：管理 Virtualization Management 页面的访问。用户可以在该页面直接导航到 Harvester 集群并访问 Harvester UI。有关详细信息，请参阅 xref:integrations/harvester/overview.adoc[Harvester 集成]。
 * `istio-virtual-service-ui`：启用xref:rancher-admin/experimental-features/istio-traffic-management-features.adoc[可视界面]来创建、读取、更新和删除 Istio 虚拟服务和目标规则，这些都是 Istio 流量管理功能。
 * `legacy`：启用 2.5.x 及更早版本的一组功能，这些功能正逐渐被新的实现淘汰。它们是已弃用以及后续可用于新版本的功能组合。新的 Rancher 安装会默认禁用此标志。如果你从以前版本的 Rancher 升级，此标志会启用。
+* `managed-system-upgrade-controller`: Enables the installation of the system-upgrade-controller app in downstream RKE2/K3s clusters, currently limited to imported clusters and the local cluster, with plans to expand support to node-driver clusters.
 * `multi-cluster-management`：允许配置和管理多个 Kubernetes 集群。此标志只能在安装时设置。后续无法启用或禁用它。
 * `rke1-custom-node-cleanup`：清除已删除的 RKE1 自定义节点。建议你启用此标志，以防止已删除的节点尝试重新加入集群。
 * `rke2`：启用配置 RKE2 集群。此标志默认启用。
@@ -27,45 +28,77 @@
 下表介绍了 Rancher 中功能开关的可用性和默认值。标记为"`GA`"的功能已普遍可用：
 
 |===
-| 功能开关名称 | 默认值 | 状态 | 可用于
+| 功能开关名称 | 默认值 | 状态 | 可用于 | Additional Information
 
 | `continuous-delivery`
 | `true`
 | GA
 | v2.6.0
+|
+
+| `external-rules`
+| v2.7.14: `false`, v2.8.5: `true`
+| Removed
+| v2.7.14, v2.8.5
+| This flag affected xref:rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/cluster-and-project-roles.adoc#_external_roletemplate_behavior[external `RoleTemplate` behavior]. It is removed in Rancher v2.9.0 and later as the behavior is enabled by default.
 
 | `fleet`
 | `true`
 | 不能禁用
 | v2.6.0
+|
 
 | `fleet`
 | `true`
 | GA
 | v2.5.0
+|
 
 | `harvester`
 | `true`
 | 实验功能
 | v2.6.1
+|
 
 | `legacy`
 | 新安装：`false`；升级：`true`
 | GA
 | v2.6.0
+|
+
+| `managed-system-upgrade-controller`
+| `true`
+| GA
+| v2.10.0
+|
 
 | `rke1-custom-node-cleanup`
 | `true`
 | GA
 | v2.6.0
+|
 
 | `rke2`
 | `true`
 | 实验功能
 | v2.6.0
+|
 
 | `token-hashing`
 | 新安装：`false`；升级：`true`
 | GA
 | v2.6.0
+|
+
+| `uiextension`
+| `true`
+| GA
+| v2.9.0
+|
+
+| `ui-sql-cache`
+| `false`
+| Highly experimental
+| v2.9.0
+|
 |===

--- a/versions/v2.9/modules/zh/pages/installation-and-upgrade/references/feature-flags.adoc
+++ b/versions/v2.9/modules/zh/pages/installation-and-upgrade/references/feature-flags.adoc
@@ -22,50 +22,77 @@
 * `rke1-custom-node-cleanup`：清除已删除的 RKE1 自定义节点。建议你启用此标志，以防止已删除的节点尝试重新加入集群。
 * `rke2`：启用配置 RKE2 集群。此标志默认启用。
 * `token-hashing`：启用令牌哈希。启用后，会使用 SHA256 算法对现有 Token 和所有新 Token 进行哈希处理。一旦对 Token 进行哈希处理，就无法撤消操作。此标志在启用后无法禁用。有关详细信息，请参阅 xref:api/api-tokens.adoc#_令牌哈希[API 令牌]。
+* `uiextension`: Enables UI extensions. This flag is enabled by default. Enabling or disabling the flag forces the Rancher pod to restart. The first time this flag is set to `true`, it creates a CRD and enables the controllers and endpoints necessary for the feature to work. If set to `false`, it disables the previously mentioned controllers and endpoints. Setting `uiextension` to `false` has no effect on the CRD -- it does not create a CRD if it does not yet exist, nor does it delete the CRD if it already exists.
 * `unsupported-storage-drivers`：允许启用非默认启用的存储提供程序和卷插件。有关详细信息，请参阅xref:rancher-admin/experimental-features/unsupported-storage-drivers.adoc[允许使用不受支持的存储驱动程序]。
+* `ui-sql-cache`: Enables a SQLite-based cache for UI tables. See xref:rancher-admin/experimental-features/ui-server-side-pagination.adoc[UI Server-Side Pagination] for more information.
 
 下表介绍了 Rancher 中功能开关的可用性和默认值。标记为"`GA`"的功能已普遍可用：
 
 |===
-| 功能开关名称 | 默认值 | 状态 | 可用于
+| 功能开关名称 | 默认值 | 状态 | 可用于 | Additional Information
 
 | `continuous-delivery`
 | `true`
 | GA
 | v2.6.0
+|
+
+| `external-rules`
+| v2.7.14: `false`, v2.8.5: `true`
+| Removed
+| v2.7.14, v2.8.5
+| This flag affected xref:rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/cluster-and-project-roles.adoc#_external_roletemplate_behavior[external `RoleTemplate` behavior]. It is removed in Rancher v2.9.0 and later as the behavior is enabled by default.
 
 | `fleet`
 | `true`
 | 不能禁用
 | v2.6.0
+|
 
 | `fleet`
 | `true`
 | GA
 | v2.5.0
+|
 
 | `harvester`
 | `true`
 | 实验功能
 | v2.6.1
+|
 
 | `legacy`
 | 新安装：`false`；升级：`true`
 | GA
 | v2.6.0
+|
 
 | `rke1-custom-node-cleanup`
 | `true`
 | GA
 | v2.6.0
+|
 
 | `rke2`
 | `true`
 | 实验功能
 | v2.6.0
+|
 
 | `token-hashing`
 | 新安装：`false`；升级：`true`
 | GA
 | v2.6.0
+
+| `uiextension`
+| `true`
+| GA
+| v2.9.0
+|
+
+| `ui-sql-cache`
+| `false`
+| Highly experimental
+| v2.9.0
+|
 |===


### PR DESCRIPTION
Also adds missing content from the zh docs to 2.9/2.10/latest

Related to https://github.com/rancher/rancher-docs/pull/1542