### PR TITLE
Add March 2025 release CVEs and advisories

### DIFF
--- a/versions/latest/modules/en/pages/security/cves.adoc
+++ b/versions/latest/modules/en/pages/security/cves.adoc
@@ -5,6 +5,10 @@ Rancher is committed to informing the community of security issues in our produc
 |===
 | ID | Description | Date | Resolution
 
+| https://github.com/rancher/rancher/security/advisories/GHSA-8p83-cpfg-fj3g[CVE-2025-23391] | A vulnerability has been identified within Rancher where a Restricted Administrator can change the password of Administrators and take over their accounts. A Restricted Administrator should not be allowed to change the password of more privileged users unless it contains the Manage Users permissions. A new validation has been added to block a user from editing or deleting another user with more permissions than themselves. Rancher deployments where the Restricted Administrator role is not being used are not affected by this CVE. 
+| 31 Mar 2025 
+| Rancher https://github.com/rancher/rancher/releases/tag/v2.11.0[v2.11.0], https://github.com/rancher/rancher/releases/tag/v2.10.4[v2.10.4], https://github.com/rancher/rancher/releases/tag/v2.9.8[v2.9.8] and https://github.com/rancher/rancher/releases/tag/v2.8.14[v2.8.14]
+
 | https://github.com/rancher/rancher/security/advisories/GHSA-5qmp-9x47-92q8[CVE-2025-23389]
 a| A vulnerability in Rancher has been discovered, leading to a local user impersonation through SAML Authentication on first login.
 

--- a/versions/latest/modules/zh/pages/security/cves.adoc
+++ b/versions/latest/modules/zh/pages/security/cves.adoc
@@ -5,6 +5,10 @@ Rancher 致力于向社区披露我们产品的安全问题。我们会针对已
 |===
 | ID | 描述 | 日期 | 解决
 
+| https://github.com/rancher/rancher/security/advisories/GHSA-8p83-cpfg-fj3g[CVE-2025-23391] | A vulnerability has been identified within Rancher where a Restricted Administrator can change the password of Administrators and take over their accounts. A Restricted Administrator should not be allowed to change the password of more privileged users unless it contains the Manage Users permissions. A new validation has been added to block a user from editing or deleting another user with more permissions than themselves. Rancher deployments where the Restricted Administrator role is not being used are not affected by this CVE. 
+| 31 Mar 2025 
+| Rancher https://github.com/rancher/rancher/releases/tag/v2.11.0[v2.11.0], https://github.com/rancher/rancher/releases/tag/v2.10.4[v2.10.4], https://github.com/rancher/rancher/releases/tag/v2.9.8[v2.9.8] and https://github.com/rancher/rancher/releases/tag/v2.8.14[v2.8.14]
+
 | https://github.com/rancher/rancher/security/advisories/GHSA-5qmp-9x47-92q8[CVE-2025-23389]
 a| A vulnerability in Rancher has been discovered, leading to a local user impersonation through SAML Authentication on first login.
 

--- a/versions/v2.10/modules/en/pages/security/cves.adoc
+++ b/versions/v2.10/modules/en/pages/security/cves.adoc
@@ -5,6 +5,10 @@ Rancher is committed to informing the community of security issues in our produc
 |===
 | ID | Description | Date | Resolution
 
+| https://github.com/rancher/rancher/security/advisories/GHSA-8p83-cpfg-fj3g[CVE-2025-23391] | A vulnerability has been identified within Rancher where a Restricted Administrator can change the password of Administrators and take over their accounts. A Restricted Administrator should not be allowed to change the password of more privileged users unless it contains the Manage Users permissions. A new validation has been added to block a user from editing or deleting another user with more permissions than themselves. Rancher deployments where the Restricted Administrator role is not being used are not affected by this CVE. 
+| 31 Mar 2025 
+| Rancher https://github.com/rancher/rancher/releases/tag/v2.11.0[v2.11.0], https://github.com/rancher/rancher/releases/tag/v2.10.4[v2.10.4], https://github.com/rancher/rancher/releases/tag/v2.9.8[v2.9.8] and https://github.com/rancher/rancher/releases/tag/v2.8.14[v2.8.14]
+
 | https://github.com/rancher/rancher/security/advisories/GHSA-5qmp-9x47-92q8[CVE-2025-23389]
 a| A vulnerability in Rancher has been discovered, leading to a local user impersonation through SAML Authentication on first login.
 

--- a/versions/v2.10/modules/zh/pages/security/cves.adoc
+++ b/versions/v2.10/modules/zh/pages/security/cves.adoc
@@ -5,6 +5,10 @@ Rancher 致力于向社区披露我们产品的安全问题。我们会针对已
 |===
 | ID | 描述 | 日期 | 解决
 
+| https://github.com/rancher/rancher/security/advisories/GHSA-8p83-cpfg-fj3g[CVE-2025-23391] | A vulnerability has been identified within Rancher where a Restricted Administrator can change the password of Administrators and take over their accounts. A Restricted Administrator should not be allowed to change the password of more privileged users unless it contains the Manage Users permissions. A new validation has been added to block a user from editing or deleting another user with more permissions than themselves. Rancher deployments where the Restricted Administrator role is not being used are not affected by this CVE. 
+| 31 Mar 2025 
+| Rancher https://github.com/rancher/rancher/releases/tag/v2.11.0[v2.11.0], https://github.com/rancher/rancher/releases/tag/v2.10.4[v2.10.4], https://github.com/rancher/rancher/releases/tag/v2.9.8[v2.9.8] and https://github.com/rancher/rancher/releases/tag/v2.8.14[v2.8.14]
+
 | https://github.com/rancher/rancher/security/advisories/GHSA-5qmp-9x47-92q8[CVE-2025-23389]
 a| A vulnerability in Rancher has been discovered, leading to a local user impersonation through SAML Authentication on first login.
 

--- a/versions/v2.11/modules/en/pages/security/cves.adoc
+++ b/versions/v2.11/modules/en/pages/security/cves.adoc
@@ -5,6 +5,10 @@ Rancher is committed to informing the community of security issues in our produc
 |===
 | ID | Description | Date | Resolution
 
+| https://github.com/rancher/rancher/security/advisories/GHSA-8p83-cpfg-fj3g[CVE-2025-23391] | A vulnerability has been identified within Rancher where a Restricted Administrator can change the password of Administrators and take over their accounts. A Restricted Administrator should not be allowed to change the password of more privileged users unless it contains the Manage Users permissions. A new validation has been added to block a user from editing or deleting another user with more permissions than themselves. Rancher deployments where the Restricted Administrator role is not being used are not affected by this CVE. 
+| 31 Mar 2025 
+| Rancher https://github.com/rancher/rancher/releases/tag/v2.11.0[v2.11.0], https://github.com/rancher/rancher/releases/tag/v2.10.4[v2.10.4], https://github.com/rancher/rancher/releases/tag/v2.9.8[v2.9.8] and https://github.com/rancher/rancher/releases/tag/v2.8.14[v2.8.14]
+
 | https://github.com/rancher/rancher/security/advisories/GHSA-5qmp-9x47-92q8[CVE-2025-23389]
 a| A vulnerability in Rancher has been discovered, leading to a local user impersonation through SAML Authentication on first login.
 

--- a/versions/v2.11/modules/zh/pages/security/cves.adoc
+++ b/versions/v2.11/modules/zh/pages/security/cves.adoc
@@ -5,6 +5,10 @@ Rancher 致力于向社区披露我们产品的安全问题。我们会针对已
 |===
 | ID | 描述 | 日期 | 解决
 
+| https://github.com/rancher/rancher/security/advisories/GHSA-8p83-cpfg-fj3g[CVE-2025-23391] | A vulnerability has been identified within Rancher where a Restricted Administrator can change the password of Administrators and take over their accounts. A Restricted Administrator should not be allowed to change the password of more privileged users unless it contains the Manage Users permissions. A new validation has been added to block a user from editing or deleting another user with more permissions than themselves. Rancher deployments where the Restricted Administrator role is not being used are not affected by this CVE. 
+| 31 Mar 2025 
+| Rancher https://github.com/rancher/rancher/releases/tag/v2.11.0[v2.11.0], https://github.com/rancher/rancher/releases/tag/v2.10.4[v2.10.4], https://github.com/rancher/rancher/releases/tag/v2.9.8[v2.9.8] and https://github.com/rancher/rancher/releases/tag/v2.8.14[v2.8.14]
+
 | https://github.com/rancher/rancher/security/advisories/GHSA-5qmp-9x47-92q8[CVE-2025-23389]
 a| A vulnerability in Rancher has been discovered, leading to a local user impersonation through SAML Authentication on first login.
 

--- a/versions/v2.8/modules/en/pages/security/cves.adoc
+++ b/versions/v2.8/modules/en/pages/security/cves.adoc
@@ -5,6 +5,10 @@ Rancher is committed to informing the community of security issues in our produc
 |===
 | ID | Description | Date | Resolution
 
+| https://github.com/rancher/rancher/security/advisories/GHSA-8p83-cpfg-fj3g[CVE-2025-23391] | A vulnerability has been identified within Rancher where a Restricted Administrator can change the password of Administrators and take over their accounts. A Restricted Administrator should not be allowed to change the password of more privileged users unless it contains the Manage Users permissions. A new validation has been added to block a user from editing or deleting another user with more permissions than themselves. Rancher deployments where the Restricted Administrator role is not being used are not affected by this CVE. 
+| 31 Mar 2025 
+| Rancher https://github.com/rancher/rancher/releases/tag/v2.11.0[v2.11.0], https://github.com/rancher/rancher/releases/tag/v2.10.4[v2.10.4], https://github.com/rancher/rancher/releases/tag/v2.9.8[v2.9.8] and https://github.com/rancher/rancher/releases/tag/v2.8.14[v2.8.14]
+
 | https://github.com/rancher/rancher/security/advisories/GHSA-5qmp-9x47-92q8[CVE-2025-23389]
 a| A vulnerability in Rancher has been discovered, leading to a local user impersonation through SAML Authentication on first login.
 

--- a/versions/v2.8/modules/zh/pages/security/cves.adoc
+++ b/versions/v2.8/modules/zh/pages/security/cves.adoc
@@ -5,6 +5,10 @@ Rancher 致力于向社区披露我们产品的安全问题。我们会针对已
 |===
 | ID | 描述 | 日期 | 解决
 
+| https://github.com/rancher/rancher/security/advisories/GHSA-8p83-cpfg-fj3g[CVE-2025-23391] | A vulnerability has been identified within Rancher where a Restricted Administrator can change the password of Administrators and take over their accounts. A Restricted Administrator should not be allowed to change the password of more privileged users unless it contains the Manage Users permissions. A new validation has been added to block a user from editing or deleting another user with more permissions than themselves. Rancher deployments where the Restricted Administrator role is not being used are not affected by this CVE. 
+| 31 Mar 2025 
+| Rancher https://github.com/rancher/rancher/releases/tag/v2.11.0[v2.11.0], https://github.com/rancher/rancher/releases/tag/v2.10.4[v2.10.4], https://github.com/rancher/rancher/releases/tag/v2.9.8[v2.9.8] and https://github.com/rancher/rancher/releases/tag/v2.8.14[v2.8.14]
+
 | https://github.com/rancher/rancher/security/advisories/GHSA-5qmp-9x47-92q8[CVE-2025-23389]
 a| A vulnerability in Rancher has been discovered, leading to a local user impersonation through SAML Authentication on first login.
 

--- a/versions/v2.9/modules/en/pages/security/cves.adoc
+++ b/versions/v2.9/modules/en/pages/security/cves.adoc
@@ -5,6 +5,10 @@ Rancher is committed to informing the community of security issues in our produc
 |===
 | ID | Description | Date | Resolution
 
+| https://github.com/rancher/rancher/security/advisories/GHSA-8p83-cpfg-fj3g[CVE-2025-23391] | A vulnerability has been identified within Rancher where a Restricted Administrator can change the password of Administrators and take over their accounts. A Restricted Administrator should not be allowed to change the password of more privileged users unless it contains the Manage Users permissions. A new validation has been added to block a user from editing or deleting another user with more permissions than themselves. Rancher deployments where the Restricted Administrator role is not being used are not affected by this CVE. 
+| 31 Mar 2025 
+| Rancher https://github.com/rancher/rancher/releases/tag/v2.11.0[v2.11.0], https://github.com/rancher/rancher/releases/tag/v2.10.4[v2.10.4], https://github.com/rancher/rancher/releases/tag/v2.9.8[v2.9.8] and https://github.com/rancher/rancher/releases/tag/v2.8.14[v2.8.14]
+
 | https://github.com/rancher/rancher/security/advisories/GHSA-5qmp-9x47-92q8[CVE-2025-23389]
 a| A vulnerability in Rancher has been discovered, leading to a local user impersonation through SAML Authentication on first login.
 

--- a/versions/v2.9/modules/zh/pages/security/cves.adoc
+++ b/versions/v2.9/modules/zh/pages/security/cves.adoc
@@ -5,6 +5,10 @@ Rancher 致力于向社区披露我们产品的安全问题。我们会针对已
 |===
 | ID | 描述 | 日期 | 解决
 
+| https://github.com/rancher/rancher/security/advisories/GHSA-8p83-cpfg-fj3g[CVE-2025-23391] | A vulnerability has been identified within Rancher where a Restricted Administrator can change the password of Administrators and take over their accounts. A Restricted Administrator should not be allowed to change the password of more privileged users unless it contains the Manage Users permissions. A new validation has been added to block a user from editing or deleting another user with more permissions than themselves. Rancher deployments where the Restricted Administrator role is not being used are not affected by this CVE. 
+| 31 Mar 2025 
+| Rancher https://github.com/rancher/rancher/releases/tag/v2.11.0[v2.11.0], https://github.com/rancher/rancher/releases/tag/v2.10.4[v2.10.4], https://github.com/rancher/rancher/releases/tag/v2.9.8[v2.9.8] and https://github.com/rancher/rancher/releases/tag/v2.8.14[v2.8.14]
+
 | https://github.com/rancher/rancher/security/advisories/GHSA-5qmp-9x47-92q8[CVE-2025-23389]
 a| A vulnerability in Rancher has been discovered, leading to a local user impersonation through SAML Authentication on first login.
 


### PR DESCRIPTION
- Update the [CVE page](https://documentation.suse.com/cloudnative/rancher-manager/latest/en/security/cves.html) for the March 2025 release. 
  - [x]   en
  - [x]   zh
- Resolves https://github.com/rancher/rancher-product-docs/issues/204