### PR TITLE
Fix content.sources.branch setting - causes duplicate resource error

### DIFF
--- a/playbook-local.yml
+++ b/playbook-local.yml
@@ -7,6 +7,7 @@ content:
   sources: 
   - url: .
     start_paths: [shared, versions/latest, versions/v2.10, versions/v2.9, versions/v2.8]
+    branches: HEAD
 ui: 
   bundle:
     url: https://github.com/rancher/product-docs-ui/blob/main/build/ui-bundle.zip?raw=true


### PR DESCRIPTION
Fixes #124 

Only use the current branch per https://docs.antora.org/antora/latest/playbook/content-branches/#current-local-branch.