### PR TITLE
Discourage third party software on the upstream cluster

### DIFF
--- a/versions/latest/modules/en/pages/installation-and-upgrade/best-practices/best-practices.adoc
+++ b/versions/latest/modules/en/pages/installation-and-upgrade/best-practices/best-practices.adoc
@@ -4,7 +4,7 @@ This guide contains our recommendations for running the Rancher server, and is i
 
 == Recommended Architecture and Infrastructure
 
-Refer to this xref:installation-and-upgrade/best-practices/tips-for-running-rancher.adoc[guide] for our general advice for setting up the Rancher server on a high-availability Kubernetes cluster.
+Refer to this xref:installation-and-upgrade/best-practices/tips-for-running-rancher.adoc[guide] for our general advice for setting up the Rancher server for a production installation.
 
 == Deployment Strategies
 

--- a/versions/latest/modules/en/pages/installation-and-upgrade/best-practices/tips-for-running-rancher.adoc
+++ b/versions/latest/modules/en/pages/installation-and-upgrade/best-practices/tips-for-running-rancher.adoc
@@ -8,9 +8,38 @@ If you are installing Rancher in a vSphere environment, refer to the best practi
 
 When you set up your high-availability Rancher installation, consider the following:
 
-== Run Rancher on a Separate Cluster
+== Minimize Third-Party Software on the Upstream Cluster
 
-Don't run other workloads or microservices in the Kubernetes cluster that Rancher is installed on.
+We generally recommend running Rancher on a dedicated cluster, free of other workloads, to avoid potential performance and compatibility issues.
+
+Rancher, especially when managing a growing number of clusters, nodes, and workloads, places a significant load on core Kubernetes components like `etcd` and `kube-apiserver` on the upstream cluster. Third-party software can interfere with the performance of these components and Rancher, potentially leading to instability.
+
+Furthermore, third-party software can functionally interfere with Rancher. To minimize compatibility risks, deploy only essential Kubernetes system components and Rancher on the upstream cluster.
+
+The following applications and components generally do not interfere with Rancher or the Kubernetes system and installing them on the upstream cluster is supported:
+
+* Rancher internal components, such as Fleet
+* Rancher extensions
+* Cluster API components
+* CNIs, CPIs, CSIs
+* Cloud controller managers
+* Observability and monitoring tools (with the exception of prometheus-rancher-exporter)
+* https://documentation.suse.com/cloudnative/suse-private-registry/html/private-registry/pr-introduction.html[SUSE Private Registry]
+
+Note that each of these components has its own minimum resource requirements, which must be met in addition to Rancher's.
+
+SUSE Private Registry, in particular, can require significant bandwidth for serving images. Ensure sufficient bandwidth is available, ideally reserved using Quality of Service (QoS) mechanisms, for Rancher.
+
+For high-scale deployments, consider dedicating separate nodes to non-Rancher software using https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[taints and tolerations] to minimize interference.
+
+Other software can interfere with Rancher and is therefore not supported on the upstream cluster.
+
+Note in particular the following software is known to interfere with Rancher performance at scale:
+
+* https://www.crossplane.io/[CrossPlane]
+* https://argoproj.github.io/cd/[Argo CD]
+* https://fluxcd.io/[Flux]
+* https://github.com/David-VTUK/prometheus-rancher-exporter[prometheus-rancher-exporter] (see https://github.com/David-VTUK/prometheus-rancher-exporter/issues/33[issue 33])
 
 == Make sure nodes are configured correctly for Kubernetes
 

--- a/versions/latest/modules/en/pages/installation-and-upgrade/best-practices/tips-for-running-rancher.adoc
+++ b/versions/latest/modules/en/pages/installation-and-upgrade/best-practices/tips-for-running-rancher.adoc
@@ -23,23 +23,31 @@ The following applications and components generally do not interfere with Ranche
 * Cluster API components
 * CNIs, CPIs, CSIs
 * Cloud controller managers
-* Observability and monitoring tools (with the exception of prometheus-rancher-exporter)
-* https://documentation.suse.com/cloudnative/suse-private-registry/html/private-registry/pr-introduction.html[SUSE Private Registry]
+* Observability and monitoring tools (except prometheus-rancher-exporter)
 
-Note that each of these components has its own minimum resource requirements, which must be met in addition to Rancher's.
-
-SUSE Private Registry, in particular, can require significant bandwidth for serving images. Ensure sufficient bandwidth is available, ideally reserved using Quality of Service (QoS) mechanisms, for Rancher.
-
-For high-scale deployments, consider dedicating separate nodes to non-Rancher software using https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[taints and tolerations] to minimize interference.
+Note that each of these components has its own minimum resource requirements, which must be met in addition to Rancher's. For high-scale deployments, also consider dedicating separate nodes to non-Rancher software using https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[taints and tolerations] to minimize interference.
 
 Other software can interfere with Rancher and is therefore not supported on the upstream cluster.
 
-Note in particular the following software is known to interfere with Rancher performance at scale:
+Note in particular the following software is known to interfere with Rancher performance:
 
 * https://www.crossplane.io/[CrossPlane]
 * https://argoproj.github.io/cd/[Argo CD]
 * https://fluxcd.io/[Flux]
 * https://github.com/David-VTUK/prometheus-rancher-exporter[prometheus-rancher-exporter] (see https://github.com/David-VTUK/prometheus-rancher-exporter/issues/33[issue 33])
+* Container registries such as SUSE Private Registry, which can require significant bandwidth for serving images
+
+=== Guidance for Container Registries
+
+Container registries, such as SUSE Private Registry, can consume significant network bandwidth when serving images. This demand increases with the number of images, the frequency of image pulls, and the quantity of clusters and container runtimes they serve. Due to this potential for interference with Rancher UI and API traffic, we recommend against running container registries on the same cluster as the Rancher management server.
+
+Regardless of your deployment strategy for a container registry, ensure sufficient bandwidth is available, ideally reserved using Quality of Service (QoS) mechanisms.
+
+Consider the following recommendations based on your needs:
+
+* *Simple Setups (HA Not a Primary Concern):* A container registry deployed as a single Virtual Machine (VM) can be a viable solution.
+* *High Availability (HA) Requirements:* We recommend running the registry in a dedicated Kubernetes cluster. All other clusters should then be configured to pull images from this centralized, HA registry.
+* *Very Large-Scale or Complex Network Topologies:* Multiple registry clusters might be necessary. These can be deployed in a hierarchical or federated model to efficiently distribute images and manage traffic.
 
 == Make sure nodes are configured correctly for Kubernetes
 

--- a/versions/latest/modules/en/pages/installation-and-upgrade/best-practices/tuning-rancher-at-scale.adoc
+++ b/versions/latest/modules/en/pages/installation-and-upgrade/best-practices/tuning-rancher-at-scale.adoc
@@ -14,25 +14,7 @@ When scaling up Rancher, one typical bottleneck is resource growth in the upstre
 
 === Minimizing Third-Party Software on the Upstream Cluster
 
-Running Rancher at scale can put significant load on internal Kubernetes components, such as `etcd` or `kubeapiserver`. Issues may arise if third-party software interferes with the performance of those components or with Rancher.
-
-Every third-party piece of software carries a risk of interference. To prevent performance issues on the upstream cluster, you should avoid running any other apps or components, beyond Kubernetes system components and Rancher itself.
-
-Software in the following categories generally won't interfere with Rancher or Kubernetes system performance:
-
-* Rancher internal components, such as Fleet
-* Rancher extensions
-* Cluster API components
-* CNIs
-* Cloud controller managers
-* Observability and monitoring tools (with the exception of prometheus-rancher-exporter)
-
-On the other hand, the following software are found to interfere with Rancher performance at scale:
-
-* https://www.crossplane.io/[CrossPlane]
-* https://argoproj.github.io/cd/[Argo CD]
-* https://fluxcd.io/[Flux]
-* https://github.com/David-VTUK/prometheus-rancher-exporter[prometheus-rancher-exporter] (see https://github.com/David-VTUK/prometheus-rancher-exporter/issues/33[issue 33])
+Recommendations outlined in the xref:installation-and-upgrade/best-practices/tips-for-running-rancher.adoc#_minimize_third-party_software_on_the_upstream_cluster[general Rancher recommendations] are particularly important in a high scale context.
 
 === Managing Your Object Counts
 

--- a/versions/v2.10/modules/en/pages/installation-and-upgrade/best-practices/best-practices.adoc
+++ b/versions/v2.10/modules/en/pages/installation-and-upgrade/best-practices/best-practices.adoc
@@ -4,7 +4,7 @@ This guide contains our recommendations for running the Rancher server, and is i
 
 == Recommended Architecture and Infrastructure
 
-Refer to this xref:installation-and-upgrade/best-practices/tips-for-running-rancher.adoc[guide] for our general advice for setting up the Rancher server on a high-availability Kubernetes cluster.
+Refer to this xref:installation-and-upgrade/best-practices/tips-for-running-rancher.adoc[guide] for our general advice for setting up the Rancher server for a production installation.
 
 == Deployment Strategies
 

--- a/versions/v2.10/modules/en/pages/installation-and-upgrade/best-practices/tips-for-running-rancher.adoc
+++ b/versions/v2.10/modules/en/pages/installation-and-upgrade/best-practices/tips-for-running-rancher.adoc
@@ -8,9 +8,38 @@ If you are installing Rancher in a vSphere environment, refer to the best practi
 
 When you set up your high-availability Rancher installation, consider the following:
 
-== Run Rancher on a Separate Cluster
+== Minimize Third-Party Software on the Upstream Cluster
 
-Don't run other workloads or microservices in the Kubernetes cluster that Rancher is installed on.
+We generally recommend running Rancher on a dedicated cluster, free of other workloads, to avoid potential performance and compatibility issues.
+
+Rancher, especially when managing a growing number of clusters, nodes, and workloads, places a significant load on core Kubernetes components like `etcd` and `kube-apiserver` on the upstream cluster. Third-party software can interfere with the performance of these components and Rancher, potentially leading to instability.
+
+Furthermore, third-party software can functionally interfere with Rancher. To minimize compatibility risks, deploy only essential Kubernetes system components and Rancher on the upstream cluster.
+
+The following applications and components generally do not interfere with Rancher or the Kubernetes system and installing them on the upstream cluster is supported:
+
+* Rancher internal components, such as Fleet
+* Rancher extensions
+* Cluster API components
+* CNIs, CPIs, CSIs
+* Cloud controller managers
+* Observability and monitoring tools (with the exception of prometheus-rancher-exporter)
+* https://documentation.suse.com/cloudnative/suse-private-registry/html/private-registry/pr-introduction.html[SUSE Private Registry]
+
+Note that each of these components has its own minimum resource requirements, which must be met in addition to Rancher's.
+
+SUSE Private Registry, in particular, can require significant bandwidth for serving images. Ensure sufficient bandwidth is available, ideally reserved using Quality of Service (QoS) mechanisms, for Rancher.
+
+For high-scale deployments, consider dedicating separate nodes to non-Rancher software using https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[taints and tolerations] to minimize interference.
+
+Other software can interfere with Rancher and is therefore not supported on the upstream cluster.
+
+Note in particular the following software is known to interfere with Rancher performance at scale:
+
+* https://www.crossplane.io/[CrossPlane]
+* https://argoproj.github.io/cd/[Argo CD]
+* https://fluxcd.io/[Flux]
+* https://github.com/David-VTUK/prometheus-rancher-exporter[prometheus-rancher-exporter] (see https://github.com/David-VTUK/prometheus-rancher-exporter/issues/33[issue 33])
 
 == Make sure nodes are configured correctly for Kubernetes
 

--- a/versions/v2.10/modules/en/pages/installation-and-upgrade/best-practices/tips-for-running-rancher.adoc
+++ b/versions/v2.10/modules/en/pages/installation-and-upgrade/best-practices/tips-for-running-rancher.adoc
@@ -23,23 +23,31 @@ The following applications and components generally do not interfere with Ranche
 * Cluster API components
 * CNIs, CPIs, CSIs
 * Cloud controller managers
-* Observability and monitoring tools (with the exception of prometheus-rancher-exporter)
-* https://documentation.suse.com/cloudnative/suse-private-registry/html/private-registry/pr-introduction.html[SUSE Private Registry]
+* Observability and monitoring tools (except prometheus-rancher-exporter)
 
-Note that each of these components has its own minimum resource requirements, which must be met in addition to Rancher's.
-
-SUSE Private Registry, in particular, can require significant bandwidth for serving images. Ensure sufficient bandwidth is available, ideally reserved using Quality of Service (QoS) mechanisms, for Rancher.
-
-For high-scale deployments, consider dedicating separate nodes to non-Rancher software using https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[taints and tolerations] to minimize interference.
+Note that each of these components has its own minimum resource requirements, which must be met in addition to Rancher's. For high-scale deployments, also consider dedicating separate nodes to non-Rancher software using https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[taints and tolerations] to minimize interference.
 
 Other software can interfere with Rancher and is therefore not supported on the upstream cluster.
 
-Note in particular the following software is known to interfere with Rancher performance at scale:
+Note in particular the following software is known to interfere with Rancher performance:
 
 * https://www.crossplane.io/[CrossPlane]
 * https://argoproj.github.io/cd/[Argo CD]
 * https://fluxcd.io/[Flux]
 * https://github.com/David-VTUK/prometheus-rancher-exporter[prometheus-rancher-exporter] (see https://github.com/David-VTUK/prometheus-rancher-exporter/issues/33[issue 33])
+* Container registries such as SUSE Private Registry, which can require significant bandwidth for serving images
+
+=== Guidance for Container Registries
+
+Container registries, such as SUSE Private Registry, can consume significant network bandwidth when serving images. This demand increases with the number of images, the frequency of image pulls, and the quantity of clusters and container runtimes they serve. Due to this potential for interference with Rancher UI and API traffic, we recommend against running container registries on the same cluster as the Rancher management server.
+
+Regardless of your deployment strategy for a container registry, ensure sufficient bandwidth is available, ideally reserved using Quality of Service (QoS) mechanisms.
+
+Consider the following recommendations based on your needs:
+
+* *Simple Setups (HA Not a Primary Concern):* A container registry deployed as a single Virtual Machine (VM) can be a viable solution.
+* *High Availability (HA) Requirements:* We recommend running the registry in a dedicated Kubernetes cluster. All other clusters should then be configured to pull images from this centralized, HA registry.
+* *Very Large-Scale or Complex Network Topologies:* Multiple registry clusters might be necessary. These can be deployed in a hierarchical or federated model to efficiently distribute images and manage traffic.
 
 == Make sure nodes are configured correctly for Kubernetes
 

--- a/versions/v2.10/modules/en/pages/installation-and-upgrade/best-practices/tuning-rancher-at-scale.adoc
+++ b/versions/v2.10/modules/en/pages/installation-and-upgrade/best-practices/tuning-rancher-at-scale.adoc
@@ -14,25 +14,7 @@ When scaling up Rancher, one typical bottleneck is resource growth in the upstre
 
 === Minimizing Third-Party Software on the Upstream Cluster
 
-Running Rancher at scale can put significant load on internal Kubernetes components, such as `etcd` or `kubeapiserver`. Issues may arise if third-party software interferes with the performance of those components or with Rancher.
-
-Every third-party piece of software carries a risk of interference. To prevent performance issues on the upstream cluster, you should avoid running any other apps or components, beyond Kubernetes system components and Rancher itself.
-
-Software in the following categories generally won't interfere with Rancher or Kubernetes system performance:
-
-* Rancher internal components, such as Fleet
-* Rancher extensions
-* Cluster API components
-* CNIs
-* Cloud controller managers
-* Observability and monitoring tools (with the exception of prometheus-rancher-exporter)
-
-On the other hand, the following software are found to interfere with Rancher performance at scale:
-
-* https://www.crossplane.io/[CrossPlane]
-* https://argoproj.github.io/cd/[Argo CD]
-* https://fluxcd.io/[Flux]
-* https://github.com/David-VTUK/prometheus-rancher-exporter[prometheus-rancher-exporter] (see https://github.com/David-VTUK/prometheus-rancher-exporter/issues/33[issue 33])
+Recommendations outlined in the xref:installation-and-upgrade/best-practices/tips-for-running-rancher.adoc#_minimize_third-party_software_on_the_upstream_cluster[general Rancher recommendations] are particularly important in a high scale context.
 
 === Managing Your Object Counts
 

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/best-practices/best-practices.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/best-practices/best-practices.adoc
@@ -4,7 +4,7 @@ This guide contains our recommendations for running the Rancher server, and is i
 
 == Recommended Architecture and Infrastructure
 
-Refer to this xref:installation-and-upgrade/best-practices/tips-for-running-rancher.adoc[guide] for our general advice for setting up the Rancher server on a high-availability Kubernetes cluster.
+Refer to this xref:installation-and-upgrade/best-practices/tips-for-running-rancher.adoc[guide] for our general advice for setting up the Rancher server for a production installation.
 
 == Deployment Strategies
 

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/best-practices/tips-for-running-rancher.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/best-practices/tips-for-running-rancher.adoc
@@ -8,9 +8,38 @@ If you are installing Rancher in a vSphere environment, refer to the best practi
 
 When you set up your high-availability Rancher installation, consider the following:
 
-== Run Rancher on a Separate Cluster
+== Minimize Third-Party Software on the Upstream Cluster
 
-Don't run other workloads or microservices in the Kubernetes cluster that Rancher is installed on.
+We generally recommend running Rancher on a dedicated cluster, free of other workloads, to avoid potential performance and compatibility issues.
+
+Rancher, especially when managing a growing number of clusters, nodes, and workloads, places a significant load on core Kubernetes components like `etcd` and `kube-apiserver` on the upstream cluster. Third-party software can interfere with the performance of these components and Rancher, potentially leading to instability.
+
+Furthermore, third-party software can functionally interfere with Rancher. To minimize compatibility risks, deploy only essential Kubernetes system components and Rancher on the upstream cluster.
+
+The following applications and components generally do not interfere with Rancher or the Kubernetes system and installing them on the upstream cluster is supported:
+
+* Rancher internal components, such as Fleet
+* Rancher extensions
+* Cluster API components
+* CNIs, CPIs, CSIs
+* Cloud controller managers
+* Observability and monitoring tools (with the exception of prometheus-rancher-exporter)
+* https://documentation.suse.com/cloudnative/suse-private-registry/html/private-registry/pr-introduction.html[SUSE Private Registry]
+
+Note that each of these components has its own minimum resource requirements, which must be met in addition to Rancher's.
+
+SUSE Private Registry, in particular, can require significant bandwidth for serving images. Ensure sufficient bandwidth is available, ideally reserved using Quality of Service (QoS) mechanisms, for Rancher.
+
+For high-scale deployments, consider dedicating separate nodes to non-Rancher software using https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[taints and tolerations] to minimize interference.
+
+Other software can interfere with Rancher and is therefore not supported on the upstream cluster.
+
+Note in particular the following software is known to interfere with Rancher performance at scale:
+
+* https://www.crossplane.io/[CrossPlane]
+* https://argoproj.github.io/cd/[Argo CD]
+* https://fluxcd.io/[Flux]
+* https://github.com/David-VTUK/prometheus-rancher-exporter[prometheus-rancher-exporter] (see https://github.com/David-VTUK/prometheus-rancher-exporter/issues/33[issue 33])
 
 == Make sure nodes are configured correctly for Kubernetes
 

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/best-practices/tips-for-running-rancher.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/best-practices/tips-for-running-rancher.adoc
@@ -23,23 +23,31 @@ The following applications and components generally do not interfere with Ranche
 * Cluster API components
 * CNIs, CPIs, CSIs
 * Cloud controller managers
-* Observability and monitoring tools (with the exception of prometheus-rancher-exporter)
-* https://documentation.suse.com/cloudnative/suse-private-registry/html/private-registry/pr-introduction.html[SUSE Private Registry]
+* Observability and monitoring tools (except prometheus-rancher-exporter)
 
-Note that each of these components has its own minimum resource requirements, which must be met in addition to Rancher's.
-
-SUSE Private Registry, in particular, can require significant bandwidth for serving images. Ensure sufficient bandwidth is available, ideally reserved using Quality of Service (QoS) mechanisms, for Rancher.
-
-For high-scale deployments, consider dedicating separate nodes to non-Rancher software using https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[taints and tolerations] to minimize interference.
+Note that each of these components has its own minimum resource requirements, which must be met in addition to Rancher's. For high-scale deployments, also consider dedicating separate nodes to non-Rancher software using https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[taints and tolerations] to minimize interference.
 
 Other software can interfere with Rancher and is therefore not supported on the upstream cluster.
 
-Note in particular the following software is known to interfere with Rancher performance at scale:
+Note in particular the following software is known to interfere with Rancher performance:
 
 * https://www.crossplane.io/[CrossPlane]
 * https://argoproj.github.io/cd/[Argo CD]
 * https://fluxcd.io/[Flux]
 * https://github.com/David-VTUK/prometheus-rancher-exporter[prometheus-rancher-exporter] (see https://github.com/David-VTUK/prometheus-rancher-exporter/issues/33[issue 33])
+* Container registries such as SUSE Private Registry, which can require significant bandwidth for serving images
+
+=== Guidance for Container Registries
+
+Container registries, such as SUSE Private Registry, can consume significant network bandwidth when serving images. This demand increases with the number of images, the frequency of image pulls, and the quantity of clusters and container runtimes they serve. Due to this potential for interference with Rancher UI and API traffic, we recommend against running container registries on the same cluster as the Rancher management server.
+
+Regardless of your deployment strategy for a container registry, ensure sufficient bandwidth is available, ideally reserved using Quality of Service (QoS) mechanisms.
+
+Consider the following recommendations based on your needs:
+
+* *Simple Setups (HA Not a Primary Concern):* A container registry deployed as a single Virtual Machine (VM) can be a viable solution.
+* *High Availability (HA) Requirements:* We recommend running the registry in a dedicated Kubernetes cluster. All other clusters should then be configured to pull images from this centralized, HA registry.
+* *Very Large-Scale or Complex Network Topologies:* Multiple registry clusters might be necessary. These can be deployed in a hierarchical or federated model to efficiently distribute images and manage traffic.
 
 == Make sure nodes are configured correctly for Kubernetes
 

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/best-practices/tuning-rancher-at-scale.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/best-practices/tuning-rancher-at-scale.adoc
@@ -14,25 +14,7 @@ When scaling up Rancher, one typical bottleneck is resource growth in the upstre
 
 === Minimizing Third-Party Software on the Upstream Cluster
 
-Running Rancher at scale can put significant load on internal Kubernetes components, such as `etcd` or `kubeapiserver`. Issues may arise if third-party software interferes with the performance of those components or with Rancher.
-
-Every third-party piece of software carries a risk of interference. To prevent performance issues on the upstream cluster, you should avoid running any other apps or components, beyond Kubernetes system components and Rancher itself.
-
-Software in the following categories generally won't interfere with Rancher or Kubernetes system performance:
-
-* Rancher internal components, such as Fleet
-* Rancher extensions
-* Cluster API components
-* CNIs
-* Cloud controller managers
-* Observability and monitoring tools (with the exception of prometheus-rancher-exporter)
-
-On the other hand, the following software are found to interfere with Rancher performance at scale:
-
-* https://www.crossplane.io/[CrossPlane]
-* https://argoproj.github.io/cd/[Argo CD]
-* https://fluxcd.io/[Flux]
-* https://github.com/David-VTUK/prometheus-rancher-exporter[prometheus-rancher-exporter] (see https://github.com/David-VTUK/prometheus-rancher-exporter/issues/33[issue 33])
+Recommendations outlined in the xref:installation-and-upgrade/best-practices/tips-for-running-rancher.adoc#_minimize_third-party_software_on_the_upstream_cluster[general Rancher recommendations] are particularly important in a high scale context.
 
 === Managing Your Object Counts
 

--- a/versions/v2.8/modules/en/pages/installation-and-upgrade/best-practices/best-practices.adoc
+++ b/versions/v2.8/modules/en/pages/installation-and-upgrade/best-practices/best-practices.adoc
@@ -4,7 +4,7 @@ This guide contains our recommendations for running the Rancher server, and is i
 
 == Recommended Architecture and Infrastructure
 
-Refer to this xref:installation-and-upgrade/best-practices/tips-for-running-rancher.adoc[guide] for our general advice for setting up the Rancher server on a high-availability Kubernetes cluster.
+Refer to this xref:installation-and-upgrade/best-practices/tips-for-running-rancher.adoc[guide] for our general advice for setting up the Rancher server for a production installation.
 
 == Deployment Strategies
 

--- a/versions/v2.8/modules/en/pages/installation-and-upgrade/best-practices/tips-for-running-rancher.adoc
+++ b/versions/v2.8/modules/en/pages/installation-and-upgrade/best-practices/tips-for-running-rancher.adoc
@@ -8,9 +8,38 @@ If you are installing Rancher in a vSphere environment, refer to the best practi
 
 When you set up your high-availability Rancher installation, consider the following:
 
-== Run Rancher on a Separate Cluster
+== Minimize Third-Party Software on the Upstream Cluster
 
-Don't run other workloads or microservices in the Kubernetes cluster that Rancher is installed on.
+We generally recommend running Rancher on a dedicated cluster, free of other workloads, to avoid potential performance and compatibility issues.
+
+Rancher, especially when managing a growing number of clusters, nodes, and workloads, places a significant load on core Kubernetes components like `etcd` and `kube-apiserver` on the upstream cluster. Third-party software can interfere with the performance of these components and Rancher, potentially leading to instability.
+
+Furthermore, third-party software can functionally interfere with Rancher. To minimize compatibility risks, deploy only essential Kubernetes system components and Rancher on the upstream cluster.
+
+The following applications and components generally do not interfere with Rancher or the Kubernetes system and installing them on the upstream cluster is supported:
+
+* Rancher internal components, such as Fleet
+* Rancher extensions
+* Cluster API components
+* CNIs, CPIs, CSIs
+* Cloud controller managers
+* Observability and monitoring tools (with the exception of prometheus-rancher-exporter)
+* https://documentation.suse.com/cloudnative/suse-private-registry/html/private-registry/pr-introduction.html[SUSE Private Registry]
+
+Note that each of these components has its own minimum resource requirements, which must be met in addition to Rancher's.
+
+SUSE Private Registry, in particular, can require significant bandwidth for serving images. Ensure sufficient bandwidth is available, ideally reserved using Quality of Service (QoS) mechanisms, for Rancher.
+
+For high-scale deployments, consider dedicating separate nodes to non-Rancher software using https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[taints and tolerations] to minimize interference.
+
+Other software can interfere with Rancher and is therefore not supported on the upstream cluster.
+
+Note in particular the following software is known to interfere with Rancher performance at scale:
+
+* https://www.crossplane.io/[CrossPlane]
+* https://argoproj.github.io/cd/[Argo CD]
+* https://fluxcd.io/[Flux]
+* https://github.com/David-VTUK/prometheus-rancher-exporter[prometheus-rancher-exporter] (see https://github.com/David-VTUK/prometheus-rancher-exporter/issues/33[issue 33])
 
 == Make sure nodes are configured correctly for Kubernetes
 

--- a/versions/v2.8/modules/en/pages/installation-and-upgrade/best-practices/tips-for-running-rancher.adoc
+++ b/versions/v2.8/modules/en/pages/installation-and-upgrade/best-practices/tips-for-running-rancher.adoc
@@ -23,23 +23,31 @@ The following applications and components generally do not interfere with Ranche
 * Cluster API components
 * CNIs, CPIs, CSIs
 * Cloud controller managers
-* Observability and monitoring tools (with the exception of prometheus-rancher-exporter)
-* https://documentation.suse.com/cloudnative/suse-private-registry/html/private-registry/pr-introduction.html[SUSE Private Registry]
+* Observability and monitoring tools (except prometheus-rancher-exporter)
 
-Note that each of these components has its own minimum resource requirements, which must be met in addition to Rancher's.
-
-SUSE Private Registry, in particular, can require significant bandwidth for serving images. Ensure sufficient bandwidth is available, ideally reserved using Quality of Service (QoS) mechanisms, for Rancher.
-
-For high-scale deployments, consider dedicating separate nodes to non-Rancher software using https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[taints and tolerations] to minimize interference.
+Note that each of these components has its own minimum resource requirements, which must be met in addition to Rancher's. For high-scale deployments, also consider dedicating separate nodes to non-Rancher software using https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[taints and tolerations] to minimize interference.
 
 Other software can interfere with Rancher and is therefore not supported on the upstream cluster.
 
-Note in particular the following software is known to interfere with Rancher performance at scale:
+Note in particular the following software is known to interfere with Rancher performance:
 
 * https://www.crossplane.io/[CrossPlane]
 * https://argoproj.github.io/cd/[Argo CD]
 * https://fluxcd.io/[Flux]
 * https://github.com/David-VTUK/prometheus-rancher-exporter[prometheus-rancher-exporter] (see https://github.com/David-VTUK/prometheus-rancher-exporter/issues/33[issue 33])
+* Container registries such as SUSE Private Registry, which can require significant bandwidth for serving images
+
+=== Guidance for Container Registries
+
+Container registries, such as SUSE Private Registry, can consume significant network bandwidth when serving images. This demand increases with the number of images, the frequency of image pulls, and the quantity of clusters and container runtimes they serve. Due to this potential for interference with Rancher UI and API traffic, we recommend against running container registries on the same cluster as the Rancher management server.
+
+Regardless of your deployment strategy for a container registry, ensure sufficient bandwidth is available, ideally reserved using Quality of Service (QoS) mechanisms.
+
+Consider the following recommendations based on your needs:
+
+* *Simple Setups (HA Not a Primary Concern):* A container registry deployed as a single Virtual Machine (VM) can be a viable solution.
+* *High Availability (HA) Requirements:* We recommend running the registry in a dedicated Kubernetes cluster. All other clusters should then be configured to pull images from this centralized, HA registry.
+* *Very Large-Scale or Complex Network Topologies:* Multiple registry clusters might be necessary. These can be deployed in a hierarchical or federated model to efficiently distribute images and manage traffic.
 
 == Make sure nodes are configured correctly for Kubernetes
 

--- a/versions/v2.8/modules/en/pages/installation-and-upgrade/best-practices/tuning-rancher-at-scale.adoc
+++ b/versions/v2.8/modules/en/pages/installation-and-upgrade/best-practices/tuning-rancher-at-scale.adoc
@@ -14,25 +14,7 @@ When scaling up Rancher, one typical bottleneck is resource growth in the upstre
 
 === Minimizing Third-Party Software on the Upstream Cluster
 
-Running Rancher at scale can put significant load on internal Kubernetes components, such as `etcd` or `kubeapiserver`. Issues may arise if third-party software interferes with the performance of those components or with Rancher.
-
-Every third-party piece of software carries a risk of interference. To prevent performance issues on the upstream cluster, you should avoid running any other apps or components, beyond Kubernetes system components and Rancher itself.
-
-Software in the following categories generally won't interfere with Rancher or Kubernetes system performance:
-
-* Rancher internal components, such as Fleet
-* Rancher extensions
-* Cluster API components
-* CNIs
-* Cloud controller managers
-* Observability and monitoring tools (with the exception of prometheus-rancher-exporter)
-
-On the other hand, the following software are found to interfere with Rancher performance at scale:
-
-* https://www.crossplane.io/[CrossPlane]
-* https://argoproj.github.io/cd/[Argo CD]
-* https://fluxcd.io/[Flux]
-* https://github.com/David-VTUK/prometheus-rancher-exporter[prometheus-rancher-exporter] (see https://github.com/David-VTUK/prometheus-rancher-exporter/issues/33[issue 33])
+Recommendations outlined in the xref:installation-and-upgrade/best-practices/tips-for-running-rancher.adoc#_minimize_third-party_software_on_the_upstream_cluster[general Rancher recommendations] are particularly important in a high scale context.
 
 === Managing Your Object Counts
 

--- a/versions/v2.9/modules/en/pages/installation-and-upgrade/best-practices/best-practices.adoc
+++ b/versions/v2.9/modules/en/pages/installation-and-upgrade/best-practices/best-practices.adoc
@@ -4,7 +4,7 @@ This guide contains our recommendations for running the Rancher server, and is i
 
 == Recommended Architecture and Infrastructure
 
-Refer to this xref:installation-and-upgrade/best-practices/tips-for-running-rancher.adoc[guide] for our general advice for setting up the Rancher server on a high-availability Kubernetes cluster.
+Refer to this xref:installation-and-upgrade/best-practices/tips-for-running-rancher.adoc[guide] for our general advice for setting up the Rancher server for a production installation.
 
 == Deployment Strategies
 

--- a/versions/v2.9/modules/en/pages/installation-and-upgrade/best-practices/tips-for-running-rancher.adoc
+++ b/versions/v2.9/modules/en/pages/installation-and-upgrade/best-practices/tips-for-running-rancher.adoc
@@ -8,9 +8,38 @@ If you are installing Rancher in a vSphere environment, refer to the best practi
 
 When you set up your high-availability Rancher installation, consider the following:
 
-== Run Rancher on a Separate Cluster
+== Minimize Third-Party Software on the Upstream Cluster
 
-Don't run other workloads or microservices in the Kubernetes cluster that Rancher is installed on.
+We generally recommend running Rancher on a dedicated cluster, free of other workloads, to avoid potential performance and compatibility issues.
+
+Rancher, especially when managing a growing number of clusters, nodes, and workloads, places a significant load on core Kubernetes components like `etcd` and `kube-apiserver` on the upstream cluster. Third-party software can interfere with the performance of these components and Rancher, potentially leading to instability.
+
+Furthermore, third-party software can functionally interfere with Rancher. To minimize compatibility risks, deploy only essential Kubernetes system components and Rancher on the upstream cluster.
+
+The following applications and components generally do not interfere with Rancher or the Kubernetes system and installing them on the upstream cluster is supported:
+
+* Rancher internal components, such as Fleet
+* Rancher extensions
+* Cluster API components
+* CNIs, CPIs, CSIs
+* Cloud controller managers
+* Observability and monitoring tools (with the exception of prometheus-rancher-exporter)
+* https://documentation.suse.com/cloudnative/suse-private-registry/html/private-registry/pr-introduction.html[SUSE Private Registry]
+
+Note that each of these components has its own minimum resource requirements, which must be met in addition to Rancher's.
+
+SUSE Private Registry, in particular, can require significant bandwidth for serving images. Ensure sufficient bandwidth is available, ideally reserved using Quality of Service (QoS) mechanisms, for Rancher.
+
+For high-scale deployments, consider dedicating separate nodes to non-Rancher software using https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[taints and tolerations] to minimize interference.
+
+Other software can interfere with Rancher and is therefore not supported on the upstream cluster.
+
+Note in particular the following software is known to interfere with Rancher performance at scale:
+
+* https://www.crossplane.io/[CrossPlane]
+* https://argoproj.github.io/cd/[Argo CD]
+* https://fluxcd.io/[Flux]
+* https://github.com/David-VTUK/prometheus-rancher-exporter[prometheus-rancher-exporter] (see https://github.com/David-VTUK/prometheus-rancher-exporter/issues/33[issue 33])
 
 == Make sure nodes are configured correctly for Kubernetes
 

--- a/versions/v2.9/modules/en/pages/installation-and-upgrade/best-practices/tips-for-running-rancher.adoc
+++ b/versions/v2.9/modules/en/pages/installation-and-upgrade/best-practices/tips-for-running-rancher.adoc
@@ -23,23 +23,31 @@ The following applications and components generally do not interfere with Ranche
 * Cluster API components
 * CNIs, CPIs, CSIs
 * Cloud controller managers
-* Observability and monitoring tools (with the exception of prometheus-rancher-exporter)
-* https://documentation.suse.com/cloudnative/suse-private-registry/html/private-registry/pr-introduction.html[SUSE Private Registry]
+* Observability and monitoring tools (except prometheus-rancher-exporter)
 
-Note that each of these components has its own minimum resource requirements, which must be met in addition to Rancher's.
-
-SUSE Private Registry, in particular, can require significant bandwidth for serving images. Ensure sufficient bandwidth is available, ideally reserved using Quality of Service (QoS) mechanisms, for Rancher.
-
-For high-scale deployments, consider dedicating separate nodes to non-Rancher software using https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[taints and tolerations] to minimize interference.
+Note that each of these components has its own minimum resource requirements, which must be met in addition to Rancher's. For high-scale deployments, also consider dedicating separate nodes to non-Rancher software using https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[taints and tolerations] to minimize interference.
 
 Other software can interfere with Rancher and is therefore not supported on the upstream cluster.
 
-Note in particular the following software is known to interfere with Rancher performance at scale:
+Note in particular the following software is known to interfere with Rancher performance:
 
 * https://www.crossplane.io/[CrossPlane]
 * https://argoproj.github.io/cd/[Argo CD]
 * https://fluxcd.io/[Flux]
 * https://github.com/David-VTUK/prometheus-rancher-exporter[prometheus-rancher-exporter] (see https://github.com/David-VTUK/prometheus-rancher-exporter/issues/33[issue 33])
+* Container registries such as SUSE Private Registry, which can require significant bandwidth for serving images
+
+=== Guidance for Container Registries
+
+Container registries, such as SUSE Private Registry, can consume significant network bandwidth when serving images. This demand increases with the number of images, the frequency of image pulls, and the quantity of clusters and container runtimes they serve. Due to this potential for interference with Rancher UI and API traffic, we recommend against running container registries on the same cluster as the Rancher management server.
+
+Regardless of your deployment strategy for a container registry, ensure sufficient bandwidth is available, ideally reserved using Quality of Service (QoS) mechanisms.
+
+Consider the following recommendations based on your needs:
+
+* *Simple Setups (HA Not a Primary Concern):* A container registry deployed as a single Virtual Machine (VM) can be a viable solution.
+* *High Availability (HA) Requirements:* We recommend running the registry in a dedicated Kubernetes cluster. All other clusters should then be configured to pull images from this centralized, HA registry.
+* *Very Large-Scale or Complex Network Topologies:* Multiple registry clusters might be necessary. These can be deployed in a hierarchical or federated model to efficiently distribute images and manage traffic.
 
 == Make sure nodes are configured correctly for Kubernetes
 

--- a/versions/v2.9/modules/en/pages/installation-and-upgrade/best-practices/tuning-rancher-at-scale.adoc
+++ b/versions/v2.9/modules/en/pages/installation-and-upgrade/best-practices/tuning-rancher-at-scale.adoc
@@ -14,25 +14,7 @@ When scaling up Rancher, one typical bottleneck is resource growth in the upstre
 
 === Minimizing Third-Party Software on the Upstream Cluster
 
-Running Rancher at scale can put significant load on internal Kubernetes components, such as `etcd` or `kubeapiserver`. Issues may arise if third-party software interferes with the performance of those components or with Rancher.
-
-Every third-party piece of software carries a risk of interference. To prevent performance issues on the upstream cluster, you should avoid running any other apps or components, beyond Kubernetes system components and Rancher itself.
-
-Software in the following categories generally won't interfere with Rancher or Kubernetes system performance:
-
-* Rancher internal components, such as Fleet
-* Rancher extensions
-* Cluster API components
-* CNIs
-* Cloud controller managers
-* Observability and monitoring tools (with the exception of prometheus-rancher-exporter)
-
-On the other hand, the following software are found to interfere with Rancher performance at scale:
-
-* https://www.crossplane.io/[CrossPlane]
-* https://argoproj.github.io/cd/[Argo CD]
-* https://fluxcd.io/[Flux]
-* https://github.com/David-VTUK/prometheus-rancher-exporter[prometheus-rancher-exporter] (see https://github.com/David-VTUK/prometheus-rancher-exporter/issues/33[issue 33])
+Recommendations outlined in the xref:installation-and-upgrade/best-practices/tips-for-running-rancher.adoc#_minimize_third-party_software_on_the_upstream_cluster[general Rancher recommendations] are particularly important in a high scale context.
 
 === Managing Your Object Counts
 


### PR DESCRIPTION
## Description

Currently we provide recommendations about (not) running third-party software on the upstream cluster for high-scale scenarios only.

This change:
 - moves the recommendations to a general page, extend its applicability from high-scale scenarios to all cases
 - adds notes about compatibility with container registries
 - improves wording a bit

**This is a port of https://github.com/rancher/rancher-docs/pull/1731 with adaptations for the product version**
