### PR TITLE
Refer to the Prime Helm chart repo

### DIFF
--- a/shared/modules/ROOT/partials/en/helm-chart-repo-url.adoc
+++ b/shared/modules/ROOT/partials/en/helm-chart-repo-url.adoc
@@ -1,0 +1,5 @@
+[IMPORTANT]
+====
+To learn more about the Rancher Prime Helm chart repository URL, see our https://scc.suse.com/rancher-docs/rancherprime/latest/en/reference-guide.html#chart-repo-url[Prime-only documentation]. Authentication is required. Use your https://scc.suse.com/[SUSE Customer Center (SCC)] credentials to log in.
+====
+

--- a/shared/modules/ROOT/partials/zh/helm-chart-repo-url.adoc
+++ b/shared/modules/ROOT/partials/zh/helm-chart-repo-url.adoc
@@ -1,0 +1,5 @@
+[IMPORTANT]
+====
+To learn more about the Rancher Prime Helm chart repository URL, see our https://scc.suse.com/rancher-docs/rancherprime/latest/en/reference-guide.html#chart-repo-url[Prime-only documentation]. Authentication is required. Use your https://scc.suse.com/[SUSE Customer Center (SCC)] credentials to log in.
+====
+

--- a/versions/latest/modules/en/pages/installation-and-upgrade/install-rancher.adoc
+++ b/versions/latest/modules/en/pages/installation-and-upgrade/install-rancher.adoc
@@ -77,6 +77,8 @@ Use the `helm repo add` command to add the Helm chart repository that contains c
 helm repo add rancher-prime <helm-chart-repo-url>
 ----
 
+include::shared:ROOT:partial$en/helm-chart-repo-url.adoc[]
+
 === 2. Create a Namespace for Rancher
 
 We'll need to define a Kubernetes namespace where the resources created by the Chart should be installed. This should always be `cattle-system`:

--- a/versions/latest/modules/en/pages/installation-and-upgrade/install-rancher.adoc
+++ b/versions/latest/modules/en/pages/installation-and-upgrade/install-rancher.adoc
@@ -70,27 +70,12 @@ To set up Rancher,
 
 === 1. Add the Helm Chart Repository
 
-Use `helm repo add` command to add the Helm chart repository that contains charts to install Rancher. For more information about the repository choices and which is best for your use case, see xref:[Choosing a Rancher Version].
+Use the `helm repo add` command to add the Helm chart repository that contains charts to install Rancher Prime.
 
-* Latest: Recommended for trying out the newest features
-+
+[,shell]
 ----
-  helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+helm repo add rancher-prime <helm-chart-repo-url>
 ----
-
-* Stable: Recommended for production environments
-+
-----
-  helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
-----
-
-* Alpha: Experimental preview of upcoming releases.
-+
-----
-  helm repo add rancher-alpha https://releases.rancher.com/server-charts/alpha
-----
-+
-NOTE: Upgrades are not supported to, from, or between Alphas.
 
 === 2. Create a Namespace for Rancher
 
@@ -227,12 +212,6 @@ helm install rancher rancher-prime/rancher \
   --set bootstrapPassword=admin
 ----
 
-If you are installing an alpha version, Helm requires adding the `--devel` option to the install command:
-
-----
-helm install rancher rancher-alpha/rancher --devel
-----
-
 Wait for Rancher to be rolled out:
 
 ----
@@ -280,12 +259,6 @@ helm install rancher rancher-prime/rancher \
   --set letsEncrypt.ingress.class=nginx
 ----
 
-If you are installing an alpha version, Helm requires adding the `--devel` option to the install command:
-
-----
-helm install rancher rancher-alpha/rancher --devel
-----
-
 Wait for Rancher to be rolled out:
 
 ----
@@ -322,12 +295,6 @@ helm install rancher rancher-prime/rancher \
   --set hostname=rancher.my.org \
   --set bootstrapPassword=admin \
   --set ingress.tls.source=secret
-----
-
-If you are installing an alpha version, Helm requires adding the `--devel` option to the install command:
-
-----
-helm install rancher rancher-alpha/rancher --devel
 ----
 
 If you are using a Private CA signed certificate , add `--set privateCA=true` to the command:

--- a/versions/latest/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
+++ b/versions/latest/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -25,6 +25,8 @@ From a system that has access to the internet, fetch the latest Helm chart and c
 ----
 helm repo add rancher-prime <helm-chart-repo-url>
 ----
++
+include::shared:ROOT:partial$en/helm-chart-repo-url.adoc[]
 
 . Fetch the Rancher Prime chart. This will pull down the chart and save it in the current directory as a `.tgz` file.
 ** To fetch the latest version:

--- a/versions/latest/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
+++ b/versions/latest/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -19,38 +19,34 @@ Rancher recommends installing Rancher on a Kubernetes cluster. A highly availabl
 From a system that has access to the internet, fetch the latest Helm chart and copy the resulting manifests to a system that has access to the Rancher server cluster.
 
 . If you haven't already, install `helm` locally on a workstation that has internet access. Note: Refer to the xref:installation-and-upgrade/requirements/helm-version-requirements.adoc[Helm version requirements] to choose a version of Helm to install Rancher.
-. Use `helm repo add` command to add the Helm chart repository that contains charts to install Rancher. For more information about the repository choices and which is best for your use case, see xref:[Choosing a Rancher Version].
- ** Latest: Recommended for trying out the newest features
+. Use the `helm repo add` command to add the Helm chart repository that contains charts to install Rancher Prime.
 +
+[,shell]
 ----
-  helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+helm repo add rancher-prime <helm-chart-repo-url>
 ----
 
- ** Stable: Recommended for production environments
+. Fetch the Rancher Prime chart. This will pull down the chart and save it in the current directory as a `.tgz` file.
+** To fetch the latest version:
 +
+[,shell]
 ----
-  helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
+helm fetch rancher-prime/rancher
 ----
-
- ** Alpha: Experimental preview of upcoming releases.
+** To fetch a specific version:
 +
-----
-  helm repo add rancher-alpha https://releases.rancher.com/server-charts/alpha
-----
+Check to see which version of Rancher Prime are available.
 +
-NOTE: Upgrades are not supported to, from, or between Alphas.
-. Fetch the latest Rancher chart. This will pull down the chart and save it in the current directory as a `.tgz` file.
-+
-[,plain]
+[,shell]
 ----
- helm fetch rancher-prime/rancher
+helm search repo --versions rancher-prime
 ----
 +
-If you require a specific version of Rancher, you can fetch this with the Helm `--version` parameter like in the following example:
+Fetch a specific version by specifying the `--version` parameter:
 +
-[,plain]
+[,shell]
 ----
- helm fetch rancher-stable/rancher --version=v2.4.8
+helm fetch rancher-prime/rancher --version=<version>
 ----
 
 === 2. Choose your SSL Configuration

--- a/versions/latest/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
+++ b/versions/latest/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
@@ -58,12 +58,12 @@ kubectl rollout status deployment -n cert-manager cert-manager
 kubectl rollout status deployment -n cert-manager cert-manager-webhook
 ----
 
-== Install Rancher
+== Install Rancher Prime
 
-Next you can install Rancher itself. First, add the Helm repository:
+Next you can install Rancher Prime itself. First, add the Helm repository:
 
 ----
-helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+helm repo add rancher-prime <helm-chart-repo-url>
 ----
 
 Create a namespace:
@@ -75,7 +75,7 @@ kubectl create namespace cattle-system
 And install Rancher with Helm. Rancher also needs a proxy configuration so that it can communicate with external application catalogs or retrieve Kubernetes version update metadata:
 
 ----
-helm upgrade --install rancher rancher-latest/rancher \
+helm upgrade --install rancher rancher-prime/rancher \
    --namespace cattle-system \
    --set hostname=rancher.example.com \
    --set proxy=http://${proxy_host} \

--- a/versions/latest/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
+++ b/versions/latest/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
@@ -66,6 +66,8 @@ Next you can install Rancher Prime itself. First, add the Helm repository:
 helm repo add rancher-prime <helm-chart-repo-url>
 ----
 
+include::shared:ROOT:partial$en/helm-chart-repo-url.adoc[]
+
 Create a namespace:
 
 ----

--- a/versions/latest/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/helm-cli.adoc
+++ b/versions/latest/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/helm-cli.adoc
@@ -102,7 +102,7 @@ To see options on how to customize the cert-manager install (including for cases
 
 
 ----
-helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+helm repo add rancher-prime <helm-chart-repo-url>
 
 kubectl create namespace cattle-system
 
@@ -131,14 +131,14 @@ For Kubernetes v1.25 or later, set `global.cattle.psp.enabled` to `false` when u
 See xref:../../installation-and-upgrade/resources/bootstrap-password.adoc#_password_requirements[Setting up the Bootstrap Password] for password requirements.
 
 ----
-helm install rancher rancher-latest/rancher \
+helm install rancher rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=<IP_OF_LINUX_NODE>.sslip.io \
   --set replicas=1 \
   --set bootstrapPassword=<PASSWORD_FOR_RANCHER_ADMIN>
 
 # Windows Powershell
-helm install rancher rancher-latest/rancher `
+helm install rancher rancher-prime/rancher `
   --namespace cattle-system `
   --set hostname=<IP_OF_LINUX_NODE>.sslip.io `
   --set replicas=1 `

--- a/versions/latest/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/helm-cli.adoc
+++ b/versions/latest/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/helm-cli.adoc
@@ -103,7 +103,11 @@ To see options on how to customize the cert-manager install (including for cases
 
 ----
 helm repo add rancher-prime <helm-chart-repo-url>
+----
 
+include::shared:ROOT:partial$en/helm-chart-repo-url.adoc[]
+
+----
 kubectl create namespace cattle-system
 
 kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/<VERSION>/cert-manager.crds.yaml

--- a/versions/latest/modules/en/pages/installation-and-upgrade/resources/update-rancher-certificate.adoc
+++ b/versions/latest/modules/en/pages/installation-and-upgrade/resources/update-rancher-certificate.adoc
@@ -89,24 +89,24 @@ The below steps update the Helm values for the Rancher chart, so the Rancher pod
 +
 [,bash]
 ----
-   helm get values rancher -n cattle-system -o yaml > values.yaml
+helm get values rancher -n cattle-system -o yaml > values.yaml
 ----
 
 . Retrieve the version string of the currently deployed Rancher chart to use below:
 +
 [,bash]
 ----
-   helm ls -n cattle-system
+helm ls -n cattle-system
 ----
 
 . Update the current Helm values in the `values.yaml` file to contain:
 +
 [,yaml]
 ----
-   ingress:
-     tls:
- source: secret
-   privateCA: true
+ingress:
+  tls:
+    source: secret
+privateCA: true
 ----
 +
 
@@ -261,14 +261,14 @@ The below steps update the Helm values for the Rancher chart, so the Rancher pod
 +
 [,bash]
 ----
-   helm get values rancher -n cattle-system -o yaml > values.yaml
+helm get values rancher -n cattle-system -o yaml > values.yaml
 ----
 
 . Also get the version string of the currently deployed Rancher chart:
 +
 [,bash]
 ----
-   helm ls -n cattle-system
+helm ls -n cattle-system
 ----
 
 . Update the current Helm values in the `values.yaml` file:
@@ -280,10 +280,10 @@ The below steps update the Helm values for the Rancher chart, so the Rancher pod
 +
 [,bash]
 ----
-    helm upgrade rancher rancher-prime/rancher \
---namespace cattle-system \
--f values.yaml \
---version <DEPLOYED_RANCHER_VERSION>
+helm upgrade rancher rancher-prime/rancher \
+  --namespace cattle-system \
+  -f values.yaml \
+  --version <DEPLOYED_RANCHER_VERSION>
 ----
 
 === 4. Reconfigure Rancher agents for the non-private/common certificate

--- a/versions/latest/modules/en/pages/installation-and-upgrade/resources/update-rancher-certificate.adoc
+++ b/versions/latest/modules/en/pages/installation-and-upgrade/resources/update-rancher-certificate.adoc
@@ -121,7 +121,7 @@ The below steps update the Helm values for the Rancher chart, so the Rancher pod
 +
 [,bash]
 ----
-    helm upgrade rancher rancher-stable/rancher \
+    helm upgrade rancher rancher-prime/rancher \
      --namespace cattle-system \
      -f values.yaml \
      --version <DEPLOYED_RANCHER_VERSION>
@@ -280,7 +280,7 @@ The below steps update the Helm values for the Rancher chart, so the Rancher pod
 +
 [,bash]
 ----
-    helm upgrade rancher rancher-stable/rancher \
+    helm upgrade rancher rancher-prime/rancher \
 --namespace cattle-system \
 -f values.yaml \
 --version <DEPLOYED_RANCHER_VERSION>

--- a/versions/latest/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
+++ b/versions/latest/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
@@ -95,7 +95,7 @@ If you are running Kubernetes v1.15 or below, you will need to add the `--valida
 +
 [,plain]
 ----
- helm repo update
+helm repo update
 ----
 
 . Install the new version of cert-manager

--- a/versions/latest/modules/en/pages/installation-and-upgrade/upgrades.adoc
+++ b/versions/latest/modules/en/pages/installation-and-upgrade/upgrades.adoc
@@ -51,17 +51,16 @@ You'll use the backup as a restore point if something goes wrong during upgrade.
 . Update your local Helm repo cache.
 +
 ----
- helm repo update
+helm repo update
 ----
 
 . Get the repository name that you used to install Rancher.
 +
 ----
- helm repo list
+helm repo list
 
- NAME          	       URL
- rancher-prime         <URL>
- rancher-<CHART_REPO>	 https://releases.rancher.com/server-charts/<CHART_REPO>
+NAME          	       URL
+rancher-prime          <helm-chart-repo-url>
 ----
 
 . Fetch the latest chart to install Rancher from the Helm chart repository.
@@ -110,11 +109,11 @@ There will be more values that are listed with this command. This is just an exa
 [TIP]
 ====
 
-Your deployment name may vary; for example, if you're deploying Rancher through the AWS Marketplace, the deployment name is 'rancher-stable'.
+Your deployment name may vary; for example, if you're deploying Rancher through the AWS Marketplace, the deployment name is 'rancher-prime'.
 Thus:
 
 ----
-helm get values rancher-stable -n cattle-system
+helm get values rancher-prime -n cattle-system
 
 hostname: rancher.my.org
 ----
@@ -147,11 +146,11 @@ The above is an example, there may be more values from the previous step that ne
 [TIP]
 ====
 
-If you deploy Rancher through the AWS Marketplace, the deployment name is 'rancher-stable'.
+If you deploy Rancher through the AWS Marketplace, the deployment name is 'rancher-prime'.
 Thus:
 
 ----
-helm upgrade rancher-stable rancher-prime/rancher \
+helm upgrade rancher-prime rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=rancher.my.org
 ----

--- a/versions/latest/modules/en/pages/rancher-admin/back-up-restore-and-disaster-recovery/migrate-to-a-new-cluster.adoc
+++ b/versions/latest/modules/en/pages/rancher-admin/back-up-restore-and-disaster-recovery/migrate-to-a-new-cluster.adoc
@@ -165,7 +165,7 @@ For Kubernetes v1.25 or later, set `global.cattle.psp.enabled` to `false` when u
 
 [,bash]
 ----
-helm install rancher rancher-latest/rancher \
+helm install rancher rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=<same hostname as the server URL from the first Rancher server> \
   --version x.y.z
@@ -185,7 +185,7 @@ These values can be reused using the `rancher-values.yaml` file. Be sure to swit
 
 [,bash]
 ----
-helm install rancher rancher-latest/rancher -n cattle-system -f rancher-values.yaml --version x.y.z
+helm install rancher rancher-prime/rancher -n cattle-system -f rancher-values.yaml --version x.y.z
 ----
 ====
 

--- a/versions/latest/modules/en/pages/rancher-admin/experimental-features/experimental-features.adoc
+++ b/versions/latest/modules/en/pages/rancher-admin/experimental-features/experimental-features.adoc
@@ -37,19 +37,12 @@ When installing Rancher with a Helm chart, use the `--set` option. In the below 
 For Kubernetes v1.25 or later, set `global.cattle.psp.enabled` to `false` when using Rancher v2.7.2-v2.7.4. This is not necessary for Rancher v2.7.5 and above, but you can still manually set the option if you choose.
 
 ----
-helm install rancher rancher-latest/rancher \
+helm install rancher rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=rancher.my.org \
   --set 'extraEnv[0].name=CATTLE_FEATURES'
   --set 'extraEnv[0].value=<FEATURE-FLAG-NAME-1>=true,<FEATURE-FLAG-NAME-2>=true'
 ----
-
-[NOTE]
-====
-
-If you are installing an alpha version, Helm requires adding the `--devel` option to the command.
-====
-
 
 === Enabling Features for Air Gap Installs
 

--- a/versions/latest/modules/zh/pages/installation-and-upgrade/install-rancher.adoc
+++ b/versions/latest/modules/zh/pages/installation-and-upgrade/install-rancher.adoc
@@ -70,27 +70,12 @@ Rancher 是使用 Kubernetes 的 https://helm.sh/[Helm] 包管理器安装的。
 
 === 1. 添加 Helm Chart 仓库
 
-执行 `helm repo add` 命令，以添加包含安装 Rancher 的 Chart 的 Helm Chart 仓库。有关如何选择仓库，以及哪个仓库最适合你的用例，请参见xref:[选择 Rancher 版本]。
+执行 `helm repo add` 命令，以添加包含安装 Rancher Prime 的 Chart 的 Helm Chart 仓库。
 
-* Latest：建议用于试用最新功能
-+
+[,shell]
 ----
- helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+helm repo add rancher-prime <helm-chart-repo-url>
 ----
-
-* Stable：建议用于生产环境
-+
-----
- helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
-----
-
-* Alpha：即将发布的实验性预览。
-+
-----
- helm repo add rancher-alpha https://releases.rancher.com/server-charts/alpha
-----
-+
-注意：不支持升级到 Alpha 版、从 Alpha 版升级或在 Alpha 版之间升级。
 
 === 2. 为 Rancher 创建命名空间
 
@@ -220,18 +205,11 @@ Rancher 生成的证书::
 * 对于 Kubernetes v1.25 或更高版本，使用 Rancher v2.7.2-v2.7.4 时，将 `global.cattle.psp.enabled` 设置为 `false`。对于 Rancher v2.7.5 及更高版本来说，这不是必需的，但你仍然可以手动设置该选项。
 
 ----
-helm install rancher rancher-<CHART_REPO>/rancher \
+helm install rancher rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=rancher.my.org \
   --set bootstrapPassword=admin
 ----
-
-如果你安装的是 alpha 版本，Helm 会要求你在安装命令中添加 `--devel` 选项：
-
-----
-helm install rancher rancher-alpha/rancher --devel
-----
-
 等待 Rancher 运行：
 
 ----
@@ -262,19 +240,13 @@ Let's Encrypt::
 * 对于 Kubernetes v1.25 或更高版本，使用 Rancher v2.7.2-v2.7.4 时，将 `global.cattle.psp.enabled` 设置为 `false`。对于 Rancher v2.7.5 及更高版本来说，这不是必需的，但你仍然可以手动设置该选项。
 
 ----
-helm install rancher rancher-<CHART_REPO>/rancher \
+helm install rancher rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=rancher.my.org \
   --set bootstrapPassword=admin \
   --set ingress.tls.source=letsEncrypt \
   --set letsEncrypt.email=me@example.org \
   --set letsEncrypt.ingress.class=nginx
-----
-
-如果你安装的是 alpha 版本，Helm 会要求你在安装命令中添加 `--devel` 选项：
-
-----
-helm install rancher rancher-alpha/rancher --devel
 ----
 
 等待 Rancher 运行：
@@ -308,23 +280,17 @@ deployment "rancher" successfully rolled out
 * 对于 Kubernetes v1.25 或更高版本，使用 Rancher v2.7.2-v2.7.4 时，将 `global.cattle.psp.enabled` 设置为 `false`。对于 Rancher v2.7.5 及更高版本来说，这不是必需的，但你仍然可以手动设置该选项。
 
 ----
-helm install rancher rancher-<CHART_REPO>/rancher \
+helm install rancher rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=rancher.my.org \
   --set bootstrapPassword=admin \
   --set ingress.tls.source=secret
 ----
 
-如果你安装的是 alpha 版本，Helm 会要求你在安装命令中添加 `--devel` 选项：
-
-----
-helm install rancher rancher-alpha/rancher --devel
-----
-
 如果你使用的是私有 CA 证书，请在命令中增加 `--set privateCA=true`。
 
 ----
-helm install rancher rancher-<CHART_REPO>/rancher \
+helm install rancher rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=rancher.my.org \
   --set bootstrapPassword=admin \

--- a/versions/latest/modules/zh/pages/installation-and-upgrade/install-rancher.adoc
+++ b/versions/latest/modules/zh/pages/installation-and-upgrade/install-rancher.adoc
@@ -77,6 +77,8 @@ Rancher 是使用 Kubernetes 的 https://helm.sh/[Helm] 包管理器安装的。
 helm repo add rancher-prime <helm-chart-repo-url>
 ----
 
+include::shared:ROOT:partial$zh/helm-chart-repo-url.adoc[]
+
 === 2. 为 Rancher 创建命名空间
 
 你需要定义一个 Kubernetes 命名空间，用于安装由 Chart 创建的资源。这个命名空间的名称为 `cattle-system`：

--- a/versions/latest/modules/zh/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
+++ b/versions/latest/modules/zh/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -26,6 +26,8 @@
 helm repo add rancher-prime <helm-chart-repo-url>
 ----
 
+include::shared:ROOT:partial$zh/helm-chart-repo-url.adoc[]
+
 . 获取的 Rancher Chart。此操作将获取 Chart 并将其作为 `.tgz` 文件保存在当前目录中。
 
 ** 如需下载最新的 Rancher Prime 版本:

--- a/versions/latest/modules/zh/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
+++ b/versions/latest/modules/zh/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -19,38 +19,35 @@
 从可以访问互联网的系统中，获取最新的 Helm Chart，然后将 manifest 复制到可访问 Rancher Server 集群的系统中。
 
 . 如果你还没有安装 `helm`，请在可访问互联网的工作站上进行本地安装。注意：参考 xref:installation-and-upgrade/requirements/helm-version-requirements.adoc[Helm 版本要求]选择 Helm 版本来安装 Rancher。
-. 执行 `helm repo add` 命令，以添加包含安装 Rancher 的 Chart 的 Helm Chart 仓库。有关如何选择仓库，以及哪个仓库最适合你的用例，请参见xref:[选择 Rancher 版本]。
- ** Latest：建议用于试用最新功能
-+
+. 执行 `helm repo add` 命令，以添加包含安装 Rancher Prime 的 Chart 的 Helm Chart 仓库。
+ +
+[,shell]
 ----
- helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
-----
-
- ** Stable：建议用于生产环境
-+
-----
- helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
+helm repo add rancher-prime <helm-chart-repo-url>
 ----
 
- ** Alpha：即将发布的实验性预览。
+. 获取的 Rancher Chart。此操作将获取 Chart 并将其作为 `.tgz` 文件保存在当前目录中。
+
+** 如需下载最新的 Rancher Prime 版本:
 +
+[,shell]
 ----
- helm repo add rancher-alpha https://releases.rancher.com/server-charts/alpha
+helm fetch rancher-prime/rancher
+----
+** To fetch a specific version:
++
+Check to see which version of Rancher Prime are available.
++
+[,shell]
+----
+helm search repo --versions rancher-prime
 ----
 +
-注意：不支持升级到 Alpha 版、从 Alpha 版升级或在 Alpha 版之间升级。
-. 获取最新的 Rancher Chart。此操作将获取 Chart 并将其作为 `.tgz` 文件保存在当前目录中。
+如需下载特定的 Rancher Prime 版本，你可以用 Helm `--version` 参数指定版本，如下：
 +
-[,plain]
+[,shell]
 ----
-helm fetch rancher-<CHART_REPO>/rancher
-----
-+
-如需下载特定的 Rancher 版本，你可以用 Helm `--version` 参数指定版本，如下：
-+
-[,plain]
-----
-helm fetch rancher-stable/rancher --version=v2.4.8
+helm fetch rancher-prime/rancher --version=<version>
 ----
 
 === 2. 选择 SSL 配置

--- a/versions/latest/modules/zh/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
+++ b/versions/latest/modules/zh/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
@@ -59,12 +59,12 @@ kubectl rollout status deployment -n cert-manager cert-manager
 kubectl rollout status deployment -n cert-manager cert-manager-webhook
 ----
 
-== 安装 Rancher
+== 安装 Rancher Prime
 
-接下来，你可以安装 Rancher 了。首先，添加 Helm 仓库：
+接下来，你可以安装 Rancher Prime 了。首先，添加 Helm 仓库：
 
 ----
-helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+helm repo add rancher-prime <helm-chart-repo-url>
 ----
 
 创建命名空间：
@@ -76,7 +76,7 @@ kubectl create namespace cattle-system
 然后使用 Helm 安装 Rancher：Rancher 也需要你配置代理，以便它可以与外部应用商店通信，或检索 Kubernetes 版本更新元数据：
 
 ----
-helm upgrade --install rancher rancher-latest/rancher \
+helm upgrade --install rancher rancher-prime/rancher \
    --namespace cattle-system \
    --set hostname=rancher.example.com \
    --set proxy=http://${proxy_host} \

--- a/versions/latest/modules/zh/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
+++ b/versions/latest/modules/zh/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
@@ -67,6 +67,8 @@ kubectl rollout status deployment -n cert-manager cert-manager-webhook
 helm repo add rancher-prime <helm-chart-repo-url>
 ----
 
+include::shared:ROOT:partial$zh/helm-chart-repo-url.adoc[]
+
 创建命名空间：
 
 ----

--- a/versions/latest/modules/zh/pages/installation-and-upgrade/quick-start/deploy-rancher/helm-cli.adoc
+++ b/versions/latest/modules/zh/pages/installation-and-upgrade/quick-start/deploy-rancher/helm-cli.adoc
@@ -1,3 +1,4 @@
+
 = Helm CLI 快速入门
 
 本文提供了快速安装 Rancher 的方法。
@@ -102,7 +103,7 @@ notepad.exe $env:USERPROFILE\.kube\config
 
 
 ----
-helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+helm repo add rancher-prime <helm-chart-repo-url>
 
 kubectl create namespace cattle-system
 
@@ -131,14 +132,14 @@ helm install cert-manager jetstack/cert-manager `
 请注意，密码至少需要 12 个字符。
 
 ----
-helm install rancher rancher-latest/rancher \
+helm install rancher rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=<IP_OF_LINUX_NODE>.sslip.io \
   --set replicas=1 \
   --set bootstrapPassword=<PASSWORD_FOR_RANCHER_ADMIN>
 
 # Windows Powershell
-helm install rancher rancher-latest/rancher `
+helm install rancher rancher-prime/rancher `
   --namespace cattle-system `
   --set hostname=<IP_OF_LINUX_NODE>.sslip.io `
   --set replicas=1 `

--- a/versions/latest/modules/zh/pages/installation-and-upgrade/quick-start/deploy-rancher/helm-cli.adoc
+++ b/versions/latest/modules/zh/pages/installation-and-upgrade/quick-start/deploy-rancher/helm-cli.adoc
@@ -104,7 +104,11 @@ notepad.exe $env:USERPROFILE\.kube\config
 
 ----
 helm repo add rancher-prime <helm-chart-repo-url>
+----
 
+include::shared:ROOT:partial$zh/helm-chart-repo-url.adoc[]
+
+----
 kubectl create namespace cattle-system
 
 kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/<VERSION>/cert-manager.crds.yaml

--- a/versions/latest/modules/zh/pages/installation-and-upgrade/resources/update-rancher-certificate.adoc
+++ b/versions/latest/modules/zh/pages/installation-and-upgrade/resources/update-rancher-certificate.adoc
@@ -121,10 +121,10 @@ privateCA: true
 +
 [,bash]
 ----
- helm upgrade rancher rancher-stable/rancher \
-  --namespace cattle-system \
-  -f values.yaml \
-  --version <DEPLOYED_RANCHER_VERSION>
+    helm upgrade rancher rancher-prime/rancher \
+     --namespace cattle-system \
+     -f values.yaml \
+     --version <DEPLOYED_RANCHER_VERSION>
 ----
 
 修改完成后，访问 `\https://<rancher_server_url>/v3/settings/cacerts`，验证该值是否与先前写入 `tls-ca` Secret 中的 CA 证书匹配。在所有 Rancher pod 启动之前，CA `cacerts` 值可能不会更新。
@@ -278,10 +278,10 @@ helm ls -n cattle-system
 +
 [,bash]
 ----
-  helm upgrade rancher rancher-stable/rancher \
---namespace cattle-system \
--f values.yaml \
---version <DEPLOYED_RANCHER_VERSION>
+helm upgrade rancher rancher-prime/rancher \
+  --namespace cattle-system \
+  -f values.yaml \
+  --version <DEPLOYED_RANCHER_VERSION>
 ----
 
 === 4. 为非私有/通用证书重新配置 Rancher Agent

--- a/versions/latest/modules/zh/pages/installation-and-upgrade/upgrades.adoc
+++ b/versions/latest/modules/zh/pages/installation-and-upgrade/upgrades.adoc
@@ -18,9 +18,7 @@ kubeconfig 也可以通过 `--kubeconfig` 标签（详情请参见 https://helm.
 
 === 查看已知问题
 
-如需查看每个 Rancher 版本的已知问题，请参见 https://github.com/rancher/rancher/releases[GitHub] 中的发行说明，或查看 https://forums.rancher.com/c/announcements/12[Rancher 论坛]。
-
-不支持 _升级_ 或 _升级到_ xref:#_helm_chart_仓库[rancher-alpha 仓库]中的任何 Chart。
+如需查看每个 Rancher 版本的已知问题，请参见 https://github\.com/rancher/rancher/releases\[GitHub\] 中的发行说明，或查看 https://forums\.rancher\.com/c/announcements/12\[Rancher 论坛\]。
 
 === Helm 版本
 
@@ -56,45 +54,14 @@ https://community.letsencrypt.org/t/blocking-old-cert-manager-versions/98753[从
 helm repo update
 ----
 
-. 获取你用来安装 Rancher 的仓库名称。
-+
-关于仓库及其区别，请参见 xref:#_helm_chart_仓库[Helm Chart 仓库]。
-
- ** Latest：建议用于试用最新功能
-+
-----
- helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
-----
-
- ** Stable：建议用于生产环境
-+
-----
- helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
-----
-
- ** Alpha：即将发布的实验性预览。
-+
-----
- helm repo add rancher-alpha https://releases.rancher.com/server-charts/alpha
-----
-+
-注意：不支持升级到 Alpha 版、从 Alpha 版升级或在 Alpha 版之间升级。
-
+. Get the repository name that you used to install Rancher.
 +
 ----
 helm repo list
 
 NAME          	       URL
-stable        	       https://charts.helm.sh/stable
-rancher-<CHART_REPO>	 https://releases.rancher.com/server-charts/<CHART_REPO>
+rancher-prime          <helm-chart-repo-url>
 ----
-+
-
-[NOTE]
-====
-如果你想切换到不同的 Helm Chart 仓库，请按照xref:#_切换到不同_helm_chart_仓库[切换仓库步骤]进行操作。如果你要切换仓库，请先再次列出仓库，再继续执行步骤 3，以确保添加了正确的仓库。
-====
-
 
 . 从 Helm Chart 仓库获取最新的 Chart 来安装 Rancher。
 +
@@ -102,14 +69,14 @@ rancher-<CHART_REPO>	 https://releases.rancher.com/server-charts/<CHART_REPO>
 +
 [,plain]
 ----
-helm fetch rancher-<CHART_REPO>/rancher
+helm fetch rancher-prime/rancher
 ----
 +
 你可以通过 `--version=` 标记，来指定要升级的目标 Chart 版本。例如：
 +
 [,plain]
 ----
-helm fetch rancher-<CHART_REPO>/rancher --version=2.6.8
+helm fetch rancher-prime/rancher --version=2.6.8
 ----
 
 === 3. 升级 Rancher
@@ -142,11 +109,11 @@ hostname: rancher.my.org
 [TIP]
 ====
 
-Deployment 的名称可能会有所不同。例如，如果你通过 AWS Marketplace 部署 Rancher，则 Deployment 的名称为"`rancher-stable`"。
+Deployment 的名称可能会有所不同。例如，如果你通过 AWS Marketplace 部署 Rancher，则 Deployment 的名称为"`rancher-prime`"。
 因此：
 
 ----
-helm get values rancher-stable -n cattle-system
+helm get values rancher-prime -n cattle-system
 
 hostname: rancher.my.org
 ----
@@ -164,7 +131,7 @@ hostname: rancher.my.org
 对于 Kubernetes v1.25 或更高版本，使用 Rancher v2.7.2-v2.7.4 时，将 `global.cattle.psp.enabled` 设置为 `false`。对于 Rancher v2.7.5 及更高版本来说，这不是必需的，但你仍然可以手动设置该选项。
 
 ----
-helm upgrade rancher rancher-<CHART_REPO>/rancher \
+helm upgrade rancher rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=rancher.my.org
 ----
@@ -179,11 +146,11 @@ helm upgrade rancher rancher-<CHART_REPO>/rancher \
 [TIP]
 ====
 
-如果你通过 AWS Marketplace 部署 Rancher，则 Deployment 的名称为"`rancher-stable`"。
+如果你通过 AWS Marketplace 部署 Rancher，则 Deployment 的名称为"`rancher-prime`"。
 因此：
 
 ----
-helm upgrade rancher-stable rancher-<CHART_REPO>/rancher \
+helm upgrade rancher-prime rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=rancher.my.org
 ----
@@ -203,7 +170,7 @@ helm get values rancher -n cattle-system -o yaml > values.yaml
 对于 Kubernetes v1.25 或更高版本，使用 Rancher v2.7.2-v2.7.4 时，将 `global.cattle.psp.enabled` 设置为 `false`。对于 Rancher v2.7.5 及更高版本来说，这不是必需的，但你仍然可以手动设置该选项。
 +
 ----
-helm upgrade rancher rancher-<CHART_REPO>/rancher \
+helm upgrade rancher rancher-prime/rancher \
   --namespace cattle-system \
   -f values.yaml \
   --version=2.6.8

--- a/versions/latest/modules/zh/pages/rancher-admin/back-up-restore-and-disaster-recovery/migrate-to-a-new-cluster.adoc
+++ b/versions/latest/modules/zh/pages/rancher-admin/back-up-restore-and-disaster-recovery/migrate-to-a-new-cluster.adoc
@@ -182,8 +182,9 @@ kubectl logs -n cattle-resources-system --tail 100 -f -l app.kubernetes.io/insta
 对于 Kubernetes v1.25 或更高版本，使用 Rancher v2.7.2-v2.7.4 时，将 `global.cattle.psp.enabled` 设置为 `false`。对于 Rancher v2.7.5 及更高版本来说，这不是必需的，但你仍然可以手动设置该选项。
 
 [,bash]
+[,bash]
 ----
-helm install rancher rancher-latest/rancher \
+helm install rancher rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=<same hostname as the server URL from the first Rancher server> \
   --version x.y.z
@@ -203,7 +204,14 @@ helm get values rancher -n cattle-system -o yaml > rancher-values.yaml
 
 [,bash]
 ----
-helm install rancher rancher-latest/rancher -n cattle-system -f rancher-values.yaml --version x.y.z
+helm install rancher rancher-prime/rancher -n cattle-system -f rancher-values.yaml --version x.y.z
 ----
 ====
+
+
+== 5. Redirect Traffic to the New Cluster
+
+After migration completes, update your DNS records and any load balancers, so that traffic is routed correctly to the migrated cluster. Remember that you must use the same hostname that was set as the server URL in the original cluster.
+
+Full instructions on how to redirect traffic to the migrated cluster differ based on your specific environment. Refer to your hosting provider's documentation for more details.
 

--- a/versions/latest/modules/zh/pages/rancher-admin/experimental-features/experimental-features.adoc
+++ b/versions/latest/modules/zh/pages/rancher-admin/experimental-features/experimental-features.adoc
@@ -37,19 +37,12 @@ Rancher 包含一些默认关闭的实验功能。在某些情况下，例如当
 对于 Kubernetes v1.25 或更高版本，使用 Rancher v2.7.2-v2.7.4 时，将 `global.cattle.psp.enabled` 设置为 `false`。对于 Rancher v2.7.5 及更高版本来说，这不是必需的，但你仍然可以手动设置该选项。
 
 ----
-helm install rancher rancher-latest/rancher \
+helm install rancher rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=rancher.my.org \
   --set 'extraEnv[0].name=CATTLE_FEATURES'
   --set 'extraEnv[0].value=<FEATURE-FLAG-NAME-1>=true,<FEATURE-FLAG-NAME-2>=true'
 ----
-
-[NOTE]
-====
-
-如果你安装的是 alpha 版本，Helm 要求你在命令中添加 `--devel` 选项。
-====
-
 
 === 离线安装的情况下渲染 Helm Chart
 

--- a/versions/latest/modules/zh/pages/security/rancher-webhook/rancher-webhook.adoc
+++ b/versions/latest/modules/zh/pages/security/rancher-webhook/rancher-webhook.adoc
@@ -91,7 +91,7 @@ Rancher 会在检测到对 ConfigMap 值的更改时重新部署 Rancher-Webhook
 
 [,bash]
 ----
-helm install rancher rancher-<CHART_REPO>/rancher \
+helm install rancher rancher-prime/rancher \
   --namespace cattle-system \
   ...
   --set webhook.port=9553 \

--- a/versions/v2.10/modules/en/pages/installation-and-upgrade/install-rancher.adoc
+++ b/versions/v2.10/modules/en/pages/installation-and-upgrade/install-rancher.adoc
@@ -77,6 +77,8 @@ Use the `helm repo add` command to add the Helm chart repository that contains c
 helm repo add rancher-prime <helm-chart-repo-url>
 ----
 
+include::shared:ROOT:partial$en/helm-chart-repo-url.adoc[]
+
 === 2. Create a Namespace for Rancher
 
 We'll need to define a Kubernetes namespace where the resources created by the Chart should be installed. This should always be `cattle-system`:

--- a/versions/v2.10/modules/en/pages/installation-and-upgrade/install-rancher.adoc
+++ b/versions/v2.10/modules/en/pages/installation-and-upgrade/install-rancher.adoc
@@ -70,27 +70,12 @@ To set up Rancher,
 
 === 1. Add the Helm Chart Repository
 
-Use `helm repo add` command to add the Helm chart repository that contains charts to install Rancher. For more information about the repository choices and which is best for your use case, see xref:[Choosing a Rancher Version].
+Use the `helm repo add` command to add the Helm chart repository that contains charts to install Rancher Prime.
 
-* Latest: Recommended for trying out the newest features
-+
+[,shell]
 ----
-  helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+helm repo add rancher-prime <helm-chart-repo-url>
 ----
-
-* Stable: Recommended for production environments
-+
-----
-  helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
-----
-
-* Alpha: Experimental preview of upcoming releases.
-+
-----
-  helm repo add rancher-alpha https://releases.rancher.com/server-charts/alpha
-----
-+
-NOTE: Upgrades are not supported to, from, or between Alphas.
 
 === 2. Create a Namespace for Rancher
 
@@ -227,12 +212,6 @@ helm install rancher rancher-prime/rancher \
   --set bootstrapPassword=admin
 ----
 
-If you are installing an alpha version, Helm requires adding the `--devel` option to the install command:
-
-----
-helm install rancher rancher-alpha/rancher --devel
-----
-
 Wait for Rancher to be rolled out:
 
 ----
@@ -280,12 +259,6 @@ helm install rancher rancher-prime/rancher \
   --set letsEncrypt.ingress.class=nginx
 ----
 
-If you are installing an alpha version, Helm requires adding the `--devel` option to the install command:
-
-----
-helm install rancher rancher-alpha/rancher --devel
-----
-
 Wait for Rancher to be rolled out:
 
 ----
@@ -322,12 +295,6 @@ helm install rancher rancher-prime/rancher \
   --set hostname=rancher.my.org \
   --set bootstrapPassword=admin \
   --set ingress.tls.source=secret
-----
-
-If you are installing an alpha version, Helm requires adding the `--devel` option to the install command:
-
-----
-helm install rancher rancher-alpha/rancher --devel
 ----
 
 If you are using a Private CA signed certificate , add `--set privateCA=true` to the command:

--- a/versions/v2.10/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
+++ b/versions/v2.10/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -25,6 +25,8 @@ From a system that has access to the internet, fetch the latest Helm chart and c
 ----
 helm repo add rancher-prime <helm-chart-repo-url>
 ----
++
+include::shared:ROOT:partial$en/helm-chart-repo-url.adoc[]
 
 . Fetch the Rancher Prime chart. This will pull down the chart and save it in the current directory as a `.tgz` file.
 ** To fetch the latest version:

--- a/versions/v2.10/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
+++ b/versions/v2.10/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -19,38 +19,34 @@ Rancher recommends installing Rancher on a Kubernetes cluster. A highly availabl
 From a system that has access to the internet, fetch the latest Helm chart and copy the resulting manifests to a system that has access to the Rancher server cluster.
 
 . If you haven't already, install `helm` locally on a workstation that has internet access. Note: Refer to the xref:installation-and-upgrade/requirements/helm-version-requirements.adoc[Helm version requirements] to choose a version of Helm to install Rancher.
-. Use `helm repo add` command to add the Helm chart repository that contains charts to install Rancher. For more information about the repository choices and which is best for your use case, see xref:[Choosing a Rancher Version].
- ** Latest: Recommended for trying out the newest features
+. Use the `helm repo add` command to add the Helm chart repository that contains charts to install Rancher Prime.
 +
+[,shell]
 ----
-  helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+helm repo add rancher-prime <helm-chart-repo-url>
 ----
 
- ** Stable: Recommended for production environments
+. Fetch the Rancher Prime chart. This will pull down the chart and save it in the current directory as a `.tgz` file.
+** To fetch the latest version:
 +
+[,shell]
 ----
-  helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
+helm fetch rancher-prime/rancher
 ----
-
- ** Alpha: Experimental preview of upcoming releases.
+** To fetch a specific version:
 +
-----
-  helm repo add rancher-alpha https://releases.rancher.com/server-charts/alpha
-----
+Check to see which version of Rancher Prime are available.
 +
-NOTE: Upgrades are not supported to, from, or between Alphas.
-. Fetch the latest Rancher chart. This will pull down the chart and save it in the current directory as a `.tgz` file.
-+
-[,plain]
+[,shell]
 ----
- helm fetch rancher-prime/rancher
+helm search repo --versions rancher-prime
 ----
 +
-If you require a specific version of Rancher, you can fetch this with the Helm `--version` parameter like in the following example:
+Fetch a specific version by specifying the `--version` parameter:
 +
-[,plain]
+[,shell]
 ----
- helm fetch rancher-stable/rancher --version=v2.4.8
+helm fetch rancher-prime/rancher --version=<version>
 ----
 
 === 2. Choose your SSL Configuration

--- a/versions/v2.10/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
+++ b/versions/v2.10/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
@@ -58,12 +58,12 @@ kubectl rollout status deployment -n cert-manager cert-manager
 kubectl rollout status deployment -n cert-manager cert-manager-webhook
 ----
 
-== Install Rancher
+== Install Rancher Prime
 
-Next you can install Rancher itself. First, add the Helm repository:
+Next you can install Rancher Prime itself. First, add the Helm repository:
 
 ----
-helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+helm repo add rancher-prime <helm-chart-repo-url>
 ----
 
 Create a namespace:
@@ -75,7 +75,7 @@ kubectl create namespace cattle-system
 And install Rancher with Helm. Rancher also needs a proxy configuration so that it can communicate with external application catalogs or retrieve Kubernetes version update metadata:
 
 ----
-helm upgrade --install rancher rancher-latest/rancher \
+helm upgrade --install rancher rancher-prime/rancher \
    --namespace cattle-system \
    --set hostname=rancher.example.com \
    --set proxy=http://${proxy_host} \

--- a/versions/v2.10/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
+++ b/versions/v2.10/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
@@ -66,6 +66,8 @@ Next you can install Rancher Prime itself. First, add the Helm repository:
 helm repo add rancher-prime <helm-chart-repo-url>
 ----
 
+include::shared:ROOT:partial$en/helm-chart-repo-url.adoc[]
+
 Create a namespace:
 
 ----

--- a/versions/v2.10/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/helm-cli.adoc
+++ b/versions/v2.10/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/helm-cli.adoc
@@ -102,7 +102,7 @@ To see options on how to customize the cert-manager install (including for cases
 
 
 ----
-helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+helm repo add rancher-prime <helm-chart-repo-url>
 
 kubectl create namespace cattle-system
 
@@ -131,14 +131,14 @@ For Kubernetes v1.25 or later, set `global.cattle.psp.enabled` to `false` when u
 See xref:../../installation-and-upgrade/resources/bootstrap-password.adoc#_password_requirements[Setting up the Bootstrap Password] for password requirements.
 
 ----
-helm install rancher rancher-latest/rancher \
+helm install rancher rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=<IP_OF_LINUX_NODE>.sslip.io \
   --set replicas=1 \
   --set bootstrapPassword=<PASSWORD_FOR_RANCHER_ADMIN>
 
 # Windows Powershell
-helm install rancher rancher-latest/rancher `
+helm install rancher rancher-prime/rancher `
   --namespace cattle-system `
   --set hostname=<IP_OF_LINUX_NODE>.sslip.io `
   --set replicas=1 `

--- a/versions/v2.10/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/helm-cli.adoc
+++ b/versions/v2.10/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/helm-cli.adoc
@@ -103,7 +103,11 @@ To see options on how to customize the cert-manager install (including for cases
 
 ----
 helm repo add rancher-prime <helm-chart-repo-url>
+----
 
+include::shared:ROOT:partial$en/helm-chart-repo-url.adoc[]
+
+----
 kubectl create namespace cattle-system
 
 kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/<VERSION>/cert-manager.crds.yaml

--- a/versions/v2.10/modules/en/pages/installation-and-upgrade/resources/update-rancher-certificate.adoc
+++ b/versions/v2.10/modules/en/pages/installation-and-upgrade/resources/update-rancher-certificate.adoc
@@ -89,24 +89,24 @@ The below steps update the Helm values for the Rancher chart, so the Rancher pod
 +
 [,bash]
 ----
-   helm get values rancher -n cattle-system -o yaml > values.yaml
+helm get values rancher -n cattle-system -o yaml > values.yaml
 ----
 
 . Retrieve the version string of the currently deployed Rancher chart to use below:
 +
 [,bash]
 ----
-   helm ls -n cattle-system
+helm ls -n cattle-system
 ----
 
 . Update the current Helm values in the `values.yaml` file to contain:
 +
 [,yaml]
 ----
-   ingress:
-     tls:
- source: secret
-   privateCA: true
+ingress:
+  tls:
+    source: secret
+privateCA: true
 ----
 +
 
@@ -261,14 +261,14 @@ The below steps update the Helm values for the Rancher chart, so the Rancher pod
 +
 [,bash]
 ----
-   helm get values rancher -n cattle-system -o yaml > values.yaml
+helm get values rancher -n cattle-system -o yaml > values.yaml
 ----
 
 . Also get the version string of the currently deployed Rancher chart:
 +
 [,bash]
 ----
-   helm ls -n cattle-system
+helm ls -n cattle-system
 ----
 
 . Update the current Helm values in the `values.yaml` file:
@@ -280,10 +280,10 @@ The below steps update the Helm values for the Rancher chart, so the Rancher pod
 +
 [,bash]
 ----
-    helm upgrade rancher rancher-prime/rancher \
---namespace cattle-system \
--f values.yaml \
---version <DEPLOYED_RANCHER_VERSION>
+helm upgrade rancher rancher-prime/rancher \
+  --namespace cattle-system \
+  -f values.yaml \
+  --version <DEPLOYED_RANCHER_VERSION>
 ----
 
 === 4. Reconfigure Rancher agents for the non-private/common certificate

--- a/versions/v2.10/modules/en/pages/installation-and-upgrade/resources/update-rancher-certificate.adoc
+++ b/versions/v2.10/modules/en/pages/installation-and-upgrade/resources/update-rancher-certificate.adoc
@@ -121,7 +121,7 @@ The below steps update the Helm values for the Rancher chart, so the Rancher pod
 +
 [,bash]
 ----
-    helm upgrade rancher rancher-stable/rancher \
+    helm upgrade rancher rancher-prime/rancher \
      --namespace cattle-system \
      -f values.yaml \
      --version <DEPLOYED_RANCHER_VERSION>
@@ -280,7 +280,7 @@ The below steps update the Helm values for the Rancher chart, so the Rancher pod
 +
 [,bash]
 ----
-    helm upgrade rancher rancher-stable/rancher \
+    helm upgrade rancher rancher-prime/rancher \
 --namespace cattle-system \
 -f values.yaml \
 --version <DEPLOYED_RANCHER_VERSION>

--- a/versions/v2.10/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
+++ b/versions/v2.10/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
@@ -95,7 +95,7 @@ If you are running Kubernetes v1.15 or below, you will need to add the `--valida
 +
 [,plain]
 ----
- helm repo update
+helm repo update
 ----
 
 . Install the new version of cert-manager

--- a/versions/v2.10/modules/en/pages/installation-and-upgrade/upgrades.adoc
+++ b/versions/v2.10/modules/en/pages/installation-and-upgrade/upgrades.adoc
@@ -51,17 +51,16 @@ You'll use the backup as a restore point if something goes wrong during upgrade.
 . Update your local Helm repo cache.
 +
 ----
- helm repo update
+helm repo update
 ----
 
 . Get the repository name that you used to install Rancher.
 +
 ----
- helm repo list
+helm repo list
 
- NAME          	       URL
- rancher-prime         <URL>
- rancher-<CHART_REPO>	 https://releases.rancher.com/server-charts/<CHART_REPO>
+NAME          	       URL
+rancher-prime          <helm-chart-repo-url>
 ----
 
 . Fetch the latest chart to install Rancher from the Helm chart repository.
@@ -110,11 +109,11 @@ There will be more values that are listed with this command. This is just an exa
 [TIP]
 ====
 
-Your deployment name may vary; for example, if you're deploying Rancher through the AWS Marketplace, the deployment name is 'rancher-stable'.
+Your deployment name may vary; for example, if you're deploying Rancher through the AWS Marketplace, the deployment name is 'rancher-prime'.
 Thus:
 
 ----
-helm get values rancher-stable -n cattle-system
+helm get values rancher-prime -n cattle-system
 
 hostname: rancher.my.org
 ----
@@ -147,11 +146,11 @@ The above is an example, there may be more values from the previous step that ne
 [TIP]
 ====
 
-If you deploy Rancher through the AWS Marketplace, the deployment name is 'rancher-stable'.
+If you deploy Rancher through the AWS Marketplace, the deployment name is 'rancher-prime'.
 Thus:
 
 ----
-helm upgrade rancher-stable rancher-prime/rancher \
+helm upgrade rancher-prime rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=rancher.my.org
 ----

--- a/versions/v2.10/modules/en/pages/rancher-admin/back-up-restore-and-disaster-recovery/migrate-to-a-new-cluster.adoc
+++ b/versions/v2.10/modules/en/pages/rancher-admin/back-up-restore-and-disaster-recovery/migrate-to-a-new-cluster.adoc
@@ -165,7 +165,7 @@ For Kubernetes v1.25 or later, set `global.cattle.psp.enabled` to `false` when u
 
 [,bash]
 ----
-helm install rancher rancher-latest/rancher \
+helm install rancher rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=<same hostname as the server URL from the first Rancher server> \
   --version x.y.z
@@ -185,7 +185,7 @@ These values can be reused using the `rancher-values.yaml` file. Be sure to swit
 
 [,bash]
 ----
-helm install rancher rancher-latest/rancher -n cattle-system -f rancher-values.yaml --version x.y.z
+helm install rancher rancher-prime/rancher -n cattle-system -f rancher-values.yaml --version x.y.z
 ----
 ====
 

--- a/versions/v2.10/modules/en/pages/rancher-admin/experimental-features/experimental-features.adoc
+++ b/versions/v2.10/modules/en/pages/rancher-admin/experimental-features/experimental-features.adoc
@@ -37,19 +37,12 @@ When installing Rancher with a Helm chart, use the `--set` option. In the below 
 For Kubernetes v1.25 or later, set `global.cattle.psp.enabled` to `false` when using Rancher v2.7.2-v2.7.4. This is not necessary for Rancher v2.7.5 and above, but you can still manually set the option if you choose.
 
 ----
-helm install rancher rancher-latest/rancher \
+helm install rancher rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=rancher.my.org \
   --set 'extraEnv[0].name=CATTLE_FEATURES'
   --set 'extraEnv[0].value=<FEATURE-FLAG-NAME-1>=true,<FEATURE-FLAG-NAME-2>=true'
 ----
-
-[NOTE]
-====
-
-If you are installing an alpha version, Helm requires adding the `--devel` option to the command.
-====
-
 
 === Enabling Features for Air Gap Installs
 

--- a/versions/v2.10/modules/zh/pages/installation-and-upgrade/install-rancher.adoc
+++ b/versions/v2.10/modules/zh/pages/installation-and-upgrade/install-rancher.adoc
@@ -70,27 +70,12 @@ Rancher 是使用 Kubernetes 的 https://helm.sh/[Helm] 包管理器安装的。
 
 === 1. 添加 Helm Chart 仓库
 
-执行 `helm repo add` 命令，以添加包含安装 Rancher 的 Chart 的 Helm Chart 仓库。有关如何选择仓库，以及哪个仓库最适合你的用例，请参见xref:[选择 Rancher 版本]。
+执行 `helm repo add` 命令，以添加包含安装 Rancher Prime 的 Chart 的 Helm Chart 仓库。
 
-* Latest：建议用于试用最新功能
-+
+[,shell]
 ----
- helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+helm repo add rancher-prime <helm-chart-repo-url>
 ----
-
-* Stable：建议用于生产环境
-+
-----
- helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
-----
-
-* Alpha：即将发布的实验性预览。
-+
-----
- helm repo add rancher-alpha https://releases.rancher.com/server-charts/alpha
-----
-+
-注意：不支持升级到 Alpha 版、从 Alpha 版升级或在 Alpha 版之间升级。
 
 === 2. 为 Rancher 创建命名空间
 
@@ -220,18 +205,11 @@ Rancher 生成的证书::
 * 对于 Kubernetes v1.25 或更高版本，使用 Rancher v2.7.2-v2.7.4 时，将 `global.cattle.psp.enabled` 设置为 `false`。对于 Rancher v2.7.5 及更高版本来说，这不是必需的，但你仍然可以手动设置该选项。
 
 ----
-helm install rancher rancher-<CHART_REPO>/rancher \
+helm install rancher rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=rancher.my.org \
   --set bootstrapPassword=admin
 ----
-
-如果你安装的是 alpha 版本，Helm 会要求你在安装命令中添加 `--devel` 选项：
-
-----
-helm install rancher rancher-alpha/rancher --devel
-----
-
 等待 Rancher 运行：
 
 ----
@@ -262,19 +240,13 @@ Let's Encrypt::
 * 对于 Kubernetes v1.25 或更高版本，使用 Rancher v2.7.2-v2.7.4 时，将 `global.cattle.psp.enabled` 设置为 `false`。对于 Rancher v2.7.5 及更高版本来说，这不是必需的，但你仍然可以手动设置该选项。
 
 ----
-helm install rancher rancher-<CHART_REPO>/rancher \
+helm install rancher rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=rancher.my.org \
   --set bootstrapPassword=admin \
   --set ingress.tls.source=letsEncrypt \
   --set letsEncrypt.email=me@example.org \
   --set letsEncrypt.ingress.class=nginx
-----
-
-如果你安装的是 alpha 版本，Helm 会要求你在安装命令中添加 `--devel` 选项：
-
-----
-helm install rancher rancher-alpha/rancher --devel
 ----
 
 等待 Rancher 运行：
@@ -308,23 +280,17 @@ deployment "rancher" successfully rolled out
 * 对于 Kubernetes v1.25 或更高版本，使用 Rancher v2.7.2-v2.7.4 时，将 `global.cattle.psp.enabled` 设置为 `false`。对于 Rancher v2.7.5 及更高版本来说，这不是必需的，但你仍然可以手动设置该选项。
 
 ----
-helm install rancher rancher-<CHART_REPO>/rancher \
+helm install rancher rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=rancher.my.org \
   --set bootstrapPassword=admin \
   --set ingress.tls.source=secret
 ----
 
-如果你安装的是 alpha 版本，Helm 会要求你在安装命令中添加 `--devel` 选项：
-
-----
-helm install rancher rancher-alpha/rancher --devel
-----
-
 如果你使用的是私有 CA 证书，请在命令中增加 `--set privateCA=true`。
 
 ----
-helm install rancher rancher-<CHART_REPO>/rancher \
+helm install rancher rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=rancher.my.org \
   --set bootstrapPassword=admin \

--- a/versions/v2.10/modules/zh/pages/installation-and-upgrade/install-rancher.adoc
+++ b/versions/v2.10/modules/zh/pages/installation-and-upgrade/install-rancher.adoc
@@ -77,6 +77,8 @@ Rancher 是使用 Kubernetes 的 https://helm.sh/[Helm] 包管理器安装的。
 helm repo add rancher-prime <helm-chart-repo-url>
 ----
 
+include::shared:ROOT:partial$zh/helm-chart-repo-url.adoc[]
+
 === 2. 为 Rancher 创建命名空间
 
 你需要定义一个 Kubernetes 命名空间，用于安装由 Chart 创建的资源。这个命名空间的名称为 `cattle-system`：

--- a/versions/v2.10/modules/zh/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
+++ b/versions/v2.10/modules/zh/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -26,6 +26,8 @@
 helm repo add rancher-prime <helm-chart-repo-url>
 ----
 
+include::shared:ROOT:partial$zh/helm-chart-repo-url.adoc[]
+
 . 获取的 Rancher Chart。此操作将获取 Chart 并将其作为 `.tgz` 文件保存在当前目录中。
 
 ** 如需下载最新的 Rancher Prime 版本:

--- a/versions/v2.10/modules/zh/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
+++ b/versions/v2.10/modules/zh/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -19,38 +19,35 @@
 从可以访问互联网的系统中，获取最新的 Helm Chart，然后将 manifest 复制到可访问 Rancher Server 集群的系统中。
 
 . 如果你还没有安装 `helm`，请在可访问互联网的工作站上进行本地安装。注意：参考 xref:installation-and-upgrade/requirements/helm-version-requirements.adoc[Helm 版本要求]选择 Helm 版本来安装 Rancher。
-. 执行 `helm repo add` 命令，以添加包含安装 Rancher 的 Chart 的 Helm Chart 仓库。有关如何选择仓库，以及哪个仓库最适合你的用例，请参见xref:[选择 Rancher 版本]。
- ** Latest：建议用于试用最新功能
-+
+. 执行 `helm repo add` 命令，以添加包含安装 Rancher Prime 的 Chart 的 Helm Chart 仓库。
+ +
+[,shell]
 ----
- helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
-----
-
- ** Stable：建议用于生产环境
-+
-----
- helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
+helm repo add rancher-prime <helm-chart-repo-url>
 ----
 
- ** Alpha：即将发布的实验性预览。
+. 获取的 Rancher Chart。此操作将获取 Chart 并将其作为 `.tgz` 文件保存在当前目录中。
+
+** 如需下载最新的 Rancher Prime 版本:
 +
+[,shell]
 ----
- helm repo add rancher-alpha https://releases.rancher.com/server-charts/alpha
+helm fetch rancher-prime/rancher
+----
+** To fetch a specific version:
++
+Check to see which version of Rancher Prime are available.
++
+[,shell]
+----
+helm search repo --versions rancher-prime
 ----
 +
-注意：不支持升级到 Alpha 版、从 Alpha 版升级或在 Alpha 版之间升级。
-. 获取最新的 Rancher Chart。此操作将获取 Chart 并将其作为 `.tgz` 文件保存在当前目录中。
+如需下载特定的 Rancher Prime 版本，你可以用 Helm `--version` 参数指定版本，如下：
 +
-[,plain]
+[,shell]
 ----
-helm fetch rancher-<CHART_REPO>/rancher
-----
-+
-如需下载特定的 Rancher 版本，你可以用 Helm `--version` 参数指定版本，如下：
-+
-[,plain]
-----
-helm fetch rancher-stable/rancher --version=v2.4.8
+helm fetch rancher-prime/rancher --version=<version>
 ----
 
 === 2. 选择 SSL 配置

--- a/versions/v2.10/modules/zh/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
+++ b/versions/v2.10/modules/zh/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
@@ -59,12 +59,12 @@ kubectl rollout status deployment -n cert-manager cert-manager
 kubectl rollout status deployment -n cert-manager cert-manager-webhook
 ----
 
-== 安装 Rancher
+== 安装 Rancher Prime
 
-接下来，你可以安装 Rancher 了。首先，添加 Helm 仓库：
+接下来，你可以安装 Rancher Prime 了。首先，添加 Helm 仓库：
 
 ----
-helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+helm repo add rancher-prime <helm-chart-repo-url>
 ----
 
 创建命名空间：
@@ -76,7 +76,7 @@ kubectl create namespace cattle-system
 然后使用 Helm 安装 Rancher：Rancher 也需要你配置代理，以便它可以与外部应用商店通信，或检索 Kubernetes 版本更新元数据：
 
 ----
-helm upgrade --install rancher rancher-latest/rancher \
+helm upgrade --install rancher rancher-prime/rancher \
    --namespace cattle-system \
    --set hostname=rancher.example.com \
    --set proxy=http://${proxy_host} \

--- a/versions/v2.10/modules/zh/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
+++ b/versions/v2.10/modules/zh/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
@@ -67,6 +67,8 @@ kubectl rollout status deployment -n cert-manager cert-manager-webhook
 helm repo add rancher-prime <helm-chart-repo-url>
 ----
 
+include::shared:ROOT:partial$zh/helm-chart-repo-url.adoc[]
+
 创建命名空间：
 
 ----

--- a/versions/v2.10/modules/zh/pages/installation-and-upgrade/quick-start/deploy-rancher/helm-cli.adoc
+++ b/versions/v2.10/modules/zh/pages/installation-and-upgrade/quick-start/deploy-rancher/helm-cli.adoc
@@ -103,7 +103,11 @@ notepad.exe $env:USERPROFILE\.kube\config
 
 ----
 helm repo add rancher-prime <helm-chart-repo-url>
+----
 
+include::shared:ROOT:partial$zh/helm-chart-repo-url.adoc[]
+
+----
 kubectl create namespace cattle-system
 
 kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/<VERSION>/cert-manager.crds.yaml

--- a/versions/v2.10/modules/zh/pages/installation-and-upgrade/quick-start/deploy-rancher/helm-cli.adoc
+++ b/versions/v2.10/modules/zh/pages/installation-and-upgrade/quick-start/deploy-rancher/helm-cli.adoc
@@ -102,7 +102,7 @@ notepad.exe $env:USERPROFILE\.kube\config
 
 
 ----
-helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+helm repo add rancher-prime <helm-chart-repo-url>
 
 kubectl create namespace cattle-system
 
@@ -131,14 +131,14 @@ helm install cert-manager jetstack/cert-manager `
 请注意，密码至少需要 12 个字符。
 
 ----
-helm install rancher rancher-latest/rancher \
+helm install rancher rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=<IP_OF_LINUX_NODE>.sslip.io \
   --set replicas=1 \
   --set bootstrapPassword=<PASSWORD_FOR_RANCHER_ADMIN>
 
 # Windows Powershell
-helm install rancher rancher-latest/rancher `
+helm install rancher rancher-prime/rancher `
   --namespace cattle-system `
   --set hostname=<IP_OF_LINUX_NODE>.sslip.io `
   --set replicas=1 `

--- a/versions/v2.10/modules/zh/pages/installation-and-upgrade/resources/update-rancher-certificate.adoc
+++ b/versions/v2.10/modules/zh/pages/installation-and-upgrade/resources/update-rancher-certificate.adoc
@@ -121,10 +121,10 @@ privateCA: true
 +
 [,bash]
 ----
- helm upgrade rancher rancher-stable/rancher \
-  --namespace cattle-system \
-  -f values.yaml \
-  --version <DEPLOYED_RANCHER_VERSION>
+    helm upgrade rancher rancher-prime/rancher \
+     --namespace cattle-system \
+     -f values.yaml \
+     --version <DEPLOYED_RANCHER_VERSION>
 ----
 
 修改完成后，访问 `\https://<rancher_server_url>/v3/settings/cacerts`，验证该值是否与先前写入 `tls-ca` Secret 中的 CA 证书匹配。在所有 Rancher pod 启动之前，CA `cacerts` 值可能不会更新。
@@ -278,10 +278,10 @@ helm ls -n cattle-system
 +
 [,bash]
 ----
-  helm upgrade rancher rancher-stable/rancher \
---namespace cattle-system \
--f values.yaml \
---version <DEPLOYED_RANCHER_VERSION>
+helm upgrade rancher rancher-prime/rancher \
+  --namespace cattle-system \
+  -f values.yaml \
+  --version <DEPLOYED_RANCHER_VERSION>
 ----
 
 === 4. 为非私有/通用证书重新配置 Rancher Agent

--- a/versions/v2.10/modules/zh/pages/installation-and-upgrade/upgrades.adoc
+++ b/versions/v2.10/modules/zh/pages/installation-and-upgrade/upgrades.adoc
@@ -18,9 +18,7 @@ kubeconfig 也可以通过 `--kubeconfig` 标签（详情请参见 https://helm.
 
 === 查看已知问题
 
-如需查看每个 Rancher 版本的已知问题，请参见 https://github.com/rancher/rancher/releases[GitHub] 中的发行说明，或查看 https://forums.rancher.com/c/announcements/12[Rancher 论坛]。
-
-不支持 _升级_ 或 _升级到_ xref:#_helm_chart_仓库[rancher-alpha 仓库]中的任何 Chart。
+如需查看每个 Rancher 版本的已知问题，请参见 https://github\.com/rancher/rancher/releases\[GitHub\] 中的发行说明，或查看 https://forums\.rancher\.com/c/announcements/12\[Rancher 论坛\]。
 
 === Helm 版本
 
@@ -56,45 +54,14 @@ https://community.letsencrypt.org/t/blocking-old-cert-manager-versions/98753[从
 helm repo update
 ----
 
-. 获取你用来安装 Rancher 的仓库名称。
-+
-关于仓库及其区别，请参见 xref:#_helm_chart_仓库[Helm Chart 仓库]。
-
- ** Latest：建议用于试用最新功能
-+
-----
- helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
-----
-
- ** Stable：建议用于生产环境
-+
-----
- helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
-----
-
- ** Alpha：即将发布的实验性预览。
-+
-----
- helm repo add rancher-alpha https://releases.rancher.com/server-charts/alpha
-----
-+
-注意：不支持升级到 Alpha 版、从 Alpha 版升级或在 Alpha 版之间升级。
-
+. Get the repository name that you used to install Rancher.
 +
 ----
 helm repo list
 
 NAME          	       URL
-stable        	       https://charts.helm.sh/stable
-rancher-<CHART_REPO>	 https://releases.rancher.com/server-charts/<CHART_REPO>
+rancher-prime          <helm-chart-repo-url>
 ----
-+
-
-[NOTE]
-====
-如果你想切换到不同的 Helm Chart 仓库，请按照xref:#_切换到不同_helm_chart_仓库[切换仓库步骤]进行操作。如果你要切换仓库，请先再次列出仓库，再继续执行步骤 3，以确保添加了正确的仓库。
-====
-
 
 . 从 Helm Chart 仓库获取最新的 Chart 来安装 Rancher。
 +
@@ -102,14 +69,14 @@ rancher-<CHART_REPO>	 https://releases.rancher.com/server-charts/<CHART_REPO>
 +
 [,plain]
 ----
-helm fetch rancher-<CHART_REPO>/rancher
+helm fetch rancher-prime/rancher
 ----
 +
 你可以通过 `--version=` 标记，来指定要升级的目标 Chart 版本。例如：
 +
 [,plain]
 ----
-helm fetch rancher-<CHART_REPO>/rancher --version=2.6.8
+helm fetch rancher-prime/rancher --version=2.6.8
 ----
 
 === 3. 升级 Rancher
@@ -142,11 +109,11 @@ hostname: rancher.my.org
 [TIP]
 ====
 
-Deployment 的名称可能会有所不同。例如，如果你通过 AWS Marketplace 部署 Rancher，则 Deployment 的名称为"`rancher-stable`"。
+Deployment 的名称可能会有所不同。例如，如果你通过 AWS Marketplace 部署 Rancher，则 Deployment 的名称为"`rancher-prime`"。
 因此：
 
 ----
-helm get values rancher-stable -n cattle-system
+helm get values rancher-prime -n cattle-system
 
 hostname: rancher.my.org
 ----
@@ -164,7 +131,7 @@ hostname: rancher.my.org
 对于 Kubernetes v1.25 或更高版本，使用 Rancher v2.7.2-v2.7.4 时，将 `global.cattle.psp.enabled` 设置为 `false`。对于 Rancher v2.7.5 及更高版本来说，这不是必需的，但你仍然可以手动设置该选项。
 
 ----
-helm upgrade rancher rancher-<CHART_REPO>/rancher \
+helm upgrade rancher rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=rancher.my.org
 ----
@@ -179,11 +146,11 @@ helm upgrade rancher rancher-<CHART_REPO>/rancher \
 [TIP]
 ====
 
-如果你通过 AWS Marketplace 部署 Rancher，则 Deployment 的名称为"`rancher-stable`"。
+如果你通过 AWS Marketplace 部署 Rancher，则 Deployment 的名称为"`rancher-prime`"。
 因此：
 
 ----
-helm upgrade rancher-stable rancher-<CHART_REPO>/rancher \
+helm upgrade rancher-prime rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=rancher.my.org
 ----
@@ -203,7 +170,7 @@ helm get values rancher -n cattle-system -o yaml > values.yaml
 对于 Kubernetes v1.25 或更高版本，使用 Rancher v2.7.2-v2.7.4 时，将 `global.cattle.psp.enabled` 设置为 `false`。对于 Rancher v2.7.5 及更高版本来说，这不是必需的，但你仍然可以手动设置该选项。
 +
 ----
-helm upgrade rancher rancher-<CHART_REPO>/rancher \
+helm upgrade rancher rancher-prime/rancher \
   --namespace cattle-system \
   -f values.yaml \
   --version=2.6.8

--- a/versions/v2.10/modules/zh/pages/rancher-admin/back-up-restore-and-disaster-recovery/migrate-to-a-new-cluster.adoc
+++ b/versions/v2.10/modules/zh/pages/rancher-admin/back-up-restore-and-disaster-recovery/migrate-to-a-new-cluster.adoc
@@ -182,8 +182,9 @@ kubectl logs -n cattle-resources-system --tail 100 -f -l app.kubernetes.io/insta
 对于 Kubernetes v1.25 或更高版本，使用 Rancher v2.7.2-v2.7.4 时，将 `global.cattle.psp.enabled` 设置为 `false`。对于 Rancher v2.7.5 及更高版本来说，这不是必需的，但你仍然可以手动设置该选项。
 
 [,bash]
+[,bash]
 ----
-helm install rancher rancher-latest/rancher \
+helm install rancher rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=<same hostname as the server URL from the first Rancher server> \
   --version x.y.z
@@ -203,7 +204,14 @@ helm get values rancher -n cattle-system -o yaml > rancher-values.yaml
 
 [,bash]
 ----
-helm install rancher rancher-latest/rancher -n cattle-system -f rancher-values.yaml --version x.y.z
+helm install rancher rancher-prime/rancher -n cattle-system -f rancher-values.yaml --version x.y.z
 ----
 ====
+
+
+== 5. Redirect Traffic to the New Cluster
+
+After migration completes, update your DNS records and any load balancers, so that traffic is routed correctly to the migrated cluster. Remember that you must use the same hostname that was set as the server URL in the original cluster.
+
+Full instructions on how to redirect traffic to the migrated cluster differ based on your specific environment. Refer to your hosting provider's documentation for more details.
 

--- a/versions/v2.10/modules/zh/pages/rancher-admin/experimental-features/experimental-features.adoc
+++ b/versions/v2.10/modules/zh/pages/rancher-admin/experimental-features/experimental-features.adoc
@@ -37,19 +37,12 @@ Rancher 包含一些默认关闭的实验功能。在某些情况下，例如当
 对于 Kubernetes v1.25 或更高版本，使用 Rancher v2.7.2-v2.7.4 时，将 `global.cattle.psp.enabled` 设置为 `false`。对于 Rancher v2.7.5 及更高版本来说，这不是必需的，但你仍然可以手动设置该选项。
 
 ----
-helm install rancher rancher-latest/rancher \
+helm install rancher rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=rancher.my.org \
   --set 'extraEnv[0].name=CATTLE_FEATURES'
   --set 'extraEnv[0].value=<FEATURE-FLAG-NAME-1>=true,<FEATURE-FLAG-NAME-2>=true'
 ----
-
-[NOTE]
-====
-
-如果你安装的是 alpha 版本，Helm 要求你在命令中添加 `--devel` 选项。
-====
-
 
 === 离线安装的情况下渲染 Helm Chart
 

--- a/versions/v2.10/modules/zh/pages/security/rancher-webhook/rancher-webhook.adoc
+++ b/versions/v2.10/modules/zh/pages/security/rancher-webhook/rancher-webhook.adoc
@@ -91,7 +91,7 @@ Rancher 会在检测到对 ConfigMap 值的更改时重新部署 Rancher-Webhook
 
 [,bash]
 ----
-helm install rancher rancher-<CHART_REPO>/rancher \
+helm install rancher rancher-prime/rancher \
   --namespace cattle-system \
   ...
   --set webhook.port=9553 \

--- a/versions/v2.8/modules/en/pages/installation-and-upgrade/install-rancher.adoc
+++ b/versions/v2.8/modules/en/pages/installation-and-upgrade/install-rancher.adoc
@@ -70,27 +70,12 @@ To set up Rancher,
 
 === 1. Add the Helm Chart Repository
 
-Use `helm repo add` command to add the Helm chart repository that contains charts to install Rancher. For more information about the repository choices and which is best for your use case, see xref:[Choosing a Rancher Version].
+Use the `helm repo add` command to add the Helm chart repository that contains charts to install Rancher Prime.
 
-* Latest: Recommended for trying out the newest features
-+
+[,shell]
 ----
-  helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+helm repo add rancher-prime <helm-chart-repo-url>
 ----
-
-* Stable: Recommended for production environments
-+
-----
-  helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
-----
-
-* Alpha: Experimental preview of upcoming releases.
-+
-----
-  helm repo add rancher-alpha https://releases.rancher.com/server-charts/alpha
-----
-+
-NOTE: Upgrades are not supported to, from, or between Alphas.
 
 === 2. Create a Namespace for Rancher
 
@@ -227,12 +212,6 @@ helm install rancher rancher-<CHART_REPO>/rancher \
   --set bootstrapPassword=admin
 ----
 
-If you are installing an alpha version, Helm requires adding the `--devel` option to the install command:
-
-----
-helm install rancher rancher-alpha/rancher --devel
-----
-
 Wait for Rancher to be rolled out:
 
 ----
@@ -280,12 +259,6 @@ helm install rancher rancher-<CHART_REPO>/rancher \
   --set letsEncrypt.ingress.class=nginx
 ----
 
-If you are installing an alpha version, Helm requires adding the `--devel` option to the install command:
-
-----
-helm install rancher rancher-alpha/rancher --devel
-----
-
 Wait for Rancher to be rolled out:
 
 ----
@@ -322,12 +295,6 @@ helm install rancher rancher-<CHART_REPO>/rancher \
   --set hostname=rancher.my.org \
   --set bootstrapPassword=admin \
   --set ingress.tls.source=secret
-----
-
-If you are installing an alpha version, Helm requires adding the `--devel` option to the install command:
-
-----
-helm install rancher rancher-alpha/rancher --devel
 ----
 
 If you are using a Private CA signed certificate , add `--set privateCA=true` to the command:

--- a/versions/v2.8/modules/en/pages/installation-and-upgrade/install-rancher.adoc
+++ b/versions/v2.8/modules/en/pages/installation-and-upgrade/install-rancher.adoc
@@ -77,6 +77,8 @@ Use the `helm repo add` command to add the Helm chart repository that contains c
 helm repo add rancher-prime <helm-chart-repo-url>
 ----
 
+include::shared:ROOT:partial$en/helm-chart-repo-url.adoc[]
+
 === 2. Create a Namespace for Rancher
 
 We'll need to define a Kubernetes namespace where the resources created by the Chart should be installed. This should always be `cattle-system`:

--- a/versions/v2.8/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
+++ b/versions/v2.8/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -19,38 +19,34 @@ Rancher recommends installing Rancher on a Kubernetes cluster. A highly availabl
 From a system that has access to the internet, fetch the latest Helm chart and copy the resulting manifests to a system that has access to the Rancher server cluster.
 
 . If you haven't already, install `helm` locally on a workstation that has internet access. Note: Refer to the xref:installation-and-upgrade/requirements/helm-version-requirements.adoc[Helm version requirements] to choose a version of Helm to install Rancher.
-. Use `helm repo add` command to add the Helm chart repository that contains charts to install Rancher. For more information about the repository choices and which is best for your use case, see xref:[Choosing a Rancher Version].
- ** Latest: Recommended for trying out the newest features
+. Use the `helm repo add` command to add the Helm chart repository that contains charts to install Rancher Prime.
 +
+[,shell]
 ----
-  helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+helm repo add rancher-prime <helm-chart-repo-url>
 ----
 
- ** Stable: Recommended for production environments
+. Fetch the Rancher Prime chart. This will pull down the chart and save it in the current directory as a `.tgz` file.
+** To fetch the latest version:
 +
+[,shell]
 ----
-  helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
+helm fetch rancher-prime/rancher
 ----
-
- ** Alpha: Experimental preview of upcoming releases.
+** To fetch a specific version:
 +
-----
-  helm repo add rancher-alpha https://releases.rancher.com/server-charts/alpha
-----
+Check to see which version of Rancher Prime are available.
 +
-NOTE: Upgrades are not supported to, from, or between Alphas.
-. Fetch the latest Rancher chart. This will pull down the chart and save it in the current directory as a `.tgz` file.
-+
-[,plain]
+[,shell]
 ----
- helm fetch rancher-<CHART_REPO>/rancher
+helm search repo --versions rancher-prime
 ----
 +
-If you require a specific version of Rancher, you can fetch this with the Helm `--version` parameter like in the following example:
+Fetch a specific version by specifying the `--version` parameter:
 +
-[,plain]
+[,shell]
 ----
- helm fetch rancher-stable/rancher --version=v2.4.8
+helm fetch rancher-prime/rancher --version=<version>
 ----
 
 === 2. Choose your SSL Configuration

--- a/versions/v2.8/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
+++ b/versions/v2.8/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -25,6 +25,8 @@ From a system that has access to the internet, fetch the latest Helm chart and c
 ----
 helm repo add rancher-prime <helm-chart-repo-url>
 ----
++
+include::shared:ROOT:partial$en/helm-chart-repo-url.adoc[]
 
 . Fetch the Rancher Prime chart. This will pull down the chart and save it in the current directory as a `.tgz` file.
 ** To fetch the latest version:

--- a/versions/v2.8/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
+++ b/versions/v2.8/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
@@ -58,12 +58,12 @@ kubectl rollout status deployment -n cert-manager cert-manager
 kubectl rollout status deployment -n cert-manager cert-manager-webhook
 ----
 
-== Install Rancher
+== Install Rancher Prime
 
-Next you can install Rancher itself. First, add the Helm repository:
+Next you can install Rancher Prime itself. First, add the Helm repository:
 
 ----
-helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+helm repo add rancher-prime <helm-chart-repo-url>
 ----
 
 Create a namespace:
@@ -75,7 +75,7 @@ kubectl create namespace cattle-system
 And install Rancher with Helm. Rancher also needs a proxy configuration so that it can communicate with external application catalogs or retrieve Kubernetes version update metadata:
 
 ----
-helm upgrade --install rancher rancher-latest/rancher \
+helm upgrade --install rancher rancher-prime/rancher \
    --namespace cattle-system \
    --set hostname=rancher.example.com \
    --set proxy=http://${proxy_host} \

--- a/versions/v2.8/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
+++ b/versions/v2.8/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
@@ -66,6 +66,8 @@ Next you can install Rancher Prime itself. First, add the Helm repository:
 helm repo add rancher-prime <helm-chart-repo-url>
 ----
 
+include::shared:ROOT:partial$en/helm-chart-repo-url.adoc[]
+
 Create a namespace:
 
 ----

--- a/versions/v2.8/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/helm-cli.adoc
+++ b/versions/v2.8/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/helm-cli.adoc
@@ -103,7 +103,11 @@ To see options on how to customize the cert-manager install (including for cases
 
 ----
 helm repo add rancher-prime <helm-chart-repo-url>
+----
 
+include::shared:ROOT:partial$en/helm-chart-repo-url.adoc[]
+
+----
 kubectl create namespace cattle-system
 
 kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/<VERSION>/cert-manager.crds.yaml

--- a/versions/v2.8/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/helm-cli.adoc
+++ b/versions/v2.8/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/helm-cli.adoc
@@ -102,7 +102,7 @@ To see options on how to customize the cert-manager install (including for cases
 
 
 ----
-helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+helm repo add rancher-prime <helm-chart-repo-url>
 
 kubectl create namespace cattle-system
 
@@ -131,14 +131,14 @@ For Kubernetes v1.25 or later, set `global.cattle.psp.enabled` to `false` when u
 See xref:installation-and-upgrade/resources/bootstrap-password.adoc#_password_requirements[Setting up the Bootstrap Password] for password requirements.
 
 ----
-helm install rancher rancher-latest/rancher \
+helm install rancher rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=<IP_OF_LINUX_NODE>.sslip.io \
   --set replicas=1 \
   --set bootstrapPassword=<PASSWORD_FOR_RANCHER_ADMIN>
 
 # Windows Powershell
-helm install rancher rancher-latest/rancher `
+helm install rancher rancher-prime/rancher `
   --namespace cattle-system `
   --set hostname=<IP_OF_LINUX_NODE>.sslip.io `
   --set replicas=1 `

--- a/versions/v2.8/modules/en/pages/installation-and-upgrade/resources/update-rancher-certificate.adoc
+++ b/versions/v2.8/modules/en/pages/installation-and-upgrade/resources/update-rancher-certificate.adoc
@@ -89,24 +89,24 @@ The below steps update the Helm values for the Rancher chart, so the Rancher pod
 +
 [,bash]
 ----
-   helm get values rancher -n cattle-system -o yaml > values.yaml
+helm get values rancher -n cattle-system -o yaml > values.yaml
 ----
 
 . Retrieve the version string of the currently deployed Rancher chart to use below:
 +
 [,bash]
 ----
-   helm ls -n cattle-system
+helm ls -n cattle-system
 ----
 
 . Update the current Helm values in the `values.yaml` file to contain:
 +
 [,yaml]
 ----
-   ingress:
-     tls:
- source: secret
-   privateCA: true
+ingress:
+  tls:
+    source: secret
+privateCA: true
 ----
 +
 
@@ -261,14 +261,14 @@ The below steps update the Helm values for the Rancher chart, so the Rancher pod
 +
 [,bash]
 ----
-   helm get values rancher -n cattle-system -o yaml > values.yaml
+helm get values rancher -n cattle-system -o yaml > values.yaml
 ----
 
 . Also get the version string of the currently deployed Rancher chart:
 +
 [,bash]
 ----
-   helm ls -n cattle-system
+helm ls -n cattle-system
 ----
 
 . Update the current Helm values in the `values.yaml` file:
@@ -280,10 +280,10 @@ The below steps update the Helm values for the Rancher chart, so the Rancher pod
 +
 [,bash]
 ----
-    helm upgrade rancher rancher-prime/rancher \
---namespace cattle-system \
--f values.yaml \
---version <DEPLOYED_RANCHER_VERSION>
+helm upgrade rancher rancher-prime/rancher \
+  --namespace cattle-system \
+  -f values.yaml \
+  --version <DEPLOYED_RANCHER_VERSION>
 ----
 
 === 4. Reconfigure Rancher agents for the non-private/common certificate

--- a/versions/v2.8/modules/en/pages/installation-and-upgrade/resources/update-rancher-certificate.adoc
+++ b/versions/v2.8/modules/en/pages/installation-and-upgrade/resources/update-rancher-certificate.adoc
@@ -121,7 +121,7 @@ The below steps update the Helm values for the Rancher chart, so the Rancher pod
 +
 [,bash]
 ----
-    helm upgrade rancher rancher-stable/rancher \
+    helm upgrade rancher rancher-prime/rancher \
      --namespace cattle-system \
      -f values.yaml \
      --version <DEPLOYED_RANCHER_VERSION>
@@ -280,7 +280,7 @@ The below steps update the Helm values for the Rancher chart, so the Rancher pod
 +
 [,bash]
 ----
-    helm upgrade rancher rancher-stable/rancher \
+    helm upgrade rancher rancher-prime/rancher \
 --namespace cattle-system \
 -f values.yaml \
 --version <DEPLOYED_RANCHER_VERSION>

--- a/versions/v2.8/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
+++ b/versions/v2.8/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
@@ -96,7 +96,7 @@ If you are running Kubernetes v1.15 or below, you will need to add the `--valida
 +
 [,plain]
 ----
- helm repo update
+helm repo update
 ----
 
 . Install the new version of cert-manager

--- a/versions/v2.8/modules/en/pages/installation-and-upgrade/upgrades.adoc
+++ b/versions/v2.8/modules/en/pages/installation-and-upgrade/upgrades.adoc
@@ -62,13 +62,6 @@ helm repo list
 NAME          	       URL
 rancher-prime          <helm-chart-repo-url>
 ----
-+
-
-[NOTE]
-====
-If you want to switch to a different Helm chart repository, please follow the xref:#_switching_to_a_different_helm_chart_repository[steps on how to switch repositories]. If you switch repositories, make sure to list the repositories again before continuing onto Step 3 to ensure you have the correct one added.
-====
-
 
 . Fetch the latest chart to install Rancher from the Helm chart repository.
 +

--- a/versions/v2.8/modules/en/pages/installation-and-upgrade/upgrades.adoc
+++ b/versions/v2.8/modules/en/pages/installation-and-upgrade/upgrades.adoc
@@ -76,14 +76,14 @@ This command will pull down the latest charts and save it in the current directo
 +
 [,plain]
 ----
- helm fetch rancher-<CHART_REPO>/rancher
+ helm fetch rancher-prime/rancher
 ----
 +
 You can fetch the chart for the specific version you are upgrading to by adding in the `--version=` tag.  For example:
 +
 [,plain]
 ----
- helm fetch rancher-<CHART_REPO>/rancher --version=2.6.8
+ helm fetch rancher-prime/rancher --version=2.6.8
 ----
 
 === 3. Upgrade Rancher
@@ -138,7 +138,7 @@ Take all the values from the previous step and append them to the command using 
 For Kubernetes v1.25 or later, set `global.cattle.psp.enabled` to `false` when using Rancher v2.7.2-v2.7.4. This is not necessary for Rancher v2.7.5 and above, but you can still manually set the option if you choose.
 
 ----
-helm upgrade rancher rancher-<CHART_REPO>/rancher \
+helm upgrade rancher rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=rancher.my.org
 ----
@@ -177,7 +177,7 @@ Alternatively, it's possible to export the current values to a file and referenc
 For Kubernetes v1.25 or later, set `global.cattle.psp.enabled` to `false` when using Rancher v2.7.2-v2.7.4. This is not necessary for Rancher v2.7.5 and above, but you can still manually set the option if you choose.
 +
 ----
- helm upgrade rancher rancher-<CHART_REPO>/rancher \
+ helm upgrade rancher rancher-prime/rancher \
    --namespace cattle-system \
    -f values.yaml \
    --version=2.6.8

--- a/versions/v2.8/modules/en/pages/installation-and-upgrade/upgrades.adoc
+++ b/versions/v2.8/modules/en/pages/installation-and-upgrade/upgrades.adoc
@@ -20,8 +20,6 @@ The kubeconfig can also be manually targeted for the intended cluster with the `
 
 Review the list of known issues for each Rancher version, which can be found in the release notes on https://github.com/rancher/rancher/releases[GitHub] and on the https://forums.rancher.com/c/announcements/12[Rancher forums.]
 
-Note that upgrades _to_ or _from_ any chart in the xref:#_helm_chart_repositories[rancher-alpha repository] aren't supported.
-
 === Helm Version
 
 include::shared:ROOT:partial$en/deprecation-helm2.adoc[]
@@ -53,40 +51,16 @@ You'll use the backup as a restore point if something goes wrong during upgrade.
 . Update your local Helm repo cache:
 +
 ----
- helm repo update
+helm repo update
 ----
 
 . Get the repository name that you used to install Rancher.
 +
-For information about the repos and their differences, see xref:#_helm_chart_repositories[Helm Chart Repositories].
+----
+helm repo list
 
- ** Latest: Recommended for trying out the newest features
-+
-----
-  helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
-----
-
- ** Stable: Recommended for production environments
-+
-----
-  helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
-----
-
- ** Alpha: Experimental preview of upcoming releases.
-+
-----
-  helm repo add rancher-alpha https://releases.rancher.com/server-charts/alpha
-----
-+
-NOTE: Upgrades are not supported to, from, or between Alphas.
-
-+
-----
- helm repo list
-
- NAME          	       URL
- stable        	       https://charts.helm.sh/stable
- rancher-<CHART_REPO>	 https://releases.rancher.com/server-charts/<CHART_REPO>
+NAME          	       URL
+rancher-prime          <helm-chart-repo-url>
 ----
 +
 
@@ -142,11 +116,11 @@ There will be more values that are listed with this command. This is just an exa
 [TIP]
 ====
 
-Your deployment name may vary; for example, if you're deploying Rancher through the AWS Marketplace, the deployment name is 'rancher-stable'.
+Your deployment name may vary; for example, if you're deploying Rancher through the AWS Marketplace, the deployment name is 'rancher-prime'.
 Thus:
 
 ----
-helm get values rancher-stable -n cattle-system
+helm get values rancher-prime -n cattle-system
 
 hostname: rancher.my.org
 ----
@@ -179,11 +153,11 @@ The above is an example, there may be more values from the previous step that ne
 [TIP]
 ====
 
-If you deploy Rancher through the AWS Marketplace, the deployment name is 'rancher-stable'.
+If you deploy Rancher through the AWS Marketplace, the deployment name is 'rancher-prime'.
 Thus:
 
 ----
-helm upgrade rancher-stable rancher-<CHART_REPO>/rancher \
+helm upgrade rancher-prime rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=rancher.my.org
 ----

--- a/versions/v2.8/modules/en/pages/rancher-admin/back-up-restore-and-disaster-recovery/migrate-to-a-new-cluster.adoc
+++ b/versions/v2.8/modules/en/pages/rancher-admin/back-up-restore-and-disaster-recovery/migrate-to-a-new-cluster.adoc
@@ -164,7 +164,7 @@ For Kubernetes v1.25 or later, set `global.cattle.psp.enabled` to `false` when u
 
 [,bash]
 ----
-helm install rancher rancher-latest/rancher \
+helm install rancher rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=<same hostname as the server URL from the first Rancher server> \
   --version x.y.z
@@ -184,7 +184,7 @@ These values can be reused using the `rancher-values.yaml` file. Be sure to swit
 
 [,bash]
 ----
-helm install rancher rancher-latest/rancher -n cattle-system -f rancher-values.yaml --version x.y.z
+helm install rancher rancher-prime/rancher -n cattle-system -f rancher-values.yaml --version x.y.z
 ----
 ====
 

--- a/versions/v2.8/modules/en/pages/rancher-admin/experimental-features/experimental-features.adoc
+++ b/versions/v2.8/modules/en/pages/rancher-admin/experimental-features/experimental-features.adoc
@@ -37,19 +37,12 @@ When installing Rancher with a Helm chart, use the `--set` option. In the below 
 For Kubernetes v1.25 or later, set `global.cattle.psp.enabled` to `false` when using Rancher v2.7.2-v2.7.4. This is not necessary for Rancher v2.7.5 and above, but you can still manually set the option if you choose.
 
 ----
-helm install rancher rancher-latest/rancher \
+helm install rancher rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=rancher.my.org \
   --set 'extraEnv[0].name=CATTLE_FEATURES'
   --set 'extraEnv[0].value=<FEATURE-FLAG-NAME-1>=true,<FEATURE-FLAG-NAME-2>=true'
 ----
-
-[NOTE]
-====
-
-If you are installing an alpha version, Helm requires adding the `--devel` option to the command.
-====
-
 
 === Enabling Features for Air Gap Installs
 

--- a/versions/v2.8/modules/en/pages/security/rancher-webhook/rancher-webhook.adoc
+++ b/versions/v2.8/modules/en/pages/security/rancher-webhook/rancher-webhook.adoc
@@ -256,14 +256,14 @@ Then, run the command:
 
 [,bash]
 ----
-helm upgrade --install rancher rancher-latest/rancher --namespace cattle-system --reuse-values --values PATH/TO/values.yaml
+helm upgrade --install rancher rancher-prime/rancher --namespace cattle-system --reuse-values --values PATH/TO/values.yaml
 ----
 
 You can instead specify the webhook version directly on the command-line:
 
 [,bash]
 ----
-helm upgrade --install rancher rancher-latest/rancher --namespace cattle-system --reuse-values \
+helm upgrade --install rancher rancher-prime/rancher --namespace cattle-system --reuse-values \
     --set extraEnv[0].name=CATTLE_RANCHER_WEBHOOK_VERSION \
     --set extraEnv[0].value=103.0.2+up0.4.3
 ----

--- a/versions/v2.8/modules/zh/pages/installation-and-upgrade/install-rancher.adoc
+++ b/versions/v2.8/modules/zh/pages/installation-and-upgrade/install-rancher.adoc
@@ -78,6 +78,8 @@ Rancher 是使用 Kubernetes 的 https://helm.sh/[Helm] 包管理器安装的。
 helm repo add rancher-prime <helm-chart-repo-url>
 ----
 
+include::shared:ROOT:partial$zh/helm-chart-repo-url.adoc[]
+
 === 2. 为 Rancher 创建命名空间
 
 你需要定义一个 Kubernetes 命名空间，用于安装由 Chart 创建的资源。这个命名空间的名称为 `cattle-system`：

--- a/versions/v2.8/modules/zh/pages/installation-and-upgrade/install-rancher.adoc
+++ b/versions/v2.8/modules/zh/pages/installation-and-upgrade/install-rancher.adoc
@@ -71,27 +71,12 @@ Rancher 是使用 Kubernetes 的 https://helm.sh/[Helm] 包管理器安装的。
 
 === 1. 添加 Helm Chart 仓库
 
-执行 `helm repo add` 命令，以添加包含安装 Rancher 的 Chart 的 Helm Chart 仓库。有关如何选择仓库，以及哪个仓库最适合你的用例，请参见xref:[选择 Rancher 版本]。
+执行 `helm repo add` 命令，以添加包含安装 Rancher Prime 的 Chart 的 Helm Chart 仓库。
 
-* Latest：建议用于试用最新功能
-+
+[,shell]
 ----
- helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+helm repo add rancher-prime <helm-chart-repo-url>
 ----
-
-* Stable：建议用于生产环境
-+
-----
- helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
-----
-
-* Alpha：即将发布的实验性预览。
-+
-----
- helm repo add rancher-alpha https://releases.rancher.com/server-charts/alpha
-----
-+
-注意：不支持升级到 Alpha 版、从 Alpha 版升级或在 Alpha 版之间升级。
 
 === 2. 为 Rancher 创建命名空间
 
@@ -221,18 +206,11 @@ Rancher 生成的证书::
 * 对于 Kubernetes v1.25 或更高版本，使用 Rancher v2.7.2-v2.7.4 时，将 `global.cattle.psp.enabled` 设置为 `false`。对于 Rancher v2.7.5 及更高版本来说，这不是必需的，但你仍然可以手动设置该选项。
 
 ----
-helm install rancher rancher-<CHART_REPO>/rancher \
+helm install rancher rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=rancher.my.org \
   --set bootstrapPassword=admin
 ----
-
-如果你安装的是 alpha 版本，Helm 会要求你在安装命令中添加 `--devel` 选项：
-
-----
-helm install rancher rancher-alpha/rancher --devel
-----
-
 等待 Rancher 运行：
 
 ----
@@ -264,19 +242,13 @@ Let's Encrypt::
 * 对于 Kubernetes v1.25 或更高版本，使用 Rancher v2.7.2-v2.7.4 时，将 `global.cattle.psp.enabled` 设置为 `false`。对于 Rancher v2.7.5 及更高版本来说，这不是必需的，但你仍然可以手动设置该选项。
 
 ----
-helm install rancher rancher-<CHART_REPO>/rancher \
+helm install rancher rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=rancher.my.org \
   --set bootstrapPassword=admin \
   --set ingress.tls.source=letsEncrypt \
   --set letsEncrypt.email=me@example.org \
   --set letsEncrypt.ingress.class=nginx
-----
-
-如果你安装的是 alpha 版本，Helm 会要求你在安装命令中添加 `--devel` 选项：
-
-----
-helm install rancher rancher-alpha/rancher --devel
 ----
 
 等待 Rancher 运行：
@@ -310,23 +282,17 @@ deployment "rancher" successfully rolled out
 * 对于 Kubernetes v1.25 或更高版本，使用 Rancher v2.7.2-v2.7.4 时，将 `global.cattle.psp.enabled` 设置为 `false`。对于 Rancher v2.7.5 及更高版本来说，这不是必需的，但你仍然可以手动设置该选项。
 
 ----
-helm install rancher rancher-<CHART_REPO>/rancher \
+helm install rancher rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=rancher.my.org \
   --set bootstrapPassword=admin \
   --set ingress.tls.source=secret
 ----
 
-如果你安装的是 alpha 版本，Helm 会要求你在安装命令中添加 `--devel` 选项：
-
-----
-helm install rancher rancher-alpha/rancher --devel
-----
-
 如果你使用的是私有 CA 证书，请在命令中增加 `--set privateCA=true`。
 
 ----
-helm install rancher rancher-<CHART_REPO>/rancher \
+helm install rancher rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=rancher.my.org \
   --set bootstrapPassword=admin \

--- a/versions/v2.8/modules/zh/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
+++ b/versions/v2.8/modules/zh/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -26,6 +26,8 @@
 helm repo add rancher-prime <helm-chart-repo-url>
 ----
 
+include::shared:ROOT:partial$zh/helm-chart-repo-url.adoc[]
+
 . 获取的 Rancher Chart。此操作将获取 Chart 并将其作为 `.tgz` 文件保存在当前目录中。
 
 ** 如需下载最新的 Rancher Prime 版本:

--- a/versions/v2.8/modules/zh/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
+++ b/versions/v2.8/modules/zh/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -19,38 +19,35 @@
 从可以访问互联网的系统中，获取最新的 Helm Chart，然后将 manifest 复制到可访问 Rancher Server 集群的系统中。
 
 . 如果你还没有安装 `helm`，请在可访问互联网的工作站上进行本地安装。注意：参考 xref:installation-and-upgrade/requirements/helm-version-requirements.adoc[Helm 版本要求]选择 Helm 版本来安装 Rancher。
-. 执行 `helm repo add` 命令，以添加包含安装 Rancher 的 Chart 的 Helm Chart 仓库。有关如何选择仓库，以及哪个仓库最适合你的用例，请参见xref:[选择 Rancher 版本]。
- ** Latest：建议用于试用最新功能
-+
+. 执行 `helm repo add` 命令，以添加包含安装 Rancher Prime 的 Chart 的 Helm Chart 仓库。
+ +
+[,shell]
 ----
- helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
-----
-
- ** Stable：建议用于生产环境
-+
-----
- helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
+helm repo add rancher-prime <helm-chart-repo-url>
 ----
 
- ** Alpha：即将发布的实验性预览。
+. 获取的 Rancher Chart。此操作将获取 Chart 并将其作为 `.tgz` 文件保存在当前目录中。
+
+** 如需下载最新的 Rancher Prime 版本:
 +
+[,shell]
 ----
- helm repo add rancher-alpha https://releases.rancher.com/server-charts/alpha
+helm fetch rancher-prime/rancher
+----
+** To fetch a specific version:
++
+Check to see which version of Rancher Prime are available.
++
+[,shell]
+----
+helm search repo --versions rancher-prime
 ----
 +
-注意：不支持升级到 Alpha 版、从 Alpha 版升级或在 Alpha 版之间升级。
-. 获取最新的 Rancher Chart。此操作将获取 Chart 并将其作为 `.tgz` 文件保存在当前目录中。
+如需下载特定的 Rancher Prime 版本，你可以用 Helm `--version` 参数指定版本，如下：
 +
-[,plain]
+[,shell]
 ----
-helm fetch rancher-<CHART_REPO>/rancher
-----
-+
-如需下载特定的 Rancher 版本，你可以用 Helm `--version` 参数指定版本，如下：
-+
-[,plain]
-----
-helm fetch rancher-stable/rancher --version=v2.4.8
+helm fetch rancher-prime/rancher --version=<version>
 ----
 
 === 2. 选择 SSL 配置

--- a/versions/v2.8/modules/zh/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
+++ b/versions/v2.8/modules/zh/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
@@ -66,6 +66,8 @@ kubectl rollout status deployment -n cert-manager cert-manager-webhook
 helm repo add rancher-prime <helm-chart-repo-url>
 ----
 
+include::shared:ROOT:partial$zh/helm-chart-repo-url.adoc[]
+
 创建命名空间：
 
 ----

--- a/versions/v2.8/modules/zh/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
+++ b/versions/v2.8/modules/zh/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
@@ -58,12 +58,12 @@ kubectl rollout status deployment -n cert-manager cert-manager
 kubectl rollout status deployment -n cert-manager cert-manager-webhook
 ----
 
-== 安装 Rancher
+== 安装 Rancher Prime
 
-接下来，你可以安装 Rancher 了。首先，添加 Helm 仓库：
+接下来，你可以安装 Rancher Prime 了。首先，添加 Helm 仓库：
 
 ----
-helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+helm repo add rancher-prime <helm-chart-repo-url>
 ----
 
 创建命名空间：
@@ -75,7 +75,7 @@ kubectl create namespace cattle-system
 然后使用 Helm 安装 Rancher：Rancher 也需要你配置代理，以便它可以与外部应用商店通信，或检索 Kubernetes 版本更新元数据：
 
 ----
-helm upgrade --install rancher rancher-latest/rancher \
+helm upgrade --install rancher rancher-prime/rancher \
    --namespace cattle-system \
    --set hostname=rancher.example.com \
    --set proxy=http://${proxy_host} \

--- a/versions/v2.8/modules/zh/pages/installation-and-upgrade/quick-start/deploy-rancher/helm-cli.adoc
+++ b/versions/v2.8/modules/zh/pages/installation-and-upgrade/quick-start/deploy-rancher/helm-cli.adoc
@@ -103,7 +103,11 @@ notepad.exe $env:USERPROFILE\.kube\config
 
 ----
 helm repo add rancher-prime <helm-chart-repo-url>
+----
 
+include::shared:ROOT:partial$zh/helm-chart-repo-url.adoc[]
+
+----
 kubectl create namespace cattle-system
 
 kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/<VERSION>/cert-manager.crds.yaml

--- a/versions/v2.8/modules/zh/pages/installation-and-upgrade/quick-start/deploy-rancher/helm-cli.adoc
+++ b/versions/v2.8/modules/zh/pages/installation-and-upgrade/quick-start/deploy-rancher/helm-cli.adoc
@@ -102,7 +102,7 @@ notepad.exe $env:USERPROFILE\.kube\config
 
 
 ----
-helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+helm repo add rancher-prime <helm-chart-repo-url>
 
 kubectl create namespace cattle-system
 
@@ -131,14 +131,14 @@ helm install cert-manager jetstack/cert-manager `
 请注意，密码至少需要 12 个字符。
 
 ----
-helm install rancher rancher-latest/rancher \
+helm install rancher rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=<IP_OF_LINUX_NODE>.sslip.io \
   --set replicas=1 \
   --set bootstrapPassword=<PASSWORD_FOR_RANCHER_ADMIN>
 
 # Windows Powershell
-helm install rancher rancher-latest/rancher `
+helm install rancher rancher-prime/rancher `
   --namespace cattle-system `
   --set hostname=<IP_OF_LINUX_NODE>.sslip.io `
   --set replicas=1 `

--- a/versions/v2.8/modules/zh/pages/installation-and-upgrade/resources/update-rancher-certificate.adoc
+++ b/versions/v2.8/modules/zh/pages/installation-and-upgrade/resources/update-rancher-certificate.adoc
@@ -121,10 +121,10 @@ privateCA: true
 +
 [,bash]
 ----
- helm upgrade rancher rancher-stable/rancher \
-  --namespace cattle-system \
-  -f values.yaml \
-  --version <DEPLOYED_RANCHER_VERSION>
+    helm upgrade rancher rancher-prime/rancher \
+     --namespace cattle-system \
+     -f values.yaml \
+     --version <DEPLOYED_RANCHER_VERSION>
 ----
 
 修改完成后，访问 `\https://<rancher_server_url>/v3/settings/cacerts`，验证该值是否与先前写入 `tls-ca` Secret 中的 CA 证书匹配。在所有 Rancher pod 启动之前，CA `cacerts` 值可能不会更新。
@@ -278,10 +278,10 @@ helm ls -n cattle-system
 +
 [,bash]
 ----
-  helm upgrade rancher rancher-stable/rancher \
---namespace cattle-system \
--f values.yaml \
---version <DEPLOYED_RANCHER_VERSION>
+helm upgrade rancher rancher-prime/rancher \
+  --namespace cattle-system \
+  -f values.yaml \
+  --version <DEPLOYED_RANCHER_VERSION>
 ----
 
 === 4. 为非私有/通用证书重新配置 Rancher Agent

--- a/versions/v2.8/modules/zh/pages/installation-and-upgrade/upgrades.adoc
+++ b/versions/v2.8/modules/zh/pages/installation-and-upgrade/upgrades.adoc
@@ -18,9 +18,7 @@ kubeconfig 也可以通过 `--kubeconfig` 标签（详情请参见 https://helm.
 
 === 查看已知问题
 
-如需查看每个 Rancher 版本的已知问题，请参见 https://github.com/rancher/rancher/releases[GitHub] 中的发行说明，或查看 https://forums.rancher.com/c/announcements/12[Rancher 论坛]。
-
-不支持 _升级_ 或 _升级到_ xref:#_helm_chart_仓库[rancher-alpha 仓库]中的任何 Chart。
+如需查看每个 Rancher 版本的已知问题，请参见 https://github\.com/rancher/rancher/releases\[GitHub\] 中的发行说明，或查看 https://forums\.rancher\.com/c/announcements/12\[Rancher 论坛\]。
 
 === Helm 版本
 
@@ -56,45 +54,14 @@ https://community.letsencrypt.org/t/blocking-old-cert-manager-versions/98753[从
 helm repo update
 ----
 
-. 获取你用来安装 Rancher 的仓库名称。
-+
-关于仓库及其区别，请参见 xref:#_helm_chart_仓库[Helm Chart 仓库]。
-
- ** Latest：建议用于试用最新功能
-+
-----
- helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
-----
-
- ** Stable：建议用于生产环境
-+
-----
- helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
-----
-
- ** Alpha：即将发布的实验性预览。
-+
-----
- helm repo add rancher-alpha https://releases.rancher.com/server-charts/alpha
-----
-+
-注意：不支持升级到 Alpha 版、从 Alpha 版升级或在 Alpha 版之间升级。
-
+. Get the repository name that you used to install Rancher.
 +
 ----
 helm repo list
 
 NAME          	       URL
-stable        	       https://charts.helm.sh/stable
-rancher-<CHART_REPO>	 https://releases.rancher.com/server-charts/<CHART_REPO>
+rancher-prime          <helm-chart-repo-url>
 ----
-+
-
-[NOTE]
-====
-如果你想切换到不同的 Helm Chart 仓库，请按照xref:#_切换到不同_helm_chart_仓库[切换仓库步骤]进行操作。如果你要切换仓库，请先再次列出仓库，再继续执行步骤 3，以确保添加了正确的仓库。
-====
-
 
 . 从 Helm Chart 仓库获取最新的 Chart 来安装 Rancher。
 +
@@ -102,14 +69,14 @@ rancher-<CHART_REPO>	 https://releases.rancher.com/server-charts/<CHART_REPO>
 +
 [,plain]
 ----
-helm fetch rancher-<CHART_REPO>/rancher
+helm fetch rancher-prime/rancher
 ----
 +
 你可以通过 `--version=` 标记，来指定要升级的目标 Chart 版本。例如：
 +
 [,plain]
 ----
-helm fetch rancher-<CHART_REPO>/rancher --version=2.6.8
+helm fetch rancher-prime/rancher --version=2.6.8
 ----
 
 === 3. 升级 Rancher
@@ -142,11 +109,11 @@ hostname: rancher.my.org
 [TIP]
 ====
 
-Deployment 的名称可能会有所不同。例如，如果你通过 AWS Marketplace 部署 Rancher，则 Deployment 的名称为"`rancher-stable`"。
+Deployment 的名称可能会有所不同。例如，如果你通过 AWS Marketplace 部署 Rancher，则 Deployment 的名称为"`rancher-prime`"。
 因此：
 
 ----
-helm get values rancher-stable -n cattle-system
+helm get values rancher-prime -n cattle-system
 
 hostname: rancher.my.org
 ----
@@ -164,7 +131,7 @@ hostname: rancher.my.org
 对于 Kubernetes v1.25 或更高版本，使用 Rancher v2.7.2-v2.7.4 时，将 `global.cattle.psp.enabled` 设置为 `false`。对于 Rancher v2.7.5 及更高版本来说，这不是必需的，但你仍然可以手动设置该选项。
 
 ----
-helm upgrade rancher rancher-<CHART_REPO>/rancher \
+helm upgrade rancher rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=rancher.my.org
 ----
@@ -179,11 +146,11 @@ helm upgrade rancher rancher-<CHART_REPO>/rancher \
 [TIP]
 ====
 
-如果你通过 AWS Marketplace 部署 Rancher，则 Deployment 的名称为"`rancher-stable`"。
+如果你通过 AWS Marketplace 部署 Rancher，则 Deployment 的名称为"`rancher-prime`"。
 因此：
 
 ----
-helm upgrade rancher-stable rancher-<CHART_REPO>/rancher \
+helm upgrade rancher-prime rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=rancher.my.org
 ----
@@ -203,7 +170,7 @@ helm get values rancher -n cattle-system -o yaml > values.yaml
 对于 Kubernetes v1.25 或更高版本，使用 Rancher v2.7.2-v2.7.4 时，将 `global.cattle.psp.enabled` 设置为 `false`。对于 Rancher v2.7.5 及更高版本来说，这不是必需的，但你仍然可以手动设置该选项。
 +
 ----
-helm upgrade rancher rancher-<CHART_REPO>/rancher \
+helm upgrade rancher rancher-prime/rancher \
   --namespace cattle-system \
   -f values.yaml \
   --version=2.6.8

--- a/versions/v2.8/modules/zh/pages/rancher-admin/back-up-restore-and-disaster-recovery/migrate-to-a-new-cluster.adoc
+++ b/versions/v2.8/modules/zh/pages/rancher-admin/back-up-restore-and-disaster-recovery/migrate-to-a-new-cluster.adoc
@@ -182,8 +182,9 @@ kubectl logs -n cattle-resources-system --tail 100 -f -l app.kubernetes.io/insta
 对于 Kubernetes v1.25 或更高版本，使用 Rancher v2.7.2-v2.7.4 时，将 `global.cattle.psp.enabled` 设置为 `false`。对于 Rancher v2.7.5 及更高版本来说，这不是必需的，但你仍然可以手动设置该选项。
 
 [,bash]
+[,bash]
 ----
-helm install rancher rancher-latest/rancher \
+helm install rancher rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=<same hostname as the server URL from the first Rancher server> \
   --version x.y.z
@@ -203,7 +204,14 @@ helm get values rancher -n cattle-system -o yaml > rancher-values.yaml
 
 [,bash]
 ----
-helm install rancher rancher-latest/rancher -n cattle-system -f rancher-values.yaml --version x.y.z
+helm install rancher rancher-prime/rancher -n cattle-system -f rancher-values.yaml --version x.y.z
 ----
 ====
+
+
+== 5. Redirect Traffic to the New Cluster
+
+After migration completes, update your DNS records and any load balancers, so that traffic is routed correctly to the migrated cluster. Remember that you must use the same hostname that was set as the server URL in the original cluster.
+
+Full instructions on how to redirect traffic to the migrated cluster differ based on your specific environment. Refer to your hosting provider's documentation for more details.
 

--- a/versions/v2.8/modules/zh/pages/rancher-admin/experimental-features/experimental-features.adoc
+++ b/versions/v2.8/modules/zh/pages/rancher-admin/experimental-features/experimental-features.adoc
@@ -37,19 +37,12 @@ Rancher 包含一些默认关闭的实验功能。在某些情况下，例如当
 对于 Kubernetes v1.25 或更高版本，使用 Rancher v2.7.2-v2.7.4 时，将 `global.cattle.psp.enabled` 设置为 `false`。对于 Rancher v2.7.5 及更高版本来说，这不是必需的，但你仍然可以手动设置该选项。
 
 ----
-helm install rancher rancher-latest/rancher \
+helm install rancher rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=rancher.my.org \
   --set 'extraEnv[0].name=CATTLE_FEATURES'
   --set 'extraEnv[0].value=<FEATURE-FLAG-NAME-1>=true,<FEATURE-FLAG-NAME-2>=true'
 ----
-
-[NOTE]
-====
-
-如果你安装的是 alpha 版本，Helm 要求你在命令中添加 `--devel` 选项。
-====
-
 
 === 离线安装的情况下渲染 Helm Chart
 

--- a/versions/v2.8/modules/zh/pages/security/rancher-webhook/rancher-webhook.adoc
+++ b/versions/v2.8/modules/zh/pages/security/rancher-webhook/rancher-webhook.adoc
@@ -141,7 +141,7 @@ Rancher 会在检测到对 ConfigMap 值的更改时重新部署 Rancher-Webhook
 
 [,bash]
 ----
-helm install rancher rancher-<CHART_REPO>/rancher \
+helm install rancher rancher-prime/rancher \
   --namespace cattle-system \
   ...
   --set webhook.port=9553 \

--- a/versions/v2.9/modules/en/pages/installation-and-upgrade/install-rancher.adoc
+++ b/versions/v2.9/modules/en/pages/installation-and-upgrade/install-rancher.adoc
@@ -77,6 +77,8 @@ Use the `helm repo add` command to add the Helm chart repository that contains c
 helm repo add rancher-prime <helm-chart-repo-url>
 ----
 
+include::shared:ROOT:partial$en/helm-chart-repo-url.adoc[]
+
 === 2. Create a Namespace for Rancher
 
 We'll need to define a Kubernetes namespace where the resources created by the Chart should be installed. This should always be `cattle-system`:

--- a/versions/v2.9/modules/en/pages/installation-and-upgrade/install-rancher.adoc
+++ b/versions/v2.9/modules/en/pages/installation-and-upgrade/install-rancher.adoc
@@ -70,27 +70,12 @@ To set up Rancher,
 
 === 1. Add the Helm Chart Repository
 
-Use `helm repo add` command to add the Helm chart repository that contains charts to install Rancher. For more information about the repository choices and which is best for your use case, see xref:[Choosing a Rancher Version].
+Use the `helm repo add` command to add the Helm chart repository that contains charts to install Rancher Prime.
 
-* Latest: Recommended for trying out the newest features
-+
+[,shell]
 ----
-  helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+helm repo add rancher-prime <helm-chart-repo-url>
 ----
-
-* Stable: Recommended for production environments
-+
-----
-  helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
-----
-
-* Alpha: Experimental preview of upcoming releases.
-+
-----
-  helm repo add rancher-alpha https://releases.rancher.com/server-charts/alpha
-----
-+
-NOTE: Upgrades are not supported to, from, or between Alphas.
 
 === 2. Create a Namespace for Rancher
 
@@ -227,12 +212,6 @@ helm install rancher rancher-prime/rancher \
   --set bootstrapPassword=admin
 ----
 
-If you are installing an alpha version, Helm requires adding the `--devel` option to the install command:
-
-----
-helm install rancher rancher-alpha/rancher --devel
-----
-
 Wait for Rancher to be rolled out:
 
 ----
@@ -280,12 +259,6 @@ helm install rancher rancher-prime/rancher \
   --set letsEncrypt.ingress.class=nginx
 ----
 
-If you are installing an alpha version, Helm requires adding the `--devel` option to the install command:
-
-----
-helm install rancher rancher-alpha/rancher --devel
-----
-
 Wait for Rancher to be rolled out:
 
 ----
@@ -322,12 +295,6 @@ helm install rancher rancher-prime/rancher \
   --set hostname=rancher.my.org \
   --set bootstrapPassword=admin \
   --set ingress.tls.source=secret
-----
-
-If you are installing an alpha version, Helm requires adding the `--devel` option to the install command:
-
-----
-helm install rancher rancher-alpha/rancher --devel
 ----
 
 If you are using a Private CA signed certificate , add `--set privateCA=true` to the command:

--- a/versions/v2.9/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
+++ b/versions/v2.9/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -25,6 +25,8 @@ From a system that has access to the internet, fetch the latest Helm chart and c
 ----
 helm repo add rancher-prime <helm-chart-repo-url>
 ----
++
+include::shared:ROOT:partial$en/helm-chart-repo-url.adoc[]
 
 . Fetch the Rancher Prime chart. This will pull down the chart and save it in the current directory as a `.tgz` file.
 ** To fetch the latest version:

--- a/versions/v2.9/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
+++ b/versions/v2.9/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -19,38 +19,34 @@ Rancher recommends installing Rancher on a Kubernetes cluster. A highly availabl
 From a system that has access to the internet, fetch the latest Helm chart and copy the resulting manifests to a system that has access to the Rancher server cluster.
 
 . If you haven't already, install `helm` locally on a workstation that has internet access. Note: Refer to the xref:installation-and-upgrade/requirements/helm-version-requirements.adoc[Helm version requirements] to choose a version of Helm to install Rancher.
-. Use `helm repo add` command to add the Helm chart repository that contains charts to install Rancher. For more information about the repository choices and which is best for your use case, see xref:[Choosing a Rancher Version].
- ** Latest: Recommended for trying out the newest features
+. Use the `helm repo add` command to add the Helm chart repository that contains charts to install Rancher Prime.
 +
+[,shell]
 ----
-  helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+helm repo add rancher-prime <helm-chart-repo-url>
 ----
 
- ** Stable: Recommended for production environments
+. Fetch the Rancher Prime chart. This will pull down the chart and save it in the current directory as a `.tgz` file.
+** To fetch the latest version:
 +
+[,shell]
 ----
-  helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
+helm fetch rancher-prime/rancher
 ----
-
- ** Alpha: Experimental preview of upcoming releases.
+** To fetch a specific version:
 +
-----
-  helm repo add rancher-alpha https://releases.rancher.com/server-charts/alpha
-----
+Check to see which version of Rancher Prime are available.
 +
-NOTE: Upgrades are not supported to, from, or between Alphas.
-. Fetch the latest Rancher chart. This will pull down the chart and save it in the current directory as a `.tgz` file.
-+
-[,plain]
+[,shell]
 ----
- helm fetch rancher-prime/rancher
+helm search repo --versions rancher-prime
 ----
 +
-If you require a specific version of Rancher, you can fetch this with the Helm `--version` parameter like in the following example:
+Fetch a specific version by specifying the `--version` parameter:
 +
-[,plain]
+[,shell]
 ----
- helm fetch rancher-stable/rancher --version=v2.4.8
+helm fetch rancher-prime/rancher --version=<version>
 ----
 
 === 2. Choose your SSL Configuration

--- a/versions/v2.9/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
+++ b/versions/v2.9/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
@@ -58,12 +58,12 @@ kubectl rollout status deployment -n cert-manager cert-manager
 kubectl rollout status deployment -n cert-manager cert-manager-webhook
 ----
 
-== Install Rancher
+== Install Rancher Prime
 
-Next you can install Rancher itself. First, add the Helm repository:
+Next you can install Rancher Prime itself. First, add the Helm repository:
 
 ----
-helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+helm repo add rancher-prime <helm-chart-repo-url>
 ----
 
 Create a namespace:
@@ -75,7 +75,7 @@ kubectl create namespace cattle-system
 And install Rancher with Helm. Rancher also needs a proxy configuration so that it can communicate with external application catalogs or retrieve Kubernetes version update metadata:
 
 ----
-helm upgrade --install rancher rancher-latest/rancher \
+helm upgrade --install rancher rancher-prime/rancher \
    --namespace cattle-system \
    --set hostname=rancher.example.com \
    --set proxy=http://${proxy_host} \

--- a/versions/v2.9/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
+++ b/versions/v2.9/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
@@ -66,6 +66,8 @@ Next you can install Rancher Prime itself. First, add the Helm repository:
 helm repo add rancher-prime <helm-chart-repo-url>
 ----
 
+include::shared:ROOT:partial$en/helm-chart-repo-url.adoc[]
+
 Create a namespace:
 
 ----

--- a/versions/v2.9/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/helm-cli.adoc
+++ b/versions/v2.9/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/helm-cli.adoc
@@ -102,7 +102,7 @@ To see options on how to customize the cert-manager install (including for cases
 
 
 ----
-helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+helm repo add rancher-prime <helm-chart-repo-url>
 
 kubectl create namespace cattle-system
 
@@ -131,14 +131,14 @@ For Kubernetes v1.25 or later, set `global.cattle.psp.enabled` to `false` when u
 See xref:../../installation-and-upgrade/resources/bootstrap-password.adoc#_password_requirements[Setting up the Bootstrap Password] for password requirements.
 
 ----
-helm install rancher rancher-latest/rancher \
+helm install rancher rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=<IP_OF_LINUX_NODE>.sslip.io \
   --set replicas=1 \
   --set bootstrapPassword=<PASSWORD_FOR_RANCHER_ADMIN>
 
 # Windows Powershell
-helm install rancher rancher-latest/rancher `
+helm install rancher rancher-prime/rancher `
   --namespace cattle-system `
   --set hostname=<IP_OF_LINUX_NODE>.sslip.io `
   --set replicas=1 `

--- a/versions/v2.9/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/helm-cli.adoc
+++ b/versions/v2.9/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/helm-cli.adoc
@@ -103,7 +103,11 @@ To see options on how to customize the cert-manager install (including for cases
 
 ----
 helm repo add rancher-prime <helm-chart-repo-url>
+----
 
+include::shared:ROOT:partial$en/helm-chart-repo-url.adoc[]
+
+----
 kubectl create namespace cattle-system
 
 kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/<VERSION>/cert-manager.crds.yaml

--- a/versions/v2.9/modules/en/pages/installation-and-upgrade/resources/update-rancher-certificate.adoc
+++ b/versions/v2.9/modules/en/pages/installation-and-upgrade/resources/update-rancher-certificate.adoc
@@ -89,24 +89,24 @@ The below steps update the Helm values for the Rancher chart, so the Rancher pod
 +
 [,bash]
 ----
-   helm get values rancher -n cattle-system -o yaml > values.yaml
+helm get values rancher -n cattle-system -o yaml > values.yaml
 ----
 
 . Retrieve the version string of the currently deployed Rancher chart to use below:
 +
 [,bash]
 ----
-   helm ls -n cattle-system
+helm ls -n cattle-system
 ----
 
 . Update the current Helm values in the `values.yaml` file to contain:
 +
 [,yaml]
 ----
-   ingress:
-     tls:
- source: secret
-   privateCA: true
+ingress:
+  tls:
+    source: secret
+privateCA: true
 ----
 +
 
@@ -261,14 +261,14 @@ The below steps update the Helm values for the Rancher chart, so the Rancher pod
 +
 [,bash]
 ----
-   helm get values rancher -n cattle-system -o yaml > values.yaml
+helm get values rancher -n cattle-system -o yaml > values.yaml
 ----
 
 . Also get the version string of the currently deployed Rancher chart:
 +
 [,bash]
 ----
-   helm ls -n cattle-system
+helm ls -n cattle-system
 ----
 
 . Update the current Helm values in the `values.yaml` file:
@@ -280,10 +280,10 @@ The below steps update the Helm values for the Rancher chart, so the Rancher pod
 +
 [,bash]
 ----
-    helm upgrade rancher rancher-prime/rancher \
---namespace cattle-system \
--f values.yaml \
---version <DEPLOYED_RANCHER_VERSION>
+helm upgrade rancher rancher-prime/rancher \
+  --namespace cattle-system \
+  -f values.yaml \
+  --version <DEPLOYED_RANCHER_VERSION>
 ----
 
 === 4. Reconfigure Rancher agents for the non-private/common certificate

--- a/versions/v2.9/modules/en/pages/installation-and-upgrade/resources/update-rancher-certificate.adoc
+++ b/versions/v2.9/modules/en/pages/installation-and-upgrade/resources/update-rancher-certificate.adoc
@@ -121,7 +121,7 @@ The below steps update the Helm values for the Rancher chart, so the Rancher pod
 +
 [,bash]
 ----
-    helm upgrade rancher rancher-stable/rancher \
+    helm upgrade rancher rancher-prime/rancher \
      --namespace cattle-system \
      -f values.yaml \
      --version <DEPLOYED_RANCHER_VERSION>
@@ -280,7 +280,7 @@ The below steps update the Helm values for the Rancher chart, so the Rancher pod
 +
 [,bash]
 ----
-    helm upgrade rancher rancher-stable/rancher \
+    helm upgrade rancher rancher-prime/rancher \
 --namespace cattle-system \
 -f values.yaml \
 --version <DEPLOYED_RANCHER_VERSION>

--- a/versions/v2.9/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
+++ b/versions/v2.9/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
@@ -95,7 +95,7 @@ If you are running Kubernetes v1.15 or below, you will need to add the `--valida
 +
 [,plain]
 ----
- helm repo update
+helm repo update
 ----
 
 . Install the new version of cert-manager

--- a/versions/v2.9/modules/en/pages/installation-and-upgrade/upgrades.adoc
+++ b/versions/v2.9/modules/en/pages/installation-and-upgrade/upgrades.adoc
@@ -51,17 +51,16 @@ You'll use the backup as a restore point if something goes wrong during upgrade.
 . Update your local Helm repo cache.
 +
 ----
- helm repo update
+helm repo update
 ----
 
 . Get the repository name that you used to install Rancher.
 +
 ----
- helm repo list
+helm repo list
 
- NAME          	       URL
- rancher-prime         <URL>
- rancher-<CHART_REPO>	 https://releases.rancher.com/server-charts/<CHART_REPO>
+NAME          	       URL
+rancher-prime          <helm-chart-repo-url>
 ----
 
 . Fetch the latest chart to install Rancher from the Helm chart repository.
@@ -110,11 +109,11 @@ There will be more values that are listed with this command. This is just an exa
 [TIP]
 ====
 
-Your deployment name may vary; for example, if you're deploying Rancher through the AWS Marketplace, the deployment name is 'rancher-stable'.
+Your deployment name may vary; for example, if you're deploying Rancher through the AWS Marketplace, the deployment name is 'rancher-prime'.
 Thus:
 
 ----
-helm get values rancher-stable -n cattle-system
+helm get values rancher-prime -n cattle-system
 
 hostname: rancher.my.org
 ----
@@ -147,11 +146,11 @@ The above is an example, there may be more values from the previous step that ne
 [TIP]
 ====
 
-If you deploy Rancher through the AWS Marketplace, the deployment name is 'rancher-stable'.
+If you deploy Rancher through the AWS Marketplace, the deployment name is 'rancher-prime'.
 Thus:
 
 ----
-helm upgrade rancher-stable rancher-prime/rancher \
+helm upgrade rancher-prime rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=rancher.my.org
 ----

--- a/versions/v2.9/modules/en/pages/rancher-admin/back-up-restore-and-disaster-recovery/migrate-to-a-new-cluster.adoc
+++ b/versions/v2.9/modules/en/pages/rancher-admin/back-up-restore-and-disaster-recovery/migrate-to-a-new-cluster.adoc
@@ -165,7 +165,7 @@ For Kubernetes v1.25 or later, set `global.cattle.psp.enabled` to `false` when u
 
 [,bash]
 ----
-helm install rancher rancher-latest/rancher \
+helm install rancher rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=<same hostname as the server URL from the first Rancher server> \
   --version x.y.z
@@ -185,7 +185,7 @@ These values can be reused using the `rancher-values.yaml` file. Be sure to swit
 
 [,bash]
 ----
-helm install rancher rancher-latest/rancher -n cattle-system -f rancher-values.yaml --version x.y.z
+helm install rancher rancher-prime/rancher -n cattle-system -f rancher-values.yaml --version x.y.z
 ----
 ====
 

--- a/versions/v2.9/modules/en/pages/rancher-admin/experimental-features/experimental-features.adoc
+++ b/versions/v2.9/modules/en/pages/rancher-admin/experimental-features/experimental-features.adoc
@@ -37,19 +37,12 @@ When installing Rancher with a Helm chart, use the `--set` option. In the below 
 For Kubernetes v1.25 or later, set `global.cattle.psp.enabled` to `false` when using Rancher v2.7.2-v2.7.4. This is not necessary for Rancher v2.7.5 and above, but you can still manually set the option if you choose.
 
 ----
-helm install rancher rancher-latest/rancher \
+helm install rancher rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=rancher.my.org \
   --set 'extraEnv[0].name=CATTLE_FEATURES'
   --set 'extraEnv[0].value=<FEATURE-FLAG-NAME-1>=true,<FEATURE-FLAG-NAME-2>=true'
 ----
-
-[NOTE]
-====
-
-If you are installing an alpha version, Helm requires adding the `--devel` option to the command.
-====
-
 
 === Enabling Features for Air Gap Installs
 

--- a/versions/v2.9/modules/zh/pages/installation-and-upgrade/install-rancher.adoc
+++ b/versions/v2.9/modules/zh/pages/installation-and-upgrade/install-rancher.adoc
@@ -70,27 +70,12 @@ Rancher 是使用 Kubernetes 的 https://helm.sh/[Helm] 包管理器安装的。
 
 === 1. 添加 Helm Chart 仓库
 
-执行 `helm repo add` 命令，以添加包含安装 Rancher 的 Chart 的 Helm Chart 仓库。有关如何选择仓库，以及哪个仓库最适合你的用例，请参见xref:[选择 Rancher 版本]。
+执行 `helm repo add` 命令，以添加包含安装 Rancher Prime 的 Chart 的 Helm Chart 仓库。
 
-* Latest：建议用于试用最新功能
-+
+[,shell]
 ----
- helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+helm repo add rancher-prime <helm-chart-repo-url>
 ----
-
-* Stable：建议用于生产环境
-+
-----
- helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
-----
-
-* Alpha：即将发布的实验性预览。
-+
-----
- helm repo add rancher-alpha https://releases.rancher.com/server-charts/alpha
-----
-+
-注意：不支持升级到 Alpha 版、从 Alpha 版升级或在 Alpha 版之间升级。
 
 === 2. 为 Rancher 创建命名空间
 
@@ -220,18 +205,11 @@ Rancher 生成的证书::
 * 对于 Kubernetes v1.25 或更高版本，使用 Rancher v2.7.2-v2.7.4 时，将 `global.cattle.psp.enabled` 设置为 `false`。对于 Rancher v2.7.5 及更高版本来说，这不是必需的，但你仍然可以手动设置该选项。
 
 ----
-helm install rancher rancher-<CHART_REPO>/rancher \
+helm install rancher rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=rancher.my.org \
   --set bootstrapPassword=admin
 ----
-
-如果你安装的是 alpha 版本，Helm 会要求你在安装命令中添加 `--devel` 选项：
-
-----
-helm install rancher rancher-alpha/rancher --devel
-----
-
 等待 Rancher 运行：
 
 ----
@@ -262,19 +240,13 @@ Let's Encrypt::
 * 对于 Kubernetes v1.25 或更高版本，使用 Rancher v2.7.2-v2.7.4 时，将 `global.cattle.psp.enabled` 设置为 `false`。对于 Rancher v2.7.5 及更高版本来说，这不是必需的，但你仍然可以手动设置该选项。
 
 ----
-helm install rancher rancher-<CHART_REPO>/rancher \
+helm install rancher rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=rancher.my.org \
   --set bootstrapPassword=admin \
   --set ingress.tls.source=letsEncrypt \
   --set letsEncrypt.email=me@example.org \
   --set letsEncrypt.ingress.class=nginx
-----
-
-如果你安装的是 alpha 版本，Helm 会要求你在安装命令中添加 `--devel` 选项：
-
-----
-helm install rancher rancher-alpha/rancher --devel
 ----
 
 等待 Rancher 运行：
@@ -308,23 +280,17 @@ deployment "rancher" successfully rolled out
 * 对于 Kubernetes v1.25 或更高版本，使用 Rancher v2.7.2-v2.7.4 时，将 `global.cattle.psp.enabled` 设置为 `false`。对于 Rancher v2.7.5 及更高版本来说，这不是必需的，但你仍然可以手动设置该选项。
 
 ----
-helm install rancher rancher-<CHART_REPO>/rancher \
+helm install rancher rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=rancher.my.org \
   --set bootstrapPassword=admin \
   --set ingress.tls.source=secret
 ----
 
-如果你安装的是 alpha 版本，Helm 会要求你在安装命令中添加 `--devel` 选项：
-
-----
-helm install rancher rancher-alpha/rancher --devel
-----
-
 如果你使用的是私有 CA 证书，请在命令中增加 `--set privateCA=true`。
 
 ----
-helm install rancher rancher-<CHART_REPO>/rancher \
+helm install rancher rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=rancher.my.org \
   --set bootstrapPassword=admin \

--- a/versions/v2.9/modules/zh/pages/installation-and-upgrade/install-rancher.adoc
+++ b/versions/v2.9/modules/zh/pages/installation-and-upgrade/install-rancher.adoc
@@ -77,6 +77,8 @@ Rancher 是使用 Kubernetes 的 https://helm.sh/[Helm] 包管理器安装的。
 helm repo add rancher-prime <helm-chart-repo-url>
 ----
 
+include::shared:ROOT:partial$zh/helm-chart-repo-url.adoc[]
+
 === 2. 为 Rancher 创建命名空间
 
 你需要定义一个 Kubernetes 命名空间，用于安装由 Chart 创建的资源。这个命名空间的名称为 `cattle-system`：

--- a/versions/v2.9/modules/zh/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
+++ b/versions/v2.9/modules/zh/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -26,6 +26,8 @@
 helm repo add rancher-prime <helm-chart-repo-url>
 ----
 
+include::shared:ROOT:partial$zh/helm-chart-repo-url.adoc[]
+
 . 获取的 Rancher Chart。此操作将获取 Chart 并将其作为 `.tgz` 文件保存在当前目录中。
 
 ** 如需下载最新的 Rancher Prime 版本:

--- a/versions/v2.9/modules/zh/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
+++ b/versions/v2.9/modules/zh/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -19,38 +19,35 @@
 从可以访问互联网的系统中，获取最新的 Helm Chart，然后将 manifest 复制到可访问 Rancher Server 集群的系统中。
 
 . 如果你还没有安装 `helm`，请在可访问互联网的工作站上进行本地安装。注意：参考 xref:installation-and-upgrade/requirements/helm-version-requirements.adoc[Helm 版本要求]选择 Helm 版本来安装 Rancher。
-. 执行 `helm repo add` 命令，以添加包含安装 Rancher 的 Chart 的 Helm Chart 仓库。有关如何选择仓库，以及哪个仓库最适合你的用例，请参见xref:[选择 Rancher 版本]。
- ** Latest：建议用于试用最新功能
-+
+. 执行 `helm repo add` 命令，以添加包含安装 Rancher Prime 的 Chart 的 Helm Chart 仓库。
+ +
+[,shell]
 ----
- helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
-----
-
- ** Stable：建议用于生产环境
-+
-----
- helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
+helm repo add rancher-prime <helm-chart-repo-url>
 ----
 
- ** Alpha：即将发布的实验性预览。
+. 获取的 Rancher Chart。此操作将获取 Chart 并将其作为 `.tgz` 文件保存在当前目录中。
+
+** 如需下载最新的 Rancher Prime 版本:
 +
+[,shell]
 ----
- helm repo add rancher-alpha https://releases.rancher.com/server-charts/alpha
+helm fetch rancher-prime/rancher
+----
+** To fetch a specific version:
++
+Check to see which version of Rancher Prime are available.
++
+[,shell]
+----
+helm search repo --versions rancher-prime
 ----
 +
-注意：不支持升级到 Alpha 版、从 Alpha 版升级或在 Alpha 版之间升级。
-. 获取最新的 Rancher Chart。此操作将获取 Chart 并将其作为 `.tgz` 文件保存在当前目录中。
+如需下载特定的 Rancher Prime 版本，你可以用 Helm `--version` 参数指定版本，如下：
 +
-[,plain]
+[,shell]
 ----
-helm fetch rancher-<CHART_REPO>/rancher
-----
-+
-如需下载特定的 Rancher 版本，你可以用 Helm `--version` 参数指定版本，如下：
-+
-[,plain]
-----
-helm fetch rancher-stable/rancher --version=v2.4.8
+helm fetch rancher-prime/rancher --version=<version>
 ----
 
 === 2. 选择 SSL 配置

--- a/versions/v2.9/modules/zh/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
+++ b/versions/v2.9/modules/zh/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
@@ -59,12 +59,12 @@ kubectl rollout status deployment -n cert-manager cert-manager
 kubectl rollout status deployment -n cert-manager cert-manager-webhook
 ----
 
-== 安装 Rancher
+== 安装 Rancher Prime
 
-接下来，你可以安装 Rancher 了。首先，添加 Helm 仓库：
+接下来，你可以安装 Rancher Prime 了。首先，添加 Helm 仓库：
 
 ----
-helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+helm repo add rancher-prime <helm-chart-repo-url>
 ----
 
 创建命名空间：
@@ -76,7 +76,7 @@ kubectl create namespace cattle-system
 然后使用 Helm 安装 Rancher：Rancher 也需要你配置代理，以便它可以与外部应用商店通信，或检索 Kubernetes 版本更新元数据：
 
 ----
-helm upgrade --install rancher rancher-latest/rancher \
+helm upgrade --install rancher rancher-prime/rancher \
    --namespace cattle-system \
    --set hostname=rancher.example.com \
    --set proxy=http://${proxy_host} \

--- a/versions/v2.9/modules/zh/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
+++ b/versions/v2.9/modules/zh/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
@@ -67,6 +67,8 @@ kubectl rollout status deployment -n cert-manager cert-manager-webhook
 helm repo add rancher-prime <helm-chart-repo-url>
 ----
 
+include::shared:ROOT:partial$zh/helm-chart-repo-url.adoc[]
+
 创建命名空间：
 
 ----

--- a/versions/v2.9/modules/zh/pages/installation-and-upgrade/quick-start/deploy-rancher/helm-cli.adoc
+++ b/versions/v2.9/modules/zh/pages/installation-and-upgrade/quick-start/deploy-rancher/helm-cli.adoc
@@ -103,7 +103,11 @@ notepad.exe $env:USERPROFILE\.kube\config
 
 ----
 helm repo add rancher-prime <helm-chart-repo-url>
+----
 
+include::shared:ROOT:partial$zh/helm-chart-repo-url.adoc[]
+
+----
 kubectl create namespace cattle-system
 
 kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/<VERSION>/cert-manager.crds.yaml

--- a/versions/v2.9/modules/zh/pages/installation-and-upgrade/quick-start/deploy-rancher/helm-cli.adoc
+++ b/versions/v2.9/modules/zh/pages/installation-and-upgrade/quick-start/deploy-rancher/helm-cli.adoc
@@ -102,7 +102,7 @@ notepad.exe $env:USERPROFILE\.kube\config
 
 
 ----
-helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+helm repo add rancher-prime <helm-chart-repo-url>
 
 kubectl create namespace cattle-system
 
@@ -131,14 +131,14 @@ helm install cert-manager jetstack/cert-manager `
 请注意，密码至少需要 12 个字符。
 
 ----
-helm install rancher rancher-latest/rancher \
+helm install rancher rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=<IP_OF_LINUX_NODE>.sslip.io \
   --set replicas=1 \
   --set bootstrapPassword=<PASSWORD_FOR_RANCHER_ADMIN>
 
 # Windows Powershell
-helm install rancher rancher-latest/rancher `
+helm install rancher rancher-prime/rancher `
   --namespace cattle-system `
   --set hostname=<IP_OF_LINUX_NODE>.sslip.io `
   --set replicas=1 `

--- a/versions/v2.9/modules/zh/pages/installation-and-upgrade/resources/update-rancher-certificate.adoc
+++ b/versions/v2.9/modules/zh/pages/installation-and-upgrade/resources/update-rancher-certificate.adoc
@@ -121,10 +121,10 @@ privateCA: true
 +
 [,bash]
 ----
- helm upgrade rancher rancher-stable/rancher \
-  --namespace cattle-system \
-  -f values.yaml \
-  --version <DEPLOYED_RANCHER_VERSION>
+    helm upgrade rancher rancher-prime/rancher \
+     --namespace cattle-system \
+     -f values.yaml \
+     --version <DEPLOYED_RANCHER_VERSION>
 ----
 
 修改完成后，访问 `\https://<rancher_server_url>/v3/settings/cacerts`，验证该值是否与先前写入 `tls-ca` Secret 中的 CA 证书匹配。在所有 Rancher pod 启动之前，CA `cacerts` 值可能不会更新。
@@ -278,10 +278,10 @@ helm ls -n cattle-system
 +
 [,bash]
 ----
-  helm upgrade rancher rancher-stable/rancher \
---namespace cattle-system \
--f values.yaml \
---version <DEPLOYED_RANCHER_VERSION>
+helm upgrade rancher rancher-prime/rancher \
+  --namespace cattle-system \
+  -f values.yaml \
+  --version <DEPLOYED_RANCHER_VERSION>
 ----
 
 === 4. 为非私有/通用证书重新配置 Rancher Agent

--- a/versions/v2.9/modules/zh/pages/installation-and-upgrade/upgrades.adoc
+++ b/versions/v2.9/modules/zh/pages/installation-and-upgrade/upgrades.adoc
@@ -18,9 +18,7 @@ kubeconfig 也可以通过 `--kubeconfig` 标签（详情请参见 https://helm.
 
 === 查看已知问题
 
-如需查看每个 Rancher 版本的已知问题，请参见 https://github.com/rancher/rancher/releases[GitHub] 中的发行说明，或查看 https://forums.rancher.com/c/announcements/12[Rancher 论坛]。
-
-不支持 _升级_ 或 _升级到_ xref:#_helm_chart_仓库[rancher-alpha 仓库]中的任何 Chart。
+如需查看每个 Rancher 版本的已知问题，请参见 https://github\.com/rancher/rancher/releases\[GitHub\] 中的发行说明，或查看 https://forums\.rancher\.com/c/announcements/12\[Rancher 论坛\]。
 
 === Helm 版本
 
@@ -56,45 +54,14 @@ https://community.letsencrypt.org/t/blocking-old-cert-manager-versions/98753[从
 helm repo update
 ----
 
-. 获取你用来安装 Rancher 的仓库名称。
-+
-关于仓库及其区别，请参见 xref:#_helm_chart_仓库[Helm Chart 仓库]。
-
- ** Latest：建议用于试用最新功能
-+
-----
- helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
-----
-
- ** Stable：建议用于生产环境
-+
-----
- helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
-----
-
- ** Alpha：即将发布的实验性预览。
-+
-----
- helm repo add rancher-alpha https://releases.rancher.com/server-charts/alpha
-----
-+
-注意：不支持升级到 Alpha 版、从 Alpha 版升级或在 Alpha 版之间升级。
-
+. Get the repository name that you used to install Rancher.
 +
 ----
 helm repo list
 
 NAME          	       URL
-stable        	       https://charts.helm.sh/stable
-rancher-<CHART_REPO>	 https://releases.rancher.com/server-charts/<CHART_REPO>
+rancher-prime          <helm-chart-repo-url>
 ----
-+
-
-[NOTE]
-====
-如果你想切换到不同的 Helm Chart 仓库，请按照xref:#_切换到不同_helm_chart_仓库[切换仓库步骤]进行操作。如果你要切换仓库，请先再次列出仓库，再继续执行步骤 3，以确保添加了正确的仓库。
-====
-
 
 . 从 Helm Chart 仓库获取最新的 Chart 来安装 Rancher。
 +
@@ -102,14 +69,14 @@ rancher-<CHART_REPO>	 https://releases.rancher.com/server-charts/<CHART_REPO>
 +
 [,plain]
 ----
-helm fetch rancher-<CHART_REPO>/rancher
+helm fetch rancher-prime/rancher
 ----
 +
 你可以通过 `--version=` 标记，来指定要升级的目标 Chart 版本。例如：
 +
 [,plain]
 ----
-helm fetch rancher-<CHART_REPO>/rancher --version=2.6.8
+helm fetch rancher-prime/rancher --version=2.6.8
 ----
 
 === 3. 升级 Rancher
@@ -142,11 +109,11 @@ hostname: rancher.my.org
 [TIP]
 ====
 
-Deployment 的名称可能会有所不同。例如，如果你通过 AWS Marketplace 部署 Rancher，则 Deployment 的名称为"`rancher-stable`"。
+Deployment 的名称可能会有所不同。例如，如果你通过 AWS Marketplace 部署 Rancher，则 Deployment 的名称为"`rancher-prime`"。
 因此：
 
 ----
-helm get values rancher-stable -n cattle-system
+helm get values rancher-prime -n cattle-system
 
 hostname: rancher.my.org
 ----
@@ -164,7 +131,7 @@ hostname: rancher.my.org
 对于 Kubernetes v1.25 或更高版本，使用 Rancher v2.7.2-v2.7.4 时，将 `global.cattle.psp.enabled` 设置为 `false`。对于 Rancher v2.7.5 及更高版本来说，这不是必需的，但你仍然可以手动设置该选项。
 
 ----
-helm upgrade rancher rancher-<CHART_REPO>/rancher \
+helm upgrade rancher rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=rancher.my.org
 ----
@@ -179,11 +146,11 @@ helm upgrade rancher rancher-<CHART_REPO>/rancher \
 [TIP]
 ====
 
-如果你通过 AWS Marketplace 部署 Rancher，则 Deployment 的名称为"`rancher-stable`"。
+如果你通过 AWS Marketplace 部署 Rancher，则 Deployment 的名称为"`rancher-prime`"。
 因此：
 
 ----
-helm upgrade rancher-stable rancher-<CHART_REPO>/rancher \
+helm upgrade rancher-prime rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=rancher.my.org
 ----
@@ -203,7 +170,7 @@ helm get values rancher -n cattle-system -o yaml > values.yaml
 对于 Kubernetes v1.25 或更高版本，使用 Rancher v2.7.2-v2.7.4 时，将 `global.cattle.psp.enabled` 设置为 `false`。对于 Rancher v2.7.5 及更高版本来说，这不是必需的，但你仍然可以手动设置该选项。
 +
 ----
-helm upgrade rancher rancher-<CHART_REPO>/rancher \
+helm upgrade rancher rancher-prime/rancher \
   --namespace cattle-system \
   -f values.yaml \
   --version=2.6.8

--- a/versions/v2.9/modules/zh/pages/rancher-admin/back-up-restore-and-disaster-recovery/migrate-to-a-new-cluster.adoc
+++ b/versions/v2.9/modules/zh/pages/rancher-admin/back-up-restore-and-disaster-recovery/migrate-to-a-new-cluster.adoc
@@ -182,8 +182,9 @@ kubectl logs -n cattle-resources-system --tail 100 -f -l app.kubernetes.io/insta
 对于 Kubernetes v1.25 或更高版本，使用 Rancher v2.7.2-v2.7.4 时，将 `global.cattle.psp.enabled` 设置为 `false`。对于 Rancher v2.7.5 及更高版本来说，这不是必需的，但你仍然可以手动设置该选项。
 
 [,bash]
+[,bash]
 ----
-helm install rancher rancher-latest/rancher \
+helm install rancher rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=<same hostname as the server URL from the first Rancher server> \
   --version x.y.z
@@ -203,7 +204,14 @@ helm get values rancher -n cattle-system -o yaml > rancher-values.yaml
 
 [,bash]
 ----
-helm install rancher rancher-latest/rancher -n cattle-system -f rancher-values.yaml --version x.y.z
+helm install rancher rancher-prime/rancher -n cattle-system -f rancher-values.yaml --version x.y.z
 ----
 ====
+
+
+== 5. Redirect Traffic to the New Cluster
+
+After migration completes, update your DNS records and any load balancers, so that traffic is routed correctly to the migrated cluster. Remember that you must use the same hostname that was set as the server URL in the original cluster.
+
+Full instructions on how to redirect traffic to the migrated cluster differ based on your specific environment. Refer to your hosting provider's documentation for more details.
 

--- a/versions/v2.9/modules/zh/pages/rancher-admin/experimental-features/experimental-features.adoc
+++ b/versions/v2.9/modules/zh/pages/rancher-admin/experimental-features/experimental-features.adoc
@@ -37,19 +37,12 @@ Rancher 包含一些默认关闭的实验功能。在某些情况下，例如当
 对于 Kubernetes v1.25 或更高版本，使用 Rancher v2.7.2-v2.7.4 时，将 `global.cattle.psp.enabled` 设置为 `false`。对于 Rancher v2.7.5 及更高版本来说，这不是必需的，但你仍然可以手动设置该选项。
 
 ----
-helm install rancher rancher-latest/rancher \
+helm install rancher rancher-prime/rancher \
   --namespace cattle-system \
   --set hostname=rancher.my.org \
   --set 'extraEnv[0].name=CATTLE_FEATURES'
   --set 'extraEnv[0].value=<FEATURE-FLAG-NAME-1>=true,<FEATURE-FLAG-NAME-2>=true'
 ----
-
-[NOTE]
-====
-
-如果你安装的是 alpha 版本，Helm 要求你在命令中添加 `--devel` 选项。
-====
-
 
 === 离线安装的情况下渲染 Helm Chart
 

--- a/versions/v2.9/modules/zh/pages/security/rancher-webhook/rancher-webhook.adoc
+++ b/versions/v2.9/modules/zh/pages/security/rancher-webhook/rancher-webhook.adoc
@@ -111,7 +111,7 @@ Rancher 会在检测到对 ConfigMap 值的更改时重新部署 Rancher-Webhook
 
 [,bash]
 ----
-helm install rancher rancher-<CHART_REPO>/rancher \
+helm install rancher rancher-prime/rancher \
   --namespace cattle-system \
   ...
   --set webhook.port=9553 \


### PR DESCRIPTION
## Description

Updates the Helm management steps to use Prime-based info. Old references to the alpha, stable, and latest repos have been removed/adjusted as they're not applicable.

Added a partial containing an admonition that links to the actual page where users can find the repo URL.