### PR TITLE
Sync PR #1540 (Document additional Project Public API workflows) from Community Docs

### DIFF
--- a/versions/latest/modules/en/pages/api/workflows/projects.adoc
+++ b/versions/latest/modules/en/pages/api/workflows/projects.adoc
@@ -45,6 +45,10 @@ EOF
 
 Setting the `field.cattle.io/creatorId` field allows the cluster member account to see project resources with the `get` command and view the project in the Rancher UI. Cluster owner and admin accounts don't need to set this annotation to perform these tasks.
 
+Setting the `field.cattle.io/creator-principal-name` annotation to the user's principal preserves it in a projectroletemplatebinding automatically created for the project owner.
+
+If you don't want the creator to be added as the owner member (e.g., if the creator is a cluster administrator) to the project you may set the `field.cattle.io/no-creator-rbac` annotation to `true`, which will prevent the corresponding projectroletemplatebinding from being created.
+
 === Creating a Project With a Resource Quota
 
 Refer to https://kubernetes.io/docs/concepts/policy/resource-quotas/[Kubernetes Resource Quota].

--- a/versions/latest/modules/zh/pages/api/workflows/projects.adoc
+++ b/versions/latest/modules/zh/pages/api/workflows/projects.adoc
@@ -45,6 +45,10 @@ EOF
 
 设置 `field.cattle.io/creatorId` 字段允许集群成员账户通过 `get` 命令查看项目资源，并可以在 Rancher UI 中查看项目。集群所有者和管理员账号不需要设置此注释。
 
+Setting the `field.cattle.io/creator-principal-name` annotation to the user's principal preserves it in a projectroletemplatebinding automatically created for the project owner.
+
+If you don't want the creator to be added as the owner member (e.g., if the creator is a cluster administrator) to the project you may set the `field.cattle.io/no-creator-rbac` annotation to `true`, which will prevent the corresponding projectroletemplatebinding from being created.
+
 === 创建一个具有 Resource Quota 的项目
 
 请查看 https://kubernetes.io/docs/concepts/policy/resource-quotas/[Kubernetes Resource Quota]。

--- a/versions/v2.10/modules/en/pages/api/workflows/projects.adoc
+++ b/versions/v2.10/modules/en/pages/api/workflows/projects.adoc
@@ -45,6 +45,10 @@ EOF
 
 Setting the `field.cattle.io/creatorId` field allows the cluster member account to see project resources with the `get` command and view the project in the Rancher UI. Cluster owner and admin accounts don't need to set this annotation to perform these tasks.
 
+Setting the `field.cattle.io/creator-principal-name` annotation to the user's principal preserves it in a projectroletemplatebinding automatically created for the project owner.
+
+If you don't want the creator to be added as the owner member (e.g., if the creator is a cluster administrator) to the project you may set the `field.cattle.io/no-creator-rbac` annotation to `true`, which will prevent the corresponding projectroletemplatebinding from being created.
+
 === Creating a Project With a Resource Quota
 
 Refer to https://kubernetes.io/docs/concepts/policy/resource-quotas/[Kubernetes Resource Quota].

--- a/versions/v2.10/modules/zh/pages/api/workflows/projects.adoc
+++ b/versions/v2.10/modules/zh/pages/api/workflows/projects.adoc
@@ -45,6 +45,10 @@ EOF
 
 设置 `field.cattle.io/creatorId` 字段允许集群成员账户通过 `get` 命令查看项目资源，并可以在 Rancher UI 中查看项目。集群所有者和管理员账号不需要设置此注释。
 
+Setting the `field.cattle.io/creator-principal-name` annotation to the user's principal preserves it in a projectroletemplatebinding automatically created for the project owner.
+
+If you don't want the creator to be added as the owner member (e.g., if the creator is a cluster administrator) to the project you may set the `field.cattle.io/no-creator-rbac` annotation to `true`, which will prevent the corresponding projectroletemplatebinding from being created.
+
 === 创建一个具有 Resource Quota 的项目
 
 请查看 https://kubernetes.io/docs/concepts/policy/resource-quotas/[Kubernetes Resource Quota]。


### PR DESCRIPTION
Related to https://github.com/rancher/rancher-docs/pull/1540 and #101.

In #101 the only the changes to v2.8 and v2.9 were ported over as our v2.10 folder was not available at the time. This PR handles the v2.10-specific content.