### PR TITLE
Add a note about cluster membership limitations

### DIFF
--- a/versions/latest/modules/en/pages/cluster-admin/manage-clusters/access-clusters/add-users-to-clusters.adoc
+++ b/versions/latest/modules/en/pages/cluster-admin/manage-clusters/access-clusters/add-users-to-clusters.adoc
@@ -4,7 +4,7 @@ To provide a user access to view certain cluster-level resources and create new 
 
 [TIP]
 ====
-Want to provide a user with access to a _specific_ project within a cluster? See xref:../../../cluster-admin/project-admin/add-users-to-projects.adoc[Adding Project Members] instead.
+Want to provide a user with access to a _specific_ project within a cluster? See xref:cluster-admin/project-admin/add-users-to-projects.adoc[Adding Project Members] instead.
 ====
 
 There are two contexts where you can add cluster members:

--- a/versions/latest/modules/en/pages/cluster-admin/manage-clusters/access-clusters/add-users-to-clusters.adoc
+++ b/versions/latest/modules/en/pages/cluster-admin/manage-clusters/access-clusters/add-users-to-clusters.adoc
@@ -1,13 +1,12 @@
 = Adding Users to Clusters
 
-If you want to provide a user with access and permissions to _all_ projects, nodes, and resources within a cluster, assign the user a cluster membership.
+To provide a user access to view certain cluster-level resources and create new projects, assign the user a **Cluster Membership**. Cluster members can create projects and manage resources in those projects. However, not all resources, namespaces and workloads in a cluster are accessible by cluster members.
 
 [TIP]
 ====
 
-Want to provide a user with access to a _specific_ project within a cluster? See xref:cluster-admin/project-admin/add-users-to-projects.adoc[][Adding Project Members] instead.
+Want to provide a user with access to a _specific_ project within a cluster? See xref:cluster-admin/project-admin/add-users-to-projects.adoc[Adding Project Members] instead.
 ====
-
 
 There are two contexts where you can add cluster members:
 
@@ -48,7 +47,6 @@ There may be an issue with your search attribute configuration. See xref:rancher
 If you are logged in as a local user, external users do not display in your search results. For more information, see xref:rancher-admin/users/authn-and-authz/authn-and-authz.adoc#_external_authentication_configuration_and_principal_users[External Authentication Configuration and Principal Users].
 ====
 
-
 . Assign the user or group *Cluster* roles.
 +
 xref:rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/cluster-and-project-roles.adoc[What are Cluster Roles?]
@@ -61,7 +59,6 @@ For Custom Roles, you can modify the list of individual roles available for assi
 * To add roles to the list, xref:rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/custom-roles.adoc[Add a Custom Role].
 * To remove roles from the list, xref:rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/locked-roles.adoc[Lock/Unlock Roles].
 ====
-
 
 *Result:* The chosen users are added to the cluster.
 

--- a/versions/latest/modules/en/pages/cluster-admin/manage-clusters/access-clusters/add-users-to-clusters.adoc
+++ b/versions/latest/modules/en/pages/cluster-admin/manage-clusters/access-clusters/add-users-to-clusters.adoc
@@ -4,8 +4,7 @@ To provide a user access to view certain cluster-level resources and create new 
 
 [TIP]
 ====
-
-Want to provide a user with access to a _specific_ project within a cluster? See xref:cluster-admin/project-admin/add-users-to-projects.adoc[Adding Project Members] instead.
+Want to provide a user with access to a _specific_ project within a cluster? See xref:../../../cluster-admin/project-admin/add-users-to-projects.adoc[Adding Project Members] instead.
 ====
 
 There are two contexts where you can add cluster members:

--- a/versions/latest/modules/zh/pages/cluster-admin/manage-clusters/access-clusters/add-users-to-clusters.adoc
+++ b/versions/latest/modules/zh/pages/cluster-admin/manage-clusters/access-clusters/add-users-to-clusters.adoc
@@ -1,13 +1,11 @@
 = 将用户添加到集群
 
-如果你想为用户提供对集群内 _所有_ 项目、节点和资源的访问权限，请为用户分配集群成员资格。
+To provide a user access to view certain cluster-level resources and create new projects, assign the user a **Cluster Membership**. Cluster members can create projects and manage resources in those projects. However, not all resources, namespaces and workloads in a cluster are accessible by cluster members.
 
 [TIP]
 ====
-
-如果你想为用户提供对集群内 _特定_ 项目的访问权限，请参见xref:cluster-admin/project-admin/add-users-to-projects.adoc[][添加项目成员]。
+Want to provide a user with access to a _specific_ project within a cluster? See xref:../../../cluster-admin/project-admin/add-users-to-projects.adoc[Adding Project Members] instead.
 ====
-
 
 你可以在两种情况下添加集群成员：
 

--- a/versions/latest/modules/zh/pages/cluster-admin/manage-clusters/access-clusters/add-users-to-clusters.adoc
+++ b/versions/latest/modules/zh/pages/cluster-admin/manage-clusters/access-clusters/add-users-to-clusters.adoc
@@ -4,7 +4,7 @@ To provide a user access to view certain cluster-level resources and create new 
 
 [TIP]
 ====
-Want to provide a user with access to a _specific_ project within a cluster? See xref:../../../cluster-admin/project-admin/add-users-to-projects.adoc[Adding Project Members] instead.
+Want to provide a user with access to a _specific_ project within a cluster? See xref:cluster-admin/project-admin/add-users-to-projects.adoc[Adding Project Members] instead.
 ====
 
 你可以在两种情况下添加集群成员：

--- a/versions/v2.10/modules/en/pages/cluster-admin/manage-clusters/access-clusters/add-users-to-clusters.adoc
+++ b/versions/v2.10/modules/en/pages/cluster-admin/manage-clusters/access-clusters/add-users-to-clusters.adoc
@@ -4,7 +4,7 @@ To provide a user access to view certain cluster-level resources and create new 
 
 [TIP]
 ====
-Want to provide a user with access to a _specific_ project within a cluster? See xref:../../../cluster-admin/project-admin/add-users-to-projects.adoc[Adding Project Members] instead.
+Want to provide a user with access to a _specific_ project within a cluster? See xref:cluster-admin/project-admin/add-users-to-projects.adoc[Adding Project Members] instead.
 ====
 
 There are two contexts where you can add cluster members:

--- a/versions/v2.10/modules/en/pages/cluster-admin/manage-clusters/access-clusters/add-users-to-clusters.adoc
+++ b/versions/v2.10/modules/en/pages/cluster-admin/manage-clusters/access-clusters/add-users-to-clusters.adoc
@@ -1,13 +1,12 @@
 = Adding Users to Clusters
 
-If you want to provide a user with access and permissions to _all_ projects, nodes, and resources within a cluster, assign the user a cluster membership.
+To provide a user access to view certain cluster-level resources and create new projects, assign the user a **Cluster Membership**. Cluster members can create projects and manage resources in those projects. However, not all resources, namespaces and workloads in a cluster are accessible by cluster members.
 
 [TIP]
 ====
 
-Want to provide a user with access to a _specific_ project within a cluster? See xref:cluster-admin/project-admin/add-users-to-projects.adoc[][Adding Project Members] instead.
+Want to provide a user with access to a _specific_ project within a cluster? See xref:cluster-admin/project-admin/add-users-to-projects.adoc[Adding Project Members] instead.
 ====
-
 
 There are two contexts where you can add cluster members:
 
@@ -48,7 +47,6 @@ There may be an issue with your search attribute configuration. See xref:rancher
 If you are logged in as a local user, external users do not display in your search results. For more information, see xref:rancher-admin/users/authn-and-authz/authn-and-authz.adoc#_external_authentication_configuration_and_principal_users[External Authentication Configuration and Principal Users].
 ====
 
-
 . Assign the user or group *Cluster* roles.
 +
 xref:rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/cluster-and-project-roles.adoc[What are Cluster Roles?]
@@ -61,7 +59,6 @@ For Custom Roles, you can modify the list of individual roles available for assi
 * To add roles to the list, xref:rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/custom-roles.adoc[Add a Custom Role].
 * To remove roles from the list, xref:rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/locked-roles.adoc[Lock/Unlock Roles].
 ====
-
 
 *Result:* The chosen users are added to the cluster.
 

--- a/versions/v2.10/modules/en/pages/cluster-admin/manage-clusters/access-clusters/add-users-to-clusters.adoc
+++ b/versions/v2.10/modules/en/pages/cluster-admin/manage-clusters/access-clusters/add-users-to-clusters.adoc
@@ -4,8 +4,7 @@ To provide a user access to view certain cluster-level resources and create new 
 
 [TIP]
 ====
-
-Want to provide a user with access to a _specific_ project within a cluster? See xref:cluster-admin/project-admin/add-users-to-projects.adoc[Adding Project Members] instead.
+Want to provide a user with access to a _specific_ project within a cluster? See xref:../../../cluster-admin/project-admin/add-users-to-projects.adoc[Adding Project Members] instead.
 ====
 
 There are two contexts where you can add cluster members:

--- a/versions/v2.10/modules/zh/pages/cluster-admin/manage-clusters/access-clusters/add-users-to-clusters.adoc
+++ b/versions/v2.10/modules/zh/pages/cluster-admin/manage-clusters/access-clusters/add-users-to-clusters.adoc
@@ -1,11 +1,10 @@
 = 将用户添加到集群
 
-如果你想为用户提供对集群内 _所有_ 项目、节点和资源的访问权限，请为用户分配集群成员资格。
+To provide a user access to view certain cluster-level resources and create new projects, assign the user a **Cluster Membership**. Cluster members can create projects and manage resources in those projects. However, not all resources, namespaces and workloads in a cluster are accessible by cluster members.
 
 [TIP]
 ====
-
-如果你想为用户提供对集群内 _特定_ 项目的访问权限，请参见xref:cluster-admin/project-admin/add-users-to-projects.adoc[][添加项目成员]。
+Want to provide a user with access to a _specific_ project within a cluster? See xref:../../../cluster-admin/project-admin/add-users-to-projects.adoc[Adding Project Members] instead.
 ====
 
 

--- a/versions/v2.10/modules/zh/pages/cluster-admin/manage-clusters/access-clusters/add-users-to-clusters.adoc
+++ b/versions/v2.10/modules/zh/pages/cluster-admin/manage-clusters/access-clusters/add-users-to-clusters.adoc
@@ -4,7 +4,7 @@ To provide a user access to view certain cluster-level resources and create new 
 
 [TIP]
 ====
-Want to provide a user with access to a _specific_ project within a cluster? See xref:../../../cluster-admin/project-admin/add-users-to-projects.adoc[Adding Project Members] instead.
+Want to provide a user with access to a _specific_ project within a cluster? See xref:cluster-admin/project-admin/add-users-to-projects.adoc[Adding Project Members] instead.
 ====
 
 

--- a/versions/v2.8/modules/en/pages/cluster-admin/manage-clusters/access-clusters/add-users-to-clusters.adoc
+++ b/versions/v2.8/modules/en/pages/cluster-admin/manage-clusters/access-clusters/add-users-to-clusters.adoc
@@ -4,7 +4,7 @@ To provide a user access to view certain cluster-level resources and create new 
 
 [TIP]
 ====
-Want to provide a user with access to a _specific_ project within a cluster? See xref:../../../cluster-admin/project-admin/add-users-to-projects.adoc[Adding Project Members] instead.
+Want to provide a user with access to a _specific_ project within a cluster? See xref:cluster-admin/project-admin/add-users-to-projects.adoc[Adding Project Members] instead.
 ====
 
 There are two contexts where you can add cluster members:

--- a/versions/v2.8/modules/en/pages/cluster-admin/manage-clusters/access-clusters/add-users-to-clusters.adoc
+++ b/versions/v2.8/modules/en/pages/cluster-admin/manage-clusters/access-clusters/add-users-to-clusters.adoc
@@ -1,13 +1,12 @@
 = Adding Users to Clusters
 
-If you want to provide a user with access and permissions to _all_ projects, nodes, and resources within a cluster, assign the user a cluster membership.
+To provide a user access to view certain cluster-level resources and create new projects, assign the user a **Cluster Membership**. Cluster members can create projects and manage resources in those projects. However, not all resources, namespaces and workloads in a cluster are accessible by cluster members.
 
 [TIP]
 ====
 
-Want to provide a user with access to a _specific_ project within a cluster? See xref:cluster-admin/project-admin/add-users-to-projects.adoc[][Adding Project Members] instead.
+Want to provide a user with access to a _specific_ project within a cluster? See xref:cluster-admin/project-admin/add-users-to-projects.adoc[Adding Project Members] instead.
 ====
-
 
 There are two contexts where you can add cluster members:
 
@@ -48,7 +47,6 @@ There may be an issue with your search attribute configuration. See xref:rancher
 If you are logged in as a local user, external users do not display in your search results. For more information, see xref:rancher-admin/users/authn-and-authz/authn-and-authz.adoc#_external_authentication_configuration_and_principal_users[External Authentication Configuration and Principal Users].
 ====
 
-
 . Assign the user or group *Cluster* roles.
 +
 xref:rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/cluster-and-project-roles.adoc[What are Cluster Roles?]
@@ -58,10 +56,9 @@ xref:rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/c
 ====
 For Custom Roles, you can modify the list of individual roles available for assignment.
 
- ** To add roles to the list, xref:rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/custom-roles.adoc[Add a Custom Role].
- ** To remove roles from the list, xref:rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/locked-roles.adoc[Lock/Unlock Roles].
+* To add roles to the list, xref:rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/custom-roles.adoc[Add a Custom Role].
+* To remove roles from the list, xref:rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/locked-roles.adoc[Lock/Unlock Roles].
 ====
-
 
 *Result:* The chosen users are added to the cluster.
 

--- a/versions/v2.8/modules/en/pages/cluster-admin/manage-clusters/access-clusters/add-users-to-clusters.adoc
+++ b/versions/v2.8/modules/en/pages/cluster-admin/manage-clusters/access-clusters/add-users-to-clusters.adoc
@@ -4,8 +4,7 @@ To provide a user access to view certain cluster-level resources and create new 
 
 [TIP]
 ====
-
-Want to provide a user with access to a _specific_ project within a cluster? See xref:cluster-admin/project-admin/add-users-to-projects.adoc[Adding Project Members] instead.
+Want to provide a user with access to a _specific_ project within a cluster? See xref:../../../cluster-admin/project-admin/add-users-to-projects.adoc[Adding Project Members] instead.
 ====
 
 There are two contexts where you can add cluster members:

--- a/versions/v2.8/modules/zh/pages/cluster-admin/manage-clusters/access-clusters/add-users-to-clusters.adoc
+++ b/versions/v2.8/modules/zh/pages/cluster-admin/manage-clusters/access-clusters/add-users-to-clusters.adoc
@@ -1,11 +1,10 @@
 = 将用户添加到集群
 
-如果你想为用户提供对集群内 _所有_ 项目、节点和资源的访问权限，请为用户分配集群成员资格。
+To provide a user access to view certain cluster-level resources and create new projects, assign the user a **Cluster Membership**. Cluster members can create projects and manage resources in those projects. However, not all resources, namespaces and workloads in a cluster are accessible by cluster members.
 
 [TIP]
 ====
-
-如果你想为用户提供对集群内 _特定_ 项目的访问权限，请参见xref:cluster-admin/project-admin/add-users-to-projects.adoc[][添加项目成员]。
+Want to provide a user with access to a _specific_ project within a cluster? See xref:../../../cluster-admin/project-admin/add-users-to-projects.adoc[Adding Project Members] instead.
 ====
 
 

--- a/versions/v2.8/modules/zh/pages/cluster-admin/manage-clusters/access-clusters/add-users-to-clusters.adoc
+++ b/versions/v2.8/modules/zh/pages/cluster-admin/manage-clusters/access-clusters/add-users-to-clusters.adoc
@@ -4,7 +4,7 @@ To provide a user access to view certain cluster-level resources and create new 
 
 [TIP]
 ====
-Want to provide a user with access to a _specific_ project within a cluster? See xref:../../../cluster-admin/project-admin/add-users-to-projects.adoc[Adding Project Members] instead.
+Want to provide a user with access to a _specific_ project within a cluster? See xref:cluster-admin/project-admin/add-users-to-projects.adoc[Adding Project Members] instead.
 ====
 
 

--- a/versions/v2.9/modules/en/pages/cluster-admin/manage-clusters/access-clusters/add-users-to-clusters.adoc
+++ b/versions/v2.9/modules/en/pages/cluster-admin/manage-clusters/access-clusters/add-users-to-clusters.adoc
@@ -4,7 +4,7 @@ To provide a user access to view certain cluster-level resources and create new 
 
 [TIP]
 ====
-Want to provide a user with access to a _specific_ project within a cluster? See xref:../../../cluster-admin/project-admin/add-users-to-projects.adoc[Adding Project Members] instead.
+Want to provide a user with access to a _specific_ project within a cluster? See xref:cluster-admin/project-admin/add-users-to-projects.adoc[Adding Project Members] instead.
 ====
 
 There are two contexts where you can add cluster members:

--- a/versions/v2.9/modules/en/pages/cluster-admin/manage-clusters/access-clusters/add-users-to-clusters.adoc
+++ b/versions/v2.9/modules/en/pages/cluster-admin/manage-clusters/access-clusters/add-users-to-clusters.adoc
@@ -1,13 +1,12 @@
 = Adding Users to Clusters
 
-If you want to provide a user with access and permissions to _all_ projects, nodes, and resources within a cluster, assign the user a cluster membership.
+To provide a user access to view certain cluster-level resources and create new projects, assign the user a **Cluster Membership**. Cluster members can create projects and manage resources in those projects. However, not all resources, namespaces and workloads in a cluster are accessible by cluster members.
 
 [TIP]
 ====
 
-Want to provide a user with access to a _specific_ project within a cluster? See xref:cluster-admin/project-admin/add-users-to-projects.adoc[][Adding Project Members] instead.
+Want to provide a user with access to a _specific_ project within a cluster? See xref:cluster-admin/project-admin/add-users-to-projects.adoc[Adding Project Members] instead.
 ====
-
 
 There are two contexts where you can add cluster members:
 
@@ -48,7 +47,6 @@ There may be an issue with your search attribute configuration. See xref:rancher
 If you are logged in as a local user, external users do not display in your search results. For more information, see xref:rancher-admin/users/authn-and-authz/authn-and-authz.adoc#_external_authentication_configuration_and_principal_users[External Authentication Configuration and Principal Users].
 ====
 
-
 . Assign the user or group *Cluster* roles.
 +
 xref:rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/cluster-and-project-roles.adoc[What are Cluster Roles?]
@@ -61,7 +59,6 @@ For Custom Roles, you can modify the list of individual roles available for assi
 * To add roles to the list, xref:rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/custom-roles.adoc[Add a Custom Role].
 * To remove roles from the list, xref:rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/locked-roles.adoc[Lock/Unlock Roles].
 ====
-
 
 *Result:* The chosen users are added to the cluster.
 

--- a/versions/v2.9/modules/en/pages/cluster-admin/manage-clusters/access-clusters/add-users-to-clusters.adoc
+++ b/versions/v2.9/modules/en/pages/cluster-admin/manage-clusters/access-clusters/add-users-to-clusters.adoc
@@ -4,8 +4,7 @@ To provide a user access to view certain cluster-level resources and create new 
 
 [TIP]
 ====
-
-Want to provide a user with access to a _specific_ project within a cluster? See xref:cluster-admin/project-admin/add-users-to-projects.adoc[Adding Project Members] instead.
+Want to provide a user with access to a _specific_ project within a cluster? See xref:../../../cluster-admin/project-admin/add-users-to-projects.adoc[Adding Project Members] instead.
 ====
 
 There are two contexts where you can add cluster members:

--- a/versions/v2.9/modules/zh/pages/cluster-admin/manage-clusters/access-clusters/add-users-to-clusters.adoc
+++ b/versions/v2.9/modules/zh/pages/cluster-admin/manage-clusters/access-clusters/add-users-to-clusters.adoc
@@ -1,11 +1,10 @@
 = 将用户添加到集群
 
-如果你想为用户提供对集群内 _所有_ 项目、节点和资源的访问权限，请为用户分配集群成员资格。
+To provide a user access to view certain cluster-level resources and create new projects, assign the user a **Cluster Membership**. Cluster members can create projects and manage resources in those projects. However, not all resources, namespaces and workloads in a cluster are accessible by cluster members.
 
 [TIP]
 ====
-
-如果你想为用户提供对集群内 _特定_ 项目的访问权限，请参见xref:cluster-admin/project-admin/add-users-to-projects.adoc[][添加项目成员]。
+Want to provide a user with access to a _specific_ project within a cluster? See xref:../../../cluster-admin/project-admin/add-users-to-projects.adoc[Adding Project Members] instead.
 ====
 
 

--- a/versions/v2.9/modules/zh/pages/cluster-admin/manage-clusters/access-clusters/add-users-to-clusters.adoc
+++ b/versions/v2.9/modules/zh/pages/cluster-admin/manage-clusters/access-clusters/add-users-to-clusters.adoc
@@ -4,7 +4,7 @@ To provide a user access to view certain cluster-level resources and create new 
 
 [TIP]
 ====
-Want to provide a user with access to a _specific_ project within a cluster? See xref:../../../cluster-admin/project-admin/add-users-to-projects.adoc[Adding Project Members] instead.
+Want to provide a user with access to a _specific_ project within a cluster? See xref:cluster-admin/project-admin/add-users-to-projects.adoc[Adding Project Members] instead.
 ====
 
 


### PR DESCRIPTION
Per SURE-7589, add a note about cluster membership limitations to intro 
- Users added to a cluster can't access all resources in a cluster
- Users added to a cluster can create projects and manage resources within that project

Fixed link formatting in tip. 