### PR TITLE
Add Workflow: create issue to track product docs <-> community docs porting needs

### DIFF
--- a/.github/workflows/create-issue.yml
+++ b/.github/workflows/create-issue.yml
@@ -1,0 +1,32 @@
+name: Create issue to track porting between Community and Product docs
+
+on:
+  pull_request_target:
+    types:
+      - closed
+    branches: 
+      - main
+    paths-ignore:
+      - '**/README.md'
+      - '**/.github/ISSUE_TEMPLATE/**'
+
+permissions:
+  issues: write
+  pull-requests: read
+
+jobs:
+  create_issue:
+    if: github.event.pull_request.merged == true && contains( github.event.pull_request.labels.*.name, 'port/community-product')
+    runs-on: ubuntu-latest
+    steps:
+    - name: Create issue
+      env:
+        GH_TOKEN: ${{ github.token }}
+        REPO_TYPE: ${{ contains( github.repository, 'product-docs') && 'Product' || 'Community' }}
+        PR_TITLE: ${{ github.event.pull_request.title }}
+      run: |
+        gh issue create \
+          --repo ${{ github.repository }} \
+          --title "Port $REPO_TYPE docs PR #${{ github.event.pull_request.number }}: $PR_TITLE" \
+          --body "Reference: https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}" \
+          --label port/community-product


### PR DESCRIPTION
## Description

The goal is to reduce the need to manually create tracking issues that arise when a PR is applicable to both our Community and Product docs. This PR adds a new workflow to create a tracking issue whenever a PR that has the `port/community-product` label is merged.


