### PR TITLE
Fix broken external links

### DIFF
--- a/versions/latest/modules/en/pages/cluster-deployment/infra-providers/vsphere/create-a-vm-template.adoc
+++ b/versions/latest/modules/en/pages/cluster-deployment/infra-providers/vsphere/create-a-vm-template.adoc
@@ -129,7 +129,7 @@ cloud-init clean -s -l
 
 === Windows Preparation
 
-Windows has a utility called https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep--generalize--a-windows-installation[sysprep] that is used to generalize an image and reset the same items listed above for Linux. The command is as follows:
+Windows has a utility called https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep\--generalize\--a-windows-installation?view=windows-11[sysprep] that is used to generalize an image and reset the same items listed above for Linux. The command is as follows:
 
 [,PowerShell]
 ----

--- a/versions/latest/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
+++ b/versions/latest/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
@@ -22,15 +22,12 @@ This Quick Start Guide is divided into different tasks for easier consumption.
 
 == Prerequisites
 
-* An https://metal.equinix.com/developers/docs/accounts/users/[Equinix Metal account]
-* An https://metal.equinix.com/developers/docs/accounts/projects/[Equinix Metal project]
+* An https://deploy.equinix.com/developers/docs/metal/identity-access-management/users/[Equinix Metal account]
+* An https://deploy.equinix.com/developers/docs/metal/projects/creating-a-project/[Equinix Metal project]
 
 === 1. Provision a Equinix Metal Host
 
-Begin deploying an Equinix Metal Host. Equinix Metal Servers can be provisioned from either the Equinix Metal console, API, or CLI. You can find instructions for each deployment type on the https://metal.equinix.com/developers/docs/deploy/on-demand/[Equinix Metal deployment documentation]. You can find additional documentation on Equinix Metal server types and prices below:
-
-* https://metal.equinix.com/developers/docs/servers/about/[Equinix Metal Server Types]
-* https://metal.equinix.com/developers/docs/servers/server-specs/[Equinix Metal Pricing]
+Begin deploying an Equinix Metal Host. Equinix Metal Servers can be provisioned from either the Equinix Metal console, API, or CLI. You can find instructions for each deployment type on the https://deploy.equinix.com/developers/docs/metal/deploy/on-demand/[Equinix Metal deployment documentation]. You can find additional information on Equinix Metal server types in the https://deploy.equinix.com/developers/docs/metal/hardware/standard-servers/[Equinix Metal Documentation].
 
 [NOTE]
 .Notes:

--- a/versions/latest/modules/en/pages/observability/istio/istio.adoc
+++ b/versions/latest/modules/en/pages/observability/istio/istio.adoc
@@ -50,7 +50,7 @@ For Istio installations `103.1.0+up1.19.6` and later, Kiali uses a token value f
 
 Our Istio installer includes a quick-start, all-in-one installation of https://www.jaegertracing.io/[Jaeger,] a tool used for tracing distributed systems.
 
-Note that this is not a production-qualified deployment of Jaeger. This deployment uses an in-memory storage component, while a persistent storage component is recommended for production. For more information on which deployment strategy you may need, refer to the https://www.jaegertracing.io/docs/latest/operator/#production-strategy[Jaeger documentation.]
+Note that this is not a production-qualified deployment of Jaeger. This deployment uses an in-memory storage component, while a persistent storage component is recommended for production. For more information on which deployment strategy you may need, refer to the https://www.jaegertracing.io/docs/1.65/operator/#production-strategy[Jaeger documentation.]
 
 == Prerequisites
 

--- a/versions/latest/modules/en/pages/observability/monitoring-and-dashboards/best-practices.adoc
+++ b/versions/latest/modules/en/pages/observability/monitoring-and-dashboards/best-practices.adoc
@@ -60,7 +60,7 @@ In general, you want to scrape data from all the workloads running in your clust
 
 === About Prometheus Exporters
 
-Many 3rd party workloads, such as databases, queues, and web-servers, already support exposing metrics in a Prometheus format, or offer exporters that translate between the tool's metrics and a format that Prometheus understands. You can usually add these exporters as additional sidecar containers to the workload's Pods. Many Helm charts already include options to deploy the correct exporter. You can find a curated list of exports by SysDig on https://promcat.io/[promcat.io] and on https://exporterhub.io/[ExporterHub].
+Many 3rd party workloads, such as databases, queues, and web-servers, already support exposing metrics in a Prometheus format, or offer exporters that translate between the tool's metrics and a format that Prometheus understands. You can usually add these exporters as additional sidecar containers to the workload's Pods. Many Helm charts already include options to deploy the correct exporter. You can find a curated list of exports on https://exporterhub.io/[ExporterHub].
 
 === Prometheus support in Programming Languages and Frameworks
 

--- a/versions/latest/modules/en/pages/observability/monitoring-and-dashboards/configuration/examples.adoc
+++ b/versions/latest/modules/en/pages/observability/monitoring-and-dashboards/configuration/examples.adoc
@@ -6,7 +6,7 @@ See the official prometheus-operator GitHub repo for an example https://github.c
 
 == PodMonitor
 
-See the https://prometheus-operator.dev/docs/user-guides/getting-started/#using-podmonitors[Prometheus Operator documentation] for an example PodMonitor and an example Prometheus resource that refers to a PodMonitor.
+See the https://prometheus-operator.dev/docs/developer/getting-started/#using-podmonitors[Prometheus Operator documentation] for an example PodMonitor and an example Prometheus resource that refers to a PodMonitor.
 
 == PrometheusRule
 
@@ -14,7 +14,7 @@ A PrometheusRule contains the alerting and recording rules that you would usuall
 
 For a more fine-grained approach, the `ruleSelector` field on a Prometheus resource can select which PrometheusRules should be loaded onto Prometheus, based on the labels attached to the PrometheusRules resources.
 
-See the https://prometheus-operator.dev/docs/user-guides/alerting/[Prometheus Operator documentation] for an example PrometheusRule.
+See the https://prometheus-operator.dev/docs/developer/alerting/[Prometheus Operator documentation] for an example PrometheusRule.
 
 == Alertmanager Config
 

--- a/versions/latest/modules/en/pages/rancher-admin/users/authn-and-authz/configure-azure-ad.adoc
+++ b/versions/latest/modules/en/pages/rancher-admin/users/authn-and-authz/configure-azure-ad.adoc
@@ -210,7 +210,7 @@ The following table maps the values you copied in the Azure portal to the fields
 | Key Value
 
 | Endpoint
-| https://login.microsoftonline.com/
+| \https://login.microsoftonline.com/
 |===
 +
 *For Custom Endpoints:*
@@ -300,32 +300,32 @@ If you upgrade to Rancher v2.7.0+ with an existing Azure AD setup, and choose to
 | Rancher Field | Deprecated Endpoints
 
 | Auth Endpoint
-| https://login.microsoftonline.com/\{tenantID}/oauth2/authorize
+| \https://login.microsoftonline.com/\{tenantID}/oauth2/authorize
 
 | Endpoint
-| https://login.microsoftonline.com/
+| \https://login.microsoftonline.com/
 
 | Graph Endpoint
-| https://graph.windows.net/
+| \https://graph.windows.net/
 
 | Token Endpoint
-| https://login.microsoftonline.com/\{tenantID}/oauth2/token
+| \https://login.microsoftonline.com/\{tenantID}/oauth2/token
 |===
 
 |===
 | Rancher Field | New Endpoints
 
 | Auth Endpoint
-| https://login.microsoftonline.com/\{tenantID}/oauth2/v2.0/authorize
+| \https://login.microsoftonline.com/\{tenantID}/oauth2/v2.0/authorize
 
 | Endpoint
-| https://login.microsoftonline.com/
+| \https://login.microsoftonline.com/
 
 | Graph Endpoint
-| https://graph.microsoft.com
+| \https://graph.microsoft.com
 
 | Token Endpoint
-| https://login.microsoftonline.com/\{tenantID}/oauth2/v2.0/token
+| \https://login.microsoftonline.com/\{tenantID}/oauth2/v2.0/token
 |===
 
 ==== China:
@@ -334,32 +334,32 @@ If you upgrade to Rancher v2.7.0+ with an existing Azure AD setup, and choose to
 | Rancher Field | Deprecated Endpoints
 
 | Auth Endpoint
-| https://login.chinacloudapi.cn/\{tenantID}/oauth2/authorize
+| \https://login.chinacloudapi.cn/\{tenantID}/oauth2/authorize
 
 | Endpoint
-| https://login.chinacloudapi.cn/
+| \https://login.chinacloudapi.cn/
 
 | Graph Endpoint
-| https://graph.chinacloudapi.cn/
+| \https://graph.chinacloudapi.cn/
 
 | Token Endpoint
-| https://login.chinacloudapi.cn/\{tenantID}/oauth2/token
+| \https://login.chinacloudapi.cn/\{tenantID}/oauth2/token
 |===
 
 |===
 | Rancher Field | New Endpoints
 
 | Auth Endpoint
-| https://login.partner.microsoftonline.cn/\{tenantID}/oauth2/v2.0/authorize
+| \https://login.partner.microsoftonline.cn/\{tenantID}/oauth2/v2.0/authorize
 
 | Endpoint
-| https://login.partner.microsoftonline.cn/
+| \https://login.partner.microsoftonline.cn/
 
 | Graph Endpoint
-| https://microsoftgraph.chinacloudapi.cn
+| \https://microsoftgraph.chinacloudapi.cn
 
 | Token Endpoint
-| https://login.partner.microsoftonline.cn/\{tenantID}/oauth2/v2.0/token
+| \https://login.partner.microsoftonline.cn/\{tenantID}/oauth2/v2.0/token
 |===
 
 == Filtering Users by Azure AD Auth Group Memberships

--- a/versions/latest/modules/zh/pages/cluster-deployment/infra-providers/vsphere/create-a-vm-template.adoc
+++ b/versions/latest/modules/zh/pages/cluster-deployment/infra-providers/vsphere/create-a-vm-template.adoc
@@ -130,7 +130,7 @@ cloud-init clean -s -l
 
 === Windows 准备
 
-Windows 有一个名为 https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep--generalize--a-windows-installation[sysprep] 的实用程序，用于一般化镜像并重置上述 Linux 项目。命令如下：
+Windows 有一个名为 https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep\--generalize\--a-windows-installation?view=windows-11[sysprep] 的实用程序，用于一般化镜像并重置上述 Linux 项目。命令如下：
 
 [,PowerShell]
 ----

--- a/versions/latest/modules/zh/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
+++ b/versions/latest/modules/zh/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
@@ -22,14 +22,14 @@
 
 == 先决条件
 
-* https://metal.equinix.com/developers/docs/accounts/users/[Equinix Metal 账号]
-* https://metal.equinix.com/developers/docs/accounts/projects/[Equinix Metal 项目]
+* https://deploy.equinix.com/developers/docs/metal/identity-access-management/users/[Equinix Metal 账号]
+* https://deploy.equinix.com/developers/docs/metal/projects/creating-a-project/[Equinix Metal 项目]
 
 === 1. 配置 Equinix Metal 主机
 
-开始部署 Equinix Metal 主机。你可以使用 Equinix Metal 控制台、CLI 或 API 来配置 Equinix Metal Server。如果你需要了解每种 Deployment 类型的说明，请参见 https://metal.equinix.com/developers/docs/deploy/on-demand/[Equinix Metal 部署]。以下链接介绍 Equinix Metal Server 的类型以及价格：
+开始部署 Equinix Metal 主机。你可以使用 Equinix Metal 控制台、CLI 或 API 来配置 Equinix Metal Server。如果你需要了解每种 Deployment 类型的说明，请参见 https://deploy.equinix.com/developers/docs/metal/deploy/on-demand/[Equinix Metal 部署]。以下链接介绍 Equinix Metal Server 的类型以及价格：
 
-* https://metal.equinix.com/developers/docs/servers/about/[Equinix Metal Server 类型]
+* https://deploy.equinix.com/developers/docs/metal/hardware/standard-servers/[Equinix Metal Server 类型]
 * https://metal.equinix.com/developers/docs/servers/server-specs/[Equinix Metal 价格]
 
 [NOTE]

--- a/versions/latest/modules/zh/pages/observability/istio/istio.adoc
+++ b/versions/latest/modules/zh/pages/observability/istio/istio.adoc
@@ -45,7 +45,7 @@ Kiali 是一个全面的可视化辅助工具，用于绘制整个服务网格�
 
 Jaeger 是用于跟踪分布式系统的工具。我们的 Istio 安装程序包括能快速启动的一体化 https://www.jaegertracing.io/[Jaeger] 安装。
 
-请注意，这不是符合 Jaeger 生产要求的部署。此部署使用在内存中的存储组件，而 Jaeger 推荐在生产环境中使用持久存储组件。有关你所需的部署策略的更多信息，请参阅 https://www.jaegertracing.io/docs/latest/operator/#production-strategy[Jaeger 文档]。
+请注意，这不是符合 Jaeger 生产要求的部署。此部署使用在内存中的存储组件，而 Jaeger 推荐在生产环境中使用持久存储组件。有关你所需的部署策略的更多信息，请参阅 https://www.jaegertracing.io/docs/1.65/operator/#production-strategy[Jaeger 文档]。
 
 == 先决条件
 

--- a/versions/latest/modules/zh/pages/observability/monitoring-and-dashboards/best-practices.adoc
+++ b/versions/latest/modules/zh/pages/observability/monitoring-and-dashboards/best-practices.adoc
@@ -60,7 +60,7 @@ Prometheus 不是用于长期存储指标的，它只用于短期存储。
 
 === 关于 Prometheus Exporters
 
-许多第三方工作负载（如数据库、队列或 Web 服务器）要么已经支持以 Prometheus 格式公开指标，要么有所谓的 exporter，来对工具的指标格式和 Prometheus 理解的指标格式进行转换。通常，你可以将这些 exporter 作为额外的 Sidecar 容器添加到工作负载的 Pod 中。很多 Helm Chart 已经包含了部署 exporter 的选项。此外，你还可以在 https://promcat.io/[promcat.io] 和 https://exporterhub.io/[ExporterHub] 上找到一个由 SysDig 策划的 exporter 列表。
+许多第三方工作负载（如数据库、队列或 Web 服务器）要么已经支持以 Prometheus 格式公开指标，要么有所谓的 exporter，来对工具的指标格式和 Prometheus 理解的指标格式进行转换。通常，你可以将这些 exporter 作为额外的 Sidecar 容器添加到工作负载的 Pod 中。很多 Helm Chart 已经包含了部署 exporter 的选项。此外，你还可以在 https://exporterhub.io/[ExporterHub] 上找到策划的 exporter 列表。
 
 === Prometheus 的编程语言和框架支持
 

--- a/versions/latest/modules/zh/pages/observability/monitoring-and-dashboards/configuration/examples.adoc
+++ b/versions/latest/modules/zh/pages/observability/monitoring-and-dashboards/configuration/examples.adoc
@@ -6,7 +6,7 @@
 
 == PodMonitor
 
-你可以在link:https://github.com/prometheus-operator/prometheus-operator/blob/master/example/user-guides/getting-started/example-app-pod-monitor.yaml[此处]找到 PodMonitor 示例，还可以在link:https://github.com/prometheus-operator/prometheus-operator/blob/master/example/user-guides/getting-started/prometheus-pod-monitor.yaml[此处]找到引用它的 Prometheus 资源示例。
+你可以在link:https://prometheus-operator.dev/docs/developer/getting-started/#using-podmonitors[此处]找到 PodMonitor 示例和引用它的 Prometheus 资源示例。
 
 == PrometheusRule
 
@@ -14,7 +14,7 @@ PrometheusRule 包含你通常放置在 https://prometheus.io/docs/prometheus/la
 
 要在集群中更细粒度地应用 PrometheusRules，你可以使用 Prometheus 资源的 ruleSelector 字段，从而根据添加到 PrometheusRules 资源的标签来选择要加载到 Prometheus 上的 PrometheusRule。
 
-你可以在link:https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/user-guides/alerting.md[此页面]找到 PrometheusRule 示例。
+你可以在link:https://prometheus-operator.dev/docs/developer/alerting/[此页面]找到 PrometheusRule 示例。
 
 == Alertmanager 配置
 

--- a/versions/latest/modules/zh/pages/rancher-admin/users/authn-and-authz/configure-azure-ad.adoc
+++ b/versions/latest/modules/zh/pages/rancher-admin/users/authn-and-authz/configure-azure-ad.adoc
@@ -201,7 +201,7 @@ Azure AD 帐户将被授予管理员权限，因为其详细信息将映射到 R
 | Key Value
 
 | 端点
-| https://login.microsoftonline.com/
+| \https://login.microsoftonline.com/
 |===
 +
 *对于自定义端点*：
@@ -286,32 +286,32 @@ image::azure-update-popup.png[Azure 更新弹出窗口]
 | Rancher 字段 | 已弃用的端点
 
 | Auth 端点
-| https://login.microsoftonline.com/\{tenantID}/oauth2/authorize
+| \https://login.microsoftonline.com/\{tenantID}/oauth2/authorize
 
 | 端点
-| https://login.microsoftonline.com/
+| \https://login.microsoftonline.com/
 
 | Graph 端点
-| https://graph.windows.net/
+| \https://graph.windows.net/
 
 | Token 端点
-| https://login.microsoftonline.com/\{tenantID}/oauth2/token
+| \https://login.microsoftonline.com/\{tenantID}/oauth2/token
 |===
 
 |===
 | Rancher 字段 | 新端点
 
 | Auth 端点
-| https://login.microsoftonline.com/\{tenantID}/oauth2/v2.0/authorize
+| \https://login.microsoftonline.com/\{tenantID}/oauth2/v2.0/authorize
 
 | 端点
-| https://login.microsoftonline.com/
+| \https://login.microsoftonline.com/
 
 | Graph 端点
-| https://graph.microsoft.com
+| \https://graph.microsoft.com
 
 | Token 端点
-| https://login.microsoftonline.com/\{tenantID}/oauth2/v2.0/token
+| \https://login.microsoftonline.com/\{tenantID}/oauth2/v2.0/token
 |===
 
 ==== 中国：
@@ -320,32 +320,32 @@ image::azure-update-popup.png[Azure 更新弹出窗口]
 | Rancher 字段 | 已弃用的端点
 
 | Auth 端点
-| https://login.chinacloudapi.cn/\{tenantID}/oauth2/authorize
+| \https://login.chinacloudapi.cn/\{tenantID}/oauth2/authorize
 
 | 端点
-| https://login.chinacloudapi.cn/
+| \https://login.chinacloudapi.cn/
 
 | Graph 端点
-| https://graph.chinacloudapi.cn/
+| \https://graph.chinacloudapi.cn/
 
 | Token 端点
-| https://login.chinacloudapi.cn/\{tenantID}/oauth2/token
+| \https://login.chinacloudapi.cn/\{tenantID}/oauth2/token
 |===
 
 |===
 | Rancher 字段 | 新端点
 
 | Auth 端点
-| https://login.partner.microsoftonline.cn/\{tenantID}/oauth2/v2.0/authorize
+| \https://login.partner.microsoftonline.cn/\{tenantID}/oauth2/v2.0/authorize
 
 | 端点
-| https://login.partner.microsoftonline.cn/
+| \https://login.partner.microsoftonline.cn/
 
 | Graph 端点
-| https://microsoftgraph.chinacloudapi.cn
+| \https://microsoftgraph.chinacloudapi.cn
 
 | Token 端点
-| https://login.partner.microsoftonline.cn/\{tenantID}/oauth2/v2.0/token
+| \https://login.partner.microsoftonline.cn/\{tenantID}/oauth2/v2.0/token
 |===
 
 == 已弃用的 Azure AD Graph API

--- a/versions/v2.10/modules/en/pages/cluster-deployment/infra-providers/vsphere/create-a-vm-template.adoc
+++ b/versions/v2.10/modules/en/pages/cluster-deployment/infra-providers/vsphere/create-a-vm-template.adoc
@@ -129,7 +129,7 @@ cloud-init clean -s -l
 
 === Windows Preparation
 
-Windows has a utility called https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep--generalize--a-windows-installation[sysprep] that is used to generalize an image and reset the same items listed above for Linux. The command is as follows:
+Windows has a utility called https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep\--generalize\--a-windows-installation?view=windows-11[sysprep] that is used to generalize an image and reset the same items listed above for Linux. The command is as follows:
 
 [,PowerShell]
 ----

--- a/versions/v2.10/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
+++ b/versions/v2.10/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
@@ -22,15 +22,12 @@ This Quick Start Guide is divided into different tasks for easier consumption.
 
 == Prerequisites
 
-* An https://metal.equinix.com/developers/docs/accounts/users/[Equinix Metal account]
-* An https://metal.equinix.com/developers/docs/accounts/projects/[Equinix Metal project]
+* An https://deploy.equinix.com/developers/docs/metal/identity-access-management/users/[Equinix Metal account]
+* An https://deploy.equinix.com/developers/docs/metal/projects/creating-a-project/[Equinix Metal project]
 
 === 1. Provision a Equinix Metal Host
 
-Begin deploying an Equinix Metal Host. Equinix Metal Servers can be provisioned from either the Equinix Metal console, API, or CLI. You can find instructions for each deployment type on the https://metal.equinix.com/developers/docs/deploy/on-demand/[Equinix Metal deployment documentation]. You can find additional documentation on Equinix Metal server types and prices below:
-
-* https://metal.equinix.com/developers/docs/servers/about/[Equinix Metal Server Types]
-* https://metal.equinix.com/developers/docs/servers/server-specs/[Equinix Metal Pricing]
+Begin deploying an Equinix Metal Host. Equinix Metal Servers can be provisioned from either the Equinix Metal console, API, or CLI. You can find instructions for each deployment type on the https://deploy.equinix.com/developers/docs/metal/deploy/on-demand/[Equinix Metal deployment documentation]. You can find additional information on Equinix Metal server types in the https://deploy.equinix.com/developers/docs/metal/hardware/standard-servers/[Equinix Metal Documentation].
 
 [NOTE]
 .Notes:

--- a/versions/v2.10/modules/en/pages/observability/istio/istio.adoc
+++ b/versions/v2.10/modules/en/pages/observability/istio/istio.adoc
@@ -50,7 +50,7 @@ For Istio installations `103.1.0+up1.19.6` and later, Kiali uses a token value f
 
 Our Istio installer includes a quick-start, all-in-one installation of https://www.jaegertracing.io/[Jaeger,] a tool used for tracing distributed systems.
 
-Note that this is not a production-qualified deployment of Jaeger. This deployment uses an in-memory storage component, while a persistent storage component is recommended for production. For more information on which deployment strategy you may need, refer to the https://www.jaegertracing.io/docs/latest/operator/#production-strategy[Jaeger documentation.]
+Note that this is not a production-qualified deployment of Jaeger. This deployment uses an in-memory storage component, while a persistent storage component is recommended for production. For more information on which deployment strategy you may need, refer to the https://www.jaegertracing.io/docs/1.65/operator/#production-strategy[Jaeger documentation.]
 
 == Prerequisites
 

--- a/versions/v2.10/modules/en/pages/observability/monitoring-and-dashboards/best-practices.adoc
+++ b/versions/v2.10/modules/en/pages/observability/monitoring-and-dashboards/best-practices.adoc
@@ -60,7 +60,7 @@ In general, you want to scrape data from all the workloads running in your clust
 
 === About Prometheus Exporters
 
-Many 3rd party workloads, such as databases, queues, and web-servers, already support exposing metrics in a Prometheus format, or offer exporters that translate between the tool's metrics and a format that Prometheus understands. You can usually add these exporters as additional sidecar containers to the workload's Pods. Many Helm charts already include options to deploy the correct exporter. You can find a curated list of exports by SysDig on https://promcat.io/[promcat.io] and on https://exporterhub.io/[ExporterHub].
+Many 3rd party workloads, such as databases, queues, and web-servers, already support exposing metrics in a Prometheus format, or offer exporters that translate between the tool's metrics and a format that Prometheus understands. You can usually add these exporters as additional sidecar containers to the workload's Pods. Many Helm charts already include options to deploy the correct exporter. You can find a curated list of exports on https://exporterhub.io/[ExporterHub].
 
 === Prometheus support in Programming Languages and Frameworks
 

--- a/versions/v2.10/modules/en/pages/observability/monitoring-and-dashboards/configuration/examples.adoc
+++ b/versions/v2.10/modules/en/pages/observability/monitoring-and-dashboards/configuration/examples.adoc
@@ -6,7 +6,7 @@ See the official prometheus-operator GitHub repo for an example https://github.c
 
 == PodMonitor
 
-See the https://prometheus-operator.dev/docs/user-guides/getting-started/#using-podmonitors[Prometheus Operator documentation] for an example PodMonitor and an example Prometheus resource that refers to a PodMonitor.
+See the https://prometheus-operator.dev/docs/developer/getting-started/#using-podmonitors[Prometheus Operator documentation] for an example PodMonitor and an example Prometheus resource that refers to a PodMonitor.
 
 == PrometheusRule
 
@@ -14,7 +14,7 @@ A PrometheusRule contains the alerting and recording rules that you would usuall
 
 For a more fine-grained approach, the `ruleSelector` field on a Prometheus resource can select which PrometheusRules should be loaded onto Prometheus, based on the labels attached to the PrometheusRules resources.
 
-See the https://prometheus-operator.dev/docs/user-guides/alerting/[Prometheus Operator documentation] for an example PrometheusRule.
+See the https://prometheus-operator.dev/docs/developer/alerting/[Prometheus Operator documentation] for an example PrometheusRule.
 
 == Alertmanager Config
 

--- a/versions/v2.10/modules/en/pages/rancher-admin/users/authn-and-authz/configure-azure-ad.adoc
+++ b/versions/v2.10/modules/en/pages/rancher-admin/users/authn-and-authz/configure-azure-ad.adoc
@@ -210,7 +210,7 @@ The following table maps the values you copied in the Azure portal to the fields
 | Key Value
 
 | Endpoint
-| https://login.microsoftonline.com/
+| \https://login.microsoftonline.com/
 |===
 +
 *For Custom Endpoints:*
@@ -300,32 +300,32 @@ If you upgrade to Rancher v2.7.0+ with an existing Azure AD setup, and choose to
 | Rancher Field | Deprecated Endpoints
 
 | Auth Endpoint
-| https://login.microsoftonline.com/\{tenantID}/oauth2/authorize
+| \https://login.microsoftonline.com/\{tenantID}/oauth2/authorize
 
 | Endpoint
-| https://login.microsoftonline.com/
+| \https://login.microsoftonline.com/
 
 | Graph Endpoint
-| https://graph.windows.net/
+| \https://graph.windows.net/
 
 | Token Endpoint
-| https://login.microsoftonline.com/\{tenantID}/oauth2/token
+| \https://login.microsoftonline.com/\{tenantID}/oauth2/token
 |===
 
 |===
 | Rancher Field | New Endpoints
 
 | Auth Endpoint
-| https://login.microsoftonline.com/\{tenantID}/oauth2/v2.0/authorize
+| \https://login.microsoftonline.com/\{tenantID}/oauth2/v2.0/authorize
 
 | Endpoint
-| https://login.microsoftonline.com/
+| \https://login.microsoftonline.com/
 
 | Graph Endpoint
-| https://graph.microsoft.com
+| \https://graph.microsoft.com
 
 | Token Endpoint
-| https://login.microsoftonline.com/\{tenantID}/oauth2/v2.0/token
+| \https://login.microsoftonline.com/\{tenantID}/oauth2/v2.0/token
 |===
 
 ==== China:
@@ -334,32 +334,32 @@ If you upgrade to Rancher v2.7.0+ with an existing Azure AD setup, and choose to
 | Rancher Field | Deprecated Endpoints
 
 | Auth Endpoint
-| https://login.chinacloudapi.cn/\{tenantID}/oauth2/authorize
+| \https://login.chinacloudapi.cn/\{tenantID}/oauth2/authorize
 
 | Endpoint
-| https://login.chinacloudapi.cn/
+| \https://login.chinacloudapi.cn/
 
 | Graph Endpoint
-| https://graph.chinacloudapi.cn/
+| \https://graph.chinacloudapi.cn/
 
 | Token Endpoint
-| https://login.chinacloudapi.cn/\{tenantID}/oauth2/token
+| \https://login.chinacloudapi.cn/\{tenantID}/oauth2/token
 |===
 
 |===
 | Rancher Field | New Endpoints
 
 | Auth Endpoint
-| https://login.partner.microsoftonline.cn/\{tenantID}/oauth2/v2.0/authorize
+| \https://login.partner.microsoftonline.cn/\{tenantID}/oauth2/v2.0/authorize
 
 | Endpoint
-| https://login.partner.microsoftonline.cn/
+| \https://login.partner.microsoftonline.cn/
 
 | Graph Endpoint
-| https://microsoftgraph.chinacloudapi.cn
+| \https://microsoftgraph.chinacloudapi.cn
 
 | Token Endpoint
-| https://login.partner.microsoftonline.cn/\{tenantID}/oauth2/v2.0/token
+| \https://login.partner.microsoftonline.cn/\{tenantID}/oauth2/v2.0/token
 |===
 
 == Filtering Users by Azure AD Auth Group Memberships

--- a/versions/v2.10/modules/zh/pages/cluster-deployment/infra-providers/vsphere/create-a-vm-template.adoc
+++ b/versions/v2.10/modules/zh/pages/cluster-deployment/infra-providers/vsphere/create-a-vm-template.adoc
@@ -130,7 +130,7 @@ cloud-init clean -s -l
 
 === Windows 准备
 
-Windows 有一个名为 https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep--generalize--a-windows-installation[sysprep] 的实用程序，用于一般化镜像并重置上述 Linux 项目。命令如下：
+Windows 有一个名为 https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep\--generalize\--a-windows-installation?view=windows-11[sysprep] 的实用程序，用于一般化镜像并重置上述 Linux 项目。命令如下：
 
 [,PowerShell]
 ----

--- a/versions/v2.10/modules/zh/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
+++ b/versions/v2.10/modules/zh/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
@@ -22,14 +22,14 @@
 
 == 先决条件
 
-* https://metal.equinix.com/developers/docs/accounts/users/[Equinix Metal 账号]
-* https://metal.equinix.com/developers/docs/accounts/projects/[Equinix Metal 项目]
+* https://deploy.equinix.com/developers/docs/metal/identity-access-management/users/[Equinix Metal 账号]
+* https://deploy.equinix.com/developers/docs/metal/projects/creating-a-project/[Equinix Metal 项目]
 
 === 1. 配置 Equinix Metal 主机
 
-开始部署 Equinix Metal 主机。你可以使用 Equinix Metal 控制台、CLI 或 API 来配置 Equinix Metal Server。如果你需要了解每种 Deployment 类型的说明，请参见 https://metal.equinix.com/developers/docs/deploy/on-demand/[Equinix Metal 部署]。以下链接介绍 Equinix Metal Server 的类型以及价格：
+开始部署 Equinix Metal 主机。你可以使用 Equinix Metal 控制台、CLI 或 API 来配置 Equinix Metal Server。如果你需要了解每种 Deployment 类型的说明，请参见 https://deploy.equinix.com/developers/docs/metal/deploy/on-demand/[Equinix Metal 部署]。以下链接介绍 Equinix Metal Server 的类型以及价格：
 
-* https://metal.equinix.com/developers/docs/servers/about/[Equinix Metal Server 类型]
+* https://deploy.equinix.com/developers/docs/metal/hardware/standard-servers/[Equinix Metal Server 类型]
 * https://metal.equinix.com/developers/docs/servers/server-specs/[Equinix Metal 价格]
 
 [NOTE]

--- a/versions/v2.10/modules/zh/pages/observability/istio/istio.adoc
+++ b/versions/v2.10/modules/zh/pages/observability/istio/istio.adoc
@@ -45,7 +45,7 @@ Kiali 是一个全面的可视化辅助工具，用于绘制整个服务网格�
 
 Jaeger 是用于跟踪分布式系统的工具。我们的 Istio 安装程序包括能快速启动的一体化 https://www.jaegertracing.io/[Jaeger] 安装。
 
-请注意，这不是符合 Jaeger 生产要求的部署。此部署使用在内存中的存储组件，而 Jaeger 推荐在生产环境中使用持久存储组件。有关你所需的部署策略的更多信息，请参阅 https://www.jaegertracing.io/docs/latest/operator/#production-strategy[Jaeger 文档]。
+请注意，这不是符合 Jaeger 生产要求的部署。此部署使用在内存中的存储组件，而 Jaeger 推荐在生产环境中使用持久存储组件。有关你所需的部署策略的更多信息，请参阅 https://www.jaegertracing.io/docs/1.65/operator/#production-strategy[Jaeger 文档]。
 
 == 先决条件
 

--- a/versions/v2.10/modules/zh/pages/observability/monitoring-and-dashboards/best-practices.adoc
+++ b/versions/v2.10/modules/zh/pages/observability/monitoring-and-dashboards/best-practices.adoc
@@ -60,7 +60,7 @@ Prometheus 不是用于长期存储指标的，它只用于短期存储。
 
 === 关于 Prometheus Exporters
 
-许多第三方工作负载（如数据库、队列或 Web 服务器）要么已经支持以 Prometheus 格式公开指标，要么有所谓的 exporter，来对工具的指标格式和 Prometheus 理解的指标格式进行转换。通常，你可以将这些 exporter 作为额外的 Sidecar 容器添加到工作负载的 Pod 中。很多 Helm Chart 已经包含了部署 exporter 的选项。此外，你还可以在 https://promcat.io/[promcat.io] 和 https://exporterhub.io/[ExporterHub] 上找到一个由 SysDig 策划的 exporter 列表。
+许多第三方工作负载（如数据库、队列或 Web 服务器）要么已经支持以 Prometheus 格式公开指标，要么有所谓的 exporter，来对工具的指标格式和 Prometheus 理解的指标格式进行转换。通常，你可以将这些 exporter 作为额外的 Sidecar 容器添加到工作负载的 Pod 中。很多 Helm Chart 已经包含了部署 exporter 的选项。此外，你还可以在 https://exporterhub.io/[ExporterHub] 上找到策划的 exporter 列表。
 
 === Prometheus 的编程语言和框架支持
 

--- a/versions/v2.10/modules/zh/pages/observability/monitoring-and-dashboards/configuration/examples.adoc
+++ b/versions/v2.10/modules/zh/pages/observability/monitoring-and-dashboards/configuration/examples.adoc
@@ -6,7 +6,7 @@
 
 == PodMonitor
 
-你可以在link:https://github.com/prometheus-operator/prometheus-operator/blob/master/example/user-guides/getting-started/example-app-pod-monitor.yaml[此处]找到 PodMonitor 示例，还可以在link:https://github.com/prometheus-operator/prometheus-operator/blob/master/example/user-guides/getting-started/prometheus-pod-monitor.yaml[此处]找到引用它的 Prometheus 资源示例。
+你可以在link:https://prometheus-operator.dev/docs/developer/getting-started/#using-podmonitors[此处]找到 PodMonitor 示例和引用它的 Prometheus 资源示例。
 
 == PrometheusRule
 
@@ -14,7 +14,7 @@ PrometheusRule 包含你通常放置在 https://prometheus.io/docs/prometheus/la
 
 要在集群中更细粒度地应用 PrometheusRules，你可以使用 Prometheus 资源的 ruleSelector 字段，从而根据添加到 PrometheusRules 资源的标签来选择要加载到 Prometheus 上的 PrometheusRule。
 
-你可以在link:https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/user-guides/alerting.md[此页面]找到 PrometheusRule 示例。
+你可以在link:https://prometheus-operator.dev/docs/developer/alerting/[此页面]找到 PrometheusRule 示例。
 
 == Alertmanager 配置
 

--- a/versions/v2.10/modules/zh/pages/rancher-admin/users/authn-and-authz/configure-azure-ad.adoc
+++ b/versions/v2.10/modules/zh/pages/rancher-admin/users/authn-and-authz/configure-azure-ad.adoc
@@ -201,7 +201,7 @@ Azure AD 帐户将被授予管理员权限，因为其详细信息将映射到 R
 | Key Value
 
 | 端点
-| https://login.microsoftonline.com/
+| \https://login.microsoftonline.com/
 |===
 +
 *对于自定义端点*：
@@ -286,32 +286,32 @@ image::azure-update-popup.png[Azure 更新弹出窗口]
 | Rancher 字段 | 已弃用的端点
 
 | Auth 端点
-| https://login.microsoftonline.com/\{tenantID}/oauth2/authorize
+| \https://login.microsoftonline.com/\{tenantID}/oauth2/authorize
 
 | 端点
-| https://login.microsoftonline.com/
+| \https://login.microsoftonline.com/
 
 | Graph 端点
-| https://graph.windows.net/
+| \https://graph.windows.net/
 
 | Token 端点
-| https://login.microsoftonline.com/\{tenantID}/oauth2/token
+| \https://login.microsoftonline.com/\{tenantID}/oauth2/token
 |===
 
 |===
 | Rancher 字段 | 新端点
 
 | Auth 端点
-| https://login.microsoftonline.com/\{tenantID}/oauth2/v2.0/authorize
+| \https://login.microsoftonline.com/\{tenantID}/oauth2/v2.0/authorize
 
 | 端点
-| https://login.microsoftonline.com/
+| \https://login.microsoftonline.com/
 
 | Graph 端点
-| https://graph.microsoft.com
+| \https://graph.microsoft.com
 
 | Token 端点
-| https://login.microsoftonline.com/\{tenantID}/oauth2/v2.0/token
+| \https://login.microsoftonline.com/\{tenantID}/oauth2/v2.0/token
 |===
 
 ==== 中国：
@@ -320,32 +320,32 @@ image::azure-update-popup.png[Azure 更新弹出窗口]
 | Rancher 字段 | 已弃用的端点
 
 | Auth 端点
-| https://login.chinacloudapi.cn/\{tenantID}/oauth2/authorize
+| \https://login.chinacloudapi.cn/\{tenantID}/oauth2/authorize
 
 | 端点
-| https://login.chinacloudapi.cn/
+| \https://login.chinacloudapi.cn/
 
 | Graph 端点
-| https://graph.chinacloudapi.cn/
+| \https://graph.chinacloudapi.cn/
 
 | Token 端点
-| https://login.chinacloudapi.cn/\{tenantID}/oauth2/token
+| \https://login.chinacloudapi.cn/\{tenantID}/oauth2/token
 |===
 
 |===
 | Rancher 字段 | 新端点
 
 | Auth 端点
-| https://login.partner.microsoftonline.cn/\{tenantID}/oauth2/v2.0/authorize
+| \https://login.partner.microsoftonline.cn/\{tenantID}/oauth2/v2.0/authorize
 
 | 端点
-| https://login.partner.microsoftonline.cn/
+| \https://login.partner.microsoftonline.cn/
 
 | Graph 端点
-| https://microsoftgraph.chinacloudapi.cn
+| \https://microsoftgraph.chinacloudapi.cn
 
 | Token 端点
-| https://login.partner.microsoftonline.cn/\{tenantID}/oauth2/v2.0/token
+| \https://login.partner.microsoftonline.cn/\{tenantID}/oauth2/v2.0/token
 |===
 
 == 已弃用的 Azure AD Graph API

--- a/versions/v2.11/modules/en/pages/cluster-deployment/infra-providers/vsphere/create-a-vm-template.adoc
+++ b/versions/v2.11/modules/en/pages/cluster-deployment/infra-providers/vsphere/create-a-vm-template.adoc
@@ -129,7 +129,7 @@ cloud-init clean -s -l
 
 === Windows Preparation
 
-Windows has a utility called https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep--generalize--a-windows-installation[sysprep] that is used to generalize an image and reset the same items listed above for Linux. The command is as follows:
+Windows has a utility called https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep\--generalize\--a-windows-installation?view=windows-11[sysprep] that is used to generalize an image and reset the same items listed above for Linux. The command is as follows:
 
 [,PowerShell]
 ----

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
@@ -22,15 +22,12 @@ This Quick Start Guide is divided into different tasks for easier consumption.
 
 == Prerequisites
 
-* An https://metal.equinix.com/developers/docs/accounts/users/[Equinix Metal account]
-* An https://metal.equinix.com/developers/docs/accounts/projects/[Equinix Metal project]
+* An https://deploy.equinix.com/developers/docs/metal/identity-access-management/users/[Equinix Metal account]
+* An https://deploy.equinix.com/developers/docs/metal/projects/creating-a-project/[Equinix Metal project]
 
 === 1. Provision a Equinix Metal Host
 
-Begin deploying an Equinix Metal Host. Equinix Metal Servers can be provisioned from either the Equinix Metal console, API, or CLI. You can find instructions for each deployment type on the https://metal.equinix.com/developers/docs/deploy/on-demand/[Equinix Metal deployment documentation]. You can find additional documentation on Equinix Metal server types and prices below:
-
-* https://metal.equinix.com/developers/docs/servers/about/[Equinix Metal Server Types]
-* https://metal.equinix.com/developers/docs/servers/server-specs/[Equinix Metal Pricing]
+Begin deploying an Equinix Metal Host. Equinix Metal Servers can be provisioned from either the Equinix Metal console, API, or CLI. You can find instructions for each deployment type on the https://deploy.equinix.com/developers/docs/metal/deploy/on-demand/[Equinix Metal deployment documentation]. You can find additional information on Equinix Metal server types in the https://deploy.equinix.com/developers/docs/metal/hardware/standard-servers/[Equinix Metal Documentation].
 
 [NOTE]
 .Notes:

--- a/versions/v2.11/modules/en/pages/observability/istio/istio.adoc
+++ b/versions/v2.11/modules/en/pages/observability/istio/istio.adoc
@@ -57,7 +57,7 @@ For Istio installations `103.1.0+up1.19.6` and later, Kiali uses a token value f
 
 Our Istio installer includes a quick-start, all-in-one installation of https://www.jaegertracing.io/[Jaeger,] a tool used for tracing distributed systems.
 
-Note that this is not a production-qualified deployment of Jaeger. This deployment uses an in-memory storage component, while a persistent storage component is recommended for production. For more information on which deployment strategy you may need, refer to the https://www.jaegertracing.io/docs/latest/operator/#production-strategy[Jaeger documentation.]
+Note that this is not a production-qualified deployment of Jaeger. This deployment uses an in-memory storage component, while a persistent storage component is recommended for production. For more information on which deployment strategy you may need, refer to the https://www.jaegertracing.io/docs/1.65/operator/#production-strategy[Jaeger documentation.]
 
 == Prerequisites
 

--- a/versions/v2.11/modules/en/pages/observability/monitoring-and-dashboards/best-practices.adoc
+++ b/versions/v2.11/modules/en/pages/observability/monitoring-and-dashboards/best-practices.adoc
@@ -60,7 +60,7 @@ In general, you want to scrape data from all the workloads running in your clust
 
 === About Prometheus Exporters
 
-Many 3rd party workloads, such as databases, queues, and web-servers, already support exposing metrics in a Prometheus format, or offer exporters that translate between the tool's metrics and a format that Prometheus understands. You can usually add these exporters as additional sidecar containers to the workload's Pods. Many Helm charts already include options to deploy the correct exporter. You can find a curated list of exports by SysDig on https://promcat.io/[promcat.io] and on https://exporterhub.io/[ExporterHub].
+Many 3rd party workloads, such as databases, queues, and web-servers, already support exposing metrics in a Prometheus format, or offer exporters that translate between the tool's metrics and a format that Prometheus understands. You can usually add these exporters as additional sidecar containers to the workload's Pods. Many Helm charts already include options to deploy the correct exporter. You can find a curated list of exports on https://exporterhub.io/[ExporterHub].
 
 === Prometheus support in Programming Languages and Frameworks
 

--- a/versions/v2.11/modules/en/pages/observability/monitoring-and-dashboards/configuration/examples.adoc
+++ b/versions/v2.11/modules/en/pages/observability/monitoring-and-dashboards/configuration/examples.adoc
@@ -6,7 +6,7 @@ See the official prometheus-operator GitHub repo for an example https://github.c
 
 == PodMonitor
 
-See the https://prometheus-operator.dev/docs/user-guides/getting-started/#using-podmonitors[Prometheus Operator documentation] for an example PodMonitor and an example Prometheus resource that refers to a PodMonitor.
+See the https://prometheus-operator.dev/docs/developer/getting-started/#using-podmonitors[Prometheus Operator documentation] for an example PodMonitor and an example Prometheus resource that refers to a PodMonitor.
 
 == PrometheusRule
 
@@ -14,7 +14,7 @@ A PrometheusRule contains the alerting and recording rules that you would usuall
 
 For a more fine-grained approach, the `ruleSelector` field on a Prometheus resource can select which PrometheusRules should be loaded onto Prometheus, based on the labels attached to the PrometheusRules resources.
 
-See the https://prometheus-operator.dev/docs/user-guides/alerting/[Prometheus Operator documentation] for an example PrometheusRule.
+See the https://prometheus-operator.dev/docs/developer/alerting/[Prometheus Operator documentation] for an example PrometheusRule.
 
 == Alertmanager Config
 

--- a/versions/v2.11/modules/en/pages/rancher-admin/users/authn-and-authz/configure-azure-ad.adoc
+++ b/versions/v2.11/modules/en/pages/rancher-admin/users/authn-and-authz/configure-azure-ad.adoc
@@ -210,7 +210,7 @@ The following table maps the values you copied in the Azure portal to the fields
 | Key Value
 
 | Endpoint
-| https://login.microsoftonline.com/
+| \https://login.microsoftonline.com/
 |===
 +
 *For Custom Endpoints:*
@@ -300,32 +300,32 @@ If you upgrade to Rancher v2.7.0+ with an existing Azure AD setup, and choose to
 | Rancher Field | Deprecated Endpoints
 
 | Auth Endpoint
-| https://login.microsoftonline.com/\{tenantID}/oauth2/authorize
+| \https://login.microsoftonline.com/\{tenantID}/oauth2/authorize
 
 | Endpoint
-| https://login.microsoftonline.com/
+| \https://login.microsoftonline.com/
 
 | Graph Endpoint
-| https://graph.windows.net/
+| \https://graph.windows.net/
 
 | Token Endpoint
-| https://login.microsoftonline.com/\{tenantID}/oauth2/token
+| \https://login.microsoftonline.com/\{tenantID}/oauth2/token
 |===
 
 |===
 | Rancher Field | New Endpoints
 
 | Auth Endpoint
-| https://login.microsoftonline.com/\{tenantID}/oauth2/v2.0/authorize
+| \https://login.microsoftonline.com/\{tenantID}/oauth2/v2.0/authorize
 
 | Endpoint
-| https://login.microsoftonline.com/
+| \https://login.microsoftonline.com/
 
 | Graph Endpoint
-| https://graph.microsoft.com
+| \https://graph.microsoft.com
 
 | Token Endpoint
-| https://login.microsoftonline.com/\{tenantID}/oauth2/v2.0/token
+| \https://login.microsoftonline.com/\{tenantID}/oauth2/v2.0/token
 |===
 
 ==== China:
@@ -334,32 +334,32 @@ If you upgrade to Rancher v2.7.0+ with an existing Azure AD setup, and choose to
 | Rancher Field | Deprecated Endpoints
 
 | Auth Endpoint
-| https://login.chinacloudapi.cn/\{tenantID}/oauth2/authorize
+| \https://login.chinacloudapi.cn/\{tenantID}/oauth2/authorize
 
 | Endpoint
-| https://login.chinacloudapi.cn/
+| \https://login.chinacloudapi.cn/
 
 | Graph Endpoint
-| https://graph.chinacloudapi.cn/
+| \https://graph.chinacloudapi.cn/
 
 | Token Endpoint
-| https://login.chinacloudapi.cn/\{tenantID}/oauth2/token
+| \https://login.chinacloudapi.cn/\{tenantID}/oauth2/token
 |===
 
 |===
 | Rancher Field | New Endpoints
 
 | Auth Endpoint
-| https://login.partner.microsoftonline.cn/\{tenantID}/oauth2/v2.0/authorize
+| \https://login.partner.microsoftonline.cn/\{tenantID}/oauth2/v2.0/authorize
 
 | Endpoint
-| https://login.partner.microsoftonline.cn/
+| \https://login.partner.microsoftonline.cn/
 
 | Graph Endpoint
-| https://microsoftgraph.chinacloudapi.cn
+| \https://microsoftgraph.chinacloudapi.cn
 
 | Token Endpoint
-| https://login.partner.microsoftonline.cn/\{tenantID}/oauth2/v2.0/token
+| \https://login.partner.microsoftonline.cn/\{tenantID}/oauth2/v2.0/token
 |===
 
 == Filtering Users by Azure AD Auth Group Memberships

--- a/versions/v2.11/modules/zh/pages/cluster-deployment/infra-providers/vsphere/create-a-vm-template.adoc
+++ b/versions/v2.11/modules/zh/pages/cluster-deployment/infra-providers/vsphere/create-a-vm-template.adoc
@@ -130,7 +130,7 @@ cloud-init clean -s -l
 
 === Windows 准备
 
-Windows 有一个名为 https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep--generalize--a-windows-installation[sysprep] 的实用程序，用于一般化镜像并重置上述 Linux 项目。命令如下：
+Windows 有一个名为 https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep\--generalize\--a-windows-installation?view=windows-11[sysprep] 的实用程序，用于一般化镜像并重置上述 Linux 项目。命令如下：
 
 [,PowerShell]
 ----

--- a/versions/v2.11/modules/zh/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
+++ b/versions/v2.11/modules/zh/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
@@ -22,14 +22,14 @@
 
 == 先决条件
 
-* https://metal.equinix.com/developers/docs/accounts/users/[Equinix Metal 账号]
-* https://metal.equinix.com/developers/docs/accounts/projects/[Equinix Metal 项目]
+* https://deploy.equinix.com/developers/docs/metal/identity-access-management/users/[Equinix Metal 账号]
+* https://deploy.equinix.com/developers/docs/metal/projects/creating-a-project/[Equinix Metal 项目]
 
 === 1. 配置 Equinix Metal 主机
 
-开始部署 Equinix Metal 主机。你可以使用 Equinix Metal 控制台、CLI 或 API 来配置 Equinix Metal Server。如果你需要了解每种 Deployment 类型的说明，请参见 https://metal.equinix.com/developers/docs/deploy/on-demand/[Equinix Metal 部署]。以下链接介绍 Equinix Metal Server 的类型以及价格：
+开始部署 Equinix Metal 主机。你可以使用 Equinix Metal 控制台、CLI 或 API 来配置 Equinix Metal Server。如果你需要了解每种 Deployment 类型的说明，请参见 https://deploy.equinix.com/developers/docs/metal/deploy/on-demand/[Equinix Metal 部署]。以下链接介绍 Equinix Metal Server 的类型以及价格：
 
-* https://metal.equinix.com/developers/docs/servers/about/[Equinix Metal Server 类型]
+* https://deploy.equinix.com/developers/docs/metal/hardware/standard-servers/[Equinix Metal Server 类型]
 * https://metal.equinix.com/developers/docs/servers/server-specs/[Equinix Metal 价格]
 
 [NOTE]

--- a/versions/v2.11/modules/zh/pages/observability/istio/istio.adoc
+++ b/versions/v2.11/modules/zh/pages/observability/istio/istio.adoc
@@ -51,7 +51,7 @@ Kiali 是一个全面的可视化辅助工具，用于绘制整个服务网格�
 
 Jaeger 是用于跟踪分布式系统的工具。我们的 Istio 安装程序包括能快速启动的一体化 https://www.jaegertracing.io/[Jaeger] 安装。
 
-请注意，这不是符合 Jaeger 生产要求的部署。此部署使用在内存中的存储组件，而 Jaeger 推荐在生产环境中使用持久存储组件。有关你所需的部署策略的更多信息，请参阅 https://www.jaegertracing.io/docs/latest/operator/#production-strategy[Jaeger 文档]。
+请注意，这不是符合 Jaeger 生产要求的部署。此部署使用在内存中的存储组件，而 Jaeger 推荐在生产环境中使用持久存储组件。有关你所需的部署策略的更多信息，请参阅 https://www.jaegertracing.io/docs/1.65/operator/#production-strategy[Jaeger 文档]。
 
 == 先决条件
 

--- a/versions/v2.11/modules/zh/pages/observability/monitoring-and-dashboards/best-practices.adoc
+++ b/versions/v2.11/modules/zh/pages/observability/monitoring-and-dashboards/best-practices.adoc
@@ -60,7 +60,7 @@ Prometheus 不是用于长期存储指标的，它只用于短期存储。
 
 === 关于 Prometheus Exporters
 
-许多第三方工作负载（如数据库、队列或 Web 服务器）要么已经支持以 Prometheus 格式公开指标，要么有所谓的 exporter，来对工具的指标格式和 Prometheus 理解的指标格式进行转换。通常，你可以将这些 exporter 作为额外的 Sidecar 容器添加到工作负载的 Pod 中。很多 Helm Chart 已经包含了部署 exporter 的选项。此外，你还可以在 https://promcat.io/[promcat.io] 和 https://exporterhub.io/[ExporterHub] 上找到一个由 SysDig 策划的 exporter 列表。
+许多第三方工作负载（如数据库、队列或 Web 服务器）要么已经支持以 Prometheus 格式公开指标，要么有所谓的 exporter，来对工具的指标格式和 Prometheus 理解的指标格式进行转换。通常，你可以将这些 exporter 作为额外的 Sidecar 容器添加到工作负载的 Pod 中。很多 Helm Chart 已经包含了部署 exporter 的选项。此外，你还可以在 https://exporterhub.io/[ExporterHub] 上找到策划的 exporter 列表。
 
 === Prometheus 的编程语言和框架支持
 

--- a/versions/v2.11/modules/zh/pages/observability/monitoring-and-dashboards/configuration/examples.adoc
+++ b/versions/v2.11/modules/zh/pages/observability/monitoring-and-dashboards/configuration/examples.adoc
@@ -6,7 +6,7 @@
 
 == PodMonitor
 
-你可以在link:https://github.com/prometheus-operator/prometheus-operator/blob/master/example/user-guides/getting-started/example-app-pod-monitor.yaml[此处]找到 PodMonitor 示例，还可以在link:https://github.com/prometheus-operator/prometheus-operator/blob/master/example/user-guides/getting-started/prometheus-pod-monitor.yaml[此处]找到引用它的 Prometheus 资源示例。
+你可以在link:https://prometheus-operator.dev/docs/developer/getting-started/#using-podmonitors[此处]找到 PodMonitor 示例和引用它的 Prometheus 资源示例。
 
 == PrometheusRule
 
@@ -14,7 +14,7 @@ PrometheusRule 包含你通常放置在 https://prometheus.io/docs/prometheus/la
 
 要在集群中更细粒度地应用 PrometheusRules，你可以使用 Prometheus 资源的 ruleSelector 字段，从而根据添加到 PrometheusRules 资源的标签来选择要加载到 Prometheus 上的 PrometheusRule。
 
-你可以在link:https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/user-guides/alerting.md[此页面]找到 PrometheusRule 示例。
+你可以在link:https://prometheus-operator.dev/docs/developer/alerting/[此页面]找到 PrometheusRule 示例。
 
 == Alertmanager 配置
 

--- a/versions/v2.11/modules/zh/pages/rancher-admin/users/authn-and-authz/configure-azure-ad.adoc
+++ b/versions/v2.11/modules/zh/pages/rancher-admin/users/authn-and-authz/configure-azure-ad.adoc
@@ -201,7 +201,7 @@ Azure AD 帐户将被授予管理员权限，因为其详细信息将映射到 R
 | Key Value
 
 | 端点
-| https://login.microsoftonline.com/
+| \https://login.microsoftonline.com/
 |===
 +
 *对于自定义端点*：
@@ -286,32 +286,32 @@ image::azure-update-popup.png[Azure 更新弹出窗口]
 | Rancher 字段 | 已弃用的端点
 
 | Auth 端点
-| https://login.microsoftonline.com/\{tenantID}/oauth2/authorize
+| \https://login.microsoftonline.com/\{tenantID}/oauth2/authorize
 
 | 端点
-| https://login.microsoftonline.com/
+| \https://login.microsoftonline.com/
 
 | Graph 端点
-| https://graph.windows.net/
+| \https://graph.windows.net/
 
 | Token 端点
-| https://login.microsoftonline.com/\{tenantID}/oauth2/token
+| \https://login.microsoftonline.com/\{tenantID}/oauth2/token
 |===
 
 |===
 | Rancher 字段 | 新端点
 
 | Auth 端点
-| https://login.microsoftonline.com/\{tenantID}/oauth2/v2.0/authorize
+| \https://login.microsoftonline.com/\{tenantID}/oauth2/v2.0/authorize
 
 | 端点
-| https://login.microsoftonline.com/
+| \https://login.microsoftonline.com/
 
 | Graph 端点
-| https://graph.microsoft.com
+| \https://graph.microsoft.com
 
 | Token 端点
-| https://login.microsoftonline.com/\{tenantID}/oauth2/v2.0/token
+| \https://login.microsoftonline.com/\{tenantID}/oauth2/v2.0/token
 |===
 
 ==== 中国：
@@ -320,32 +320,32 @@ image::azure-update-popup.png[Azure 更新弹出窗口]
 | Rancher 字段 | 已弃用的端点
 
 | Auth 端点
-| https://login.chinacloudapi.cn/\{tenantID}/oauth2/authorize
+| \https://login.chinacloudapi.cn/\{tenantID}/oauth2/authorize
 
 | 端点
-| https://login.chinacloudapi.cn/
+| \https://login.chinacloudapi.cn/
 
 | Graph 端点
-| https://graph.chinacloudapi.cn/
+| \https://graph.chinacloudapi.cn/
 
 | Token 端点
-| https://login.chinacloudapi.cn/\{tenantID}/oauth2/token
+| \https://login.chinacloudapi.cn/\{tenantID}/oauth2/token
 |===
 
 |===
 | Rancher 字段 | 新端点
 
 | Auth 端点
-| https://login.partner.microsoftonline.cn/\{tenantID}/oauth2/v2.0/authorize
+| \https://login.partner.microsoftonline.cn/\{tenantID}/oauth2/v2.0/authorize
 
 | 端点
-| https://login.partner.microsoftonline.cn/
+| \https://login.partner.microsoftonline.cn/
 
 | Graph 端点
-| https://microsoftgraph.chinacloudapi.cn
+| \https://microsoftgraph.chinacloudapi.cn
 
 | Token 端点
-| https://login.partner.microsoftonline.cn/\{tenantID}/oauth2/v2.0/token
+| \https://login.partner.microsoftonline.cn/\{tenantID}/oauth2/v2.0/token
 |===
 
 == 已弃用的 Azure AD Graph API

--- a/versions/v2.8/modules/en/pages/cluster-deployment/infra-providers/vsphere/create-a-vm-template.adoc
+++ b/versions/v2.8/modules/en/pages/cluster-deployment/infra-providers/vsphere/create-a-vm-template.adoc
@@ -129,7 +129,7 @@ cloud-init clean -s -l
 
 === Windows Preparation
 
-Windows has a utility called https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep--generalize--a-windows-installation[sysprep] that is used to generalize an image and reset the same items listed above for Linux. The command is as follows:
+Windows has a utility called https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep\--generalize\--a-windows-installation?view=windows-11[sysprep] that is used to generalize an image and reset the same items listed above for Linux. The command is as follows:
 
 [,PowerShell]
 ----

--- a/versions/v2.8/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
+++ b/versions/v2.8/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
@@ -22,15 +22,12 @@ This Quick Start Guide is divided into different tasks for easier consumption.
 
 == Prerequisites
 
-* An https://metal.equinix.com/developers/docs/accounts/users/[Equinix Metal account]
-* An https://metal.equinix.com/developers/docs/accounts/projects/[Equinix Metal project]
+* An https://deploy.equinix.com/developers/docs/metal/identity-access-management/users/[Equinix Metal account]
+* An https://deploy.equinix.com/developers/docs/metal/projects/creating-a-project/[Equinix Metal project]
 
 === 1. Provision a Equinix Metal Host
 
-Begin deploying an Equinix Metal Host. Equinix Metal Servers can be provisioned from either the Equinix Metal console, CLI, or API. You can find instructions for each deployment type on the https://metal.equinix.com/developers/docs/deploy/on-demand/[Equinix Metal deployment documentation]. You can find additional documentation on Equinix Metal server types and prices below:
-
-* https://metal.equinix.com/developers/docs/servers/about/[Equinix Metal Server Types]
-* https://metal.equinix.com/developers/docs/servers/server-specs/[Equinix Metal Pricing]
+Begin deploying an Equinix Metal Host. Equinix Metal Servers can be provisioned from either the Equinix Metal console, CLI, or API. You can find instructions for each deployment type on the https://deploy.equinix.com/developers/docs/metal/deploy/on-demand/[Equinix Metal deployment documentation]. You can find additional information on Equinix Metal server types in the https://deploy.equinix.com/developers/docs/metal/hardware/standard-servers/[Equinix Metal Documentation].
 
 [NOTE]
 .Notes:

--- a/versions/v2.8/modules/en/pages/observability/istio/istio.adoc
+++ b/versions/v2.8/modules/en/pages/observability/istio/istio.adoc
@@ -50,7 +50,7 @@ For Istio installations `103.1.0+up1.19.6` and later, Kiali uses a token value f
 
 Our Istio installer includes a quick-start, all-in-one installation of https://www.jaegertracing.io/[Jaeger,] a tool used for tracing distributed systems.
 
-Note that this is not a production-qualified deployment of Jaeger. This deployment uses an in-memory storage component, while a persistent storage component is recommended for production. For more information on which deployment strategy you may need, refer to the https://www.jaegertracing.io/docs/latest/operator/#production-strategy[Jaeger documentation.]
+Note that this is not a production-qualified deployment of Jaeger. This deployment uses an in-memory storage component, while a persistent storage component is recommended for production. For more information on which deployment strategy you may need, refer to the https://www.jaegertracing.io/docs/1.65/operator/#production-strategy[Jaeger documentation.]
 
 == Prerequisites
 

--- a/versions/v2.8/modules/en/pages/observability/monitoring-and-dashboards/best-practices.adoc
+++ b/versions/v2.8/modules/en/pages/observability/monitoring-and-dashboards/best-practices.adoc
@@ -60,7 +60,7 @@ In general, you want to scrape data from all the workloads running in your clust
 
 === About Prometheus Exporters
 
-Many 3rd party workloads, such as databases, queues, and web-servers, already support exposing metrics in a Prometheus format, or offer exporters that translate between the tool's metrics and a format that Prometheus understands. You can usually add these exporters as additional sidecar containers to the workload's Pods. Many Helm charts already include options to deploy the correct exporter. You can find a curated list of exports by SysDig on https://promcat.io/[promcat.io] and on https://exporterhub.io/[ExporterHub].
+Many 3rd party workloads, such as databases, queues, and web-servers, already support exposing metrics in a Prometheus format, or offer exporters that translate between the tool's metrics and a format that Prometheus understands. You can usually add these exporters as additional sidecar containers to the workload's Pods. Many Helm charts already include options to deploy the correct exporter. You can find a curated list of exports on https://exporterhub.io/[ExporterHub].
 
 === Prometheus support in Programming Languages and Frameworks
 

--- a/versions/v2.8/modules/en/pages/observability/monitoring-and-dashboards/configuration/examples.adoc
+++ b/versions/v2.8/modules/en/pages/observability/monitoring-and-dashboards/configuration/examples.adoc
@@ -6,7 +6,7 @@ See the official prometheus-operator GitHub repo for an example https://github.c
 
 == PodMonitor
 
-See the https://prometheus-operator.dev/docs/user-guides/getting-started/#using-podmonitors[Prometheus Operator documentation] for an example PodMonitor and an example Prometheus resource that refers to a PodMonitor.
+See the https://prometheus-operator.dev/docs/developer/getting-started/#using-podmonitors[Prometheus Operator documentation] for an example PodMonitor and an example Prometheus resource that refers to a PodMonitor.
 
 == PrometheusRule
 
@@ -14,7 +14,7 @@ A PrometheusRule contains the alerting and recording rules that you would usuall
 
 For a more fine-grained approach, the `ruleSelector` field on a Prometheus resource can select which PrometheusRules should be loaded onto Prometheus, based on the labels attached to the PrometheusRules resources.
 
-See the https://prometheus-operator.dev/docs/user-guides/alerting/[Prometheus Operator documentation] for an example PrometheusRule.
+See the https://prometheus-operator.dev/docs/developer/alerting/[Prometheus Operator documentation] for an example PrometheusRule.
 
 == Alertmanager Config
 

--- a/versions/v2.8/modules/en/pages/rancher-admin/users/authn-and-authz/configure-azure-ad.adoc
+++ b/versions/v2.8/modules/en/pages/rancher-admin/users/authn-and-authz/configure-azure-ad.adoc
@@ -207,7 +207,7 @@ The following table maps the values you copied in the Azure portal to the fields
 | Key Value
 
 | Endpoint
-| https://login.microsoftonline.com/
+| \https://login.microsoftonline.com/
 |===
 +
 *For Custom Endpoints:*
@@ -294,32 +294,32 @@ If you upgrade to Rancher v2.7.0+ with an existing Azure AD setup, and choose to
 | Rancher Field | Deprecated Endpoints
 
 | Auth Endpoint
-| https://login.microsoftonline.com/\{tenantID}/oauth2/authorize
+| \https://login.microsoftonline.com/\{tenantID}/oauth2/authorize
 
 | Endpoint
-| https://login.microsoftonline.com/
+| \https://login.microsoftonline.com/
 
 | Graph Endpoint
-| https://graph.windows.net/
+| \https://graph.windows.net/
 
 | Token Endpoint
-| https://login.microsoftonline.com/\{tenantID}/oauth2/token
+| \https://login.microsoftonline.com/\{tenantID}/oauth2/token
 |===
 
 |===
 | Rancher Field | New Endpoints
 
 | Auth Endpoint
-| https://login.microsoftonline.com/\{tenantID}/oauth2/v2.0/authorize
+| \https://login.microsoftonline.com/\{tenantID}/oauth2/v2.0/authorize
 
 | Endpoint
-| https://login.microsoftonline.com/
+| \https://login.microsoftonline.com/
 
 | Graph Endpoint
-| https://graph.microsoft.com
+| \https://graph.microsoft.com
 
 | Token Endpoint
-| https://login.microsoftonline.com/\{tenantID}/oauth2/v2.0/token
+| \https://login.microsoftonline.com/\{tenantID}/oauth2/v2.0/token
 |===
 
 ==== China:
@@ -328,32 +328,32 @@ If you upgrade to Rancher v2.7.0+ with an existing Azure AD setup, and choose to
 | Rancher Field | Deprecated Endpoints
 
 | Auth Endpoint
-| https://login.chinacloudapi.cn/\{tenantID}/oauth2/authorize
+| \https://login.chinacloudapi.cn/\{tenantID}/oauth2/authorize
 
 | Endpoint
-| https://login.chinacloudapi.cn/
+| \https://login.chinacloudapi.cn/
 
 | Graph Endpoint
-| https://graph.chinacloudapi.cn/
+| \https://graph.chinacloudapi.cn/
 
 | Token Endpoint
-| https://login.chinacloudapi.cn/\{tenantID}/oauth2/token
+| \https://login.chinacloudapi.cn/\{tenantID}/oauth2/token
 |===
 
 |===
 | Rancher Field | New Endpoints
 
 | Auth Endpoint
-| https://login.partner.microsoftonline.cn/\{tenantID}/oauth2/v2.0/authorize
+| \https://login.partner.microsoftonline.cn/\{tenantID}/oauth2/v2.0/authorize
 
 | Endpoint
-| https://login.partner.microsoftonline.cn/
+| \https://login.partner.microsoftonline.cn/
 
 | Graph Endpoint
-| https://microsoftgraph.chinacloudapi.cn
+| \https://microsoftgraph.chinacloudapi.cn
 
 | Token Endpoint
-| https://login.partner.microsoftonline.cn/\{tenantID}/oauth2/v2.0/token
+| \https://login.partner.microsoftonline.cn/\{tenantID}/oauth2/v2.0/token
 |===
 
 == Deprecated Azure AD Graph API

--- a/versions/v2.8/modules/zh/pages/cluster-deployment/infra-providers/vsphere/create-a-vm-template.adoc
+++ b/versions/v2.8/modules/zh/pages/cluster-deployment/infra-providers/vsphere/create-a-vm-template.adoc
@@ -130,7 +130,7 @@ cloud-init clean -s -l
 
 === Windows 准备
 
-Windows 有一个名为 https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep--generalize--a-windows-installation[sysprep] 的实用程序，用于一般化镜像并重置上述 Linux 项目。命令如下：
+Windows 有一个名为 https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep\--generalize\--a-windows-installation?view=windows-11[sysprep] 的实用程序，用于一般化镜像并重置上述 Linux 项目。命令如下：
 
 [,PowerShell]
 ----

--- a/versions/v2.8/modules/zh/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
+++ b/versions/v2.8/modules/zh/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
@@ -22,14 +22,14 @@
 
 == 先决条件
 
-* https://metal.equinix.com/developers/docs/accounts/users/[Equinix Metal 账号]
-* https://metal.equinix.com/developers/docs/accounts/projects/[Equinix Metal 项目]
+* https://deploy.equinix.com/developers/docs/metal/identity-access-management/users/[Equinix Metal 账号]
+* https://deploy.equinix.com/developers/docs/metal/projects/creating-a-project/[Equinix Metal 项目]
 
 === 1. 配置 Equinix Metal 主机
 
-开始部署 Equinix Metal 主机。你可以使用 Equinix Metal 控制台、CLI 或 API 来配置 Equinix Metal Server。如果你需要了解每种 Deployment 类型的说明，请参见 https://metal.equinix.com/developers/docs/deploy/on-demand/[Equinix Metal 部署]。以下链接介绍 Equinix Metal Server 的类型以及价格：
+开始部署 Equinix Metal 主机。你可以使用 Equinix Metal 控制台、CLI 或 API 来配置 Equinix Metal Server。如果你需要了解每种 Deployment 类型的说明，请参见 https://deploy.equinix.com/developers/docs/metal/deploy/on-demand/[Equinix Metal 部署]。以下链接介绍 Equinix Metal Server 的类型以及价格：
 
-* https://metal.equinix.com/developers/docs/servers/about/[Equinix Metal Server 类型]
+* https://deploy.equinix.com/developers/docs/metal/hardware/standard-servers/[Equinix Metal Server 类型]
 * https://metal.equinix.com/developers/docs/servers/server-specs/[Equinix Metal 价格]
 
 [NOTE]

--- a/versions/v2.8/modules/zh/pages/observability/istio/istio.adoc
+++ b/versions/v2.8/modules/zh/pages/observability/istio/istio.adoc
@@ -45,7 +45,7 @@ Kiali 是一个全面的可视化辅助工具，用于绘制整个服务网格�
 
 Jaeger 是用于跟踪分布式系统的工具。我们的 Istio 安装程序包括能快速启动的一体化 https://www.jaegertracing.io/[Jaeger] 安装。
 
-请注意，这不是符合 Jaeger 生产要求的部署。此部署使用在内存中的存储组件，而 Jaeger 推荐在生产环境中使用持久存储组件。有关你所需的部署策略的更多信息，请参阅 https://www.jaegertracing.io/docs/latest/operator/#production-strategy[Jaeger 文档]。
+请注意，这不是符合 Jaeger 生产要求的部署。此部署使用在内存中的存储组件，而 Jaeger 推荐在生产环境中使用持久存储组件。有关你所需的部署策略的更多信息，请参阅 https://www.jaegertracing.io/docs/1.65/operator/#production-strategy[Jaeger 文档]。
 
 == 先决条件
 

--- a/versions/v2.8/modules/zh/pages/observability/monitoring-and-dashboards/best-practices.adoc
+++ b/versions/v2.8/modules/zh/pages/observability/monitoring-and-dashboards/best-practices.adoc
@@ -60,7 +60,7 @@ Prometheus 不是用于长期存储指标的，它只用于短期存储。
 
 === 关于 Prometheus Exporters
 
-许多第三方工作负载（如数据库、队列或 Web 服务器）要么已经支持以 Prometheus 格式公开指标，要么有所谓的 exporter，来对工具的指标格式和 Prometheus 理解的指标格式进行转换。通常，你可以将这些 exporter 作为额外的 Sidecar 容器添加到工作负载的 Pod 中。很多 Helm Chart 已经包含了部署 exporter 的选项。此外，你还可以在 https://promcat.io/[promcat.io] 和 https://exporterhub.io/[ExporterHub] 上找到一个由 SysDig 策划的 exporter 列表。
+许多第三方工作负载（如数据库、队列或 Web 服务器）要么已经支持以 Prometheus 格式公开指标，要么有所谓的 exporter，来对工具的指标格式和 Prometheus 理解的指标格式进行转换。通常，你可以将这些 exporter 作为额外的 Sidecar 容器添加到工作负载的 Pod 中。很多 Helm Chart 已经包含了部署 exporter 的选项。此外，你还可以在 https://exporterhub.io/[ExporterHub] 上找到策划的 exporter 列表。
 
 === Prometheus 的编程语言和框架支持
 

--- a/versions/v2.8/modules/zh/pages/observability/monitoring-and-dashboards/configuration/examples.adoc
+++ b/versions/v2.8/modules/zh/pages/observability/monitoring-and-dashboards/configuration/examples.adoc
@@ -6,7 +6,7 @@
 
 == PodMonitor
 
-你可以在link:https://github.com/prometheus-operator/prometheus-operator/blob/master/example/user-guides/getting-started/example-app-pod-monitor.yaml[此处]找到 PodMonitor 示例，还可以在link:https://github.com/prometheus-operator/prometheus-operator/blob/master/example/user-guides/getting-started/prometheus-pod-monitor.yaml[此处]找到引用它的 Prometheus 资源示例。
+你可以在link:https://prometheus-operator.dev/docs/developer/getting-started/#using-podmonitors[此处]找到 PodMonitor 示例和引用它的 Prometheus 资源示例。
 
 == PrometheusRule
 
@@ -14,7 +14,7 @@ PrometheusRule 包含你通常放置在 https://prometheus.io/docs/prometheus/la
 
 要在集群中更细粒度地应用 PrometheusRules，你可以使用 Prometheus 资源的 ruleSelector 字段，从而根据添加到 PrometheusRules 资源的标签来选择要加载到 Prometheus 上的 PrometheusRule。
 
-你可以在link:https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/user-guides/alerting.md[此页面]找到 PrometheusRule 示例。
+你可以在link:https://prometheus-operator.dev/docs/developer/alerting/[此页面]找到 PrometheusRule 示例。
 
 == Alertmanager 配置
 

--- a/versions/v2.8/modules/zh/pages/rancher-admin/users/authn-and-authz/configure-azure-ad.adoc
+++ b/versions/v2.8/modules/zh/pages/rancher-admin/users/authn-and-authz/configure-azure-ad.adoc
@@ -201,7 +201,7 @@ Azure AD 帐户将被授予管理员权限，因为其详细信息将映射到 R
 | Key Value
 
 | 端点
-| https://login.microsoftonline.com/
+| \https://login.microsoftonline.com/
 |===
 +
 *对于自定义端点*：
@@ -286,32 +286,32 @@ image::azure-update-popup.png[Azure 更新弹出窗口]
 | Rancher 字段 | 已弃用的端点
 
 | Auth 端点
-| https://login.microsoftonline.com/\{tenantID}/oauth2/authorize
+| \https://login.microsoftonline.com/\{tenantID}/oauth2/authorize
 
 | 端点
-| https://login.microsoftonline.com/
+| \https://login.microsoftonline.com/
 
 | Graph 端点
-| https://graph.windows.net/
+| \https://graph.windows.net/
 
 | Token 端点
-| https://login.microsoftonline.com/\{tenantID}/oauth2/token
+| \https://login.microsoftonline.com/\{tenantID}/oauth2/token
 |===
 
 |===
 | Rancher 字段 | 新端点
 
 | Auth 端点
-| https://login.microsoftonline.com/\{tenantID}/oauth2/v2.0/authorize
+| \https://login.microsoftonline.com/\{tenantID}/oauth2/v2.0/authorize
 
 | 端点
-| https://login.microsoftonline.com/
+| \https://login.microsoftonline.com/
 
 | Graph 端点
-| https://graph.microsoft.com
+| \https://graph.microsoft.com
 
 | Token 端点
-| https://login.microsoftonline.com/\{tenantID}/oauth2/v2.0/token
+| \https://login.microsoftonline.com/\{tenantID}/oauth2/v2.0/token
 |===
 
 ==== 中国：
@@ -320,32 +320,32 @@ image::azure-update-popup.png[Azure 更新弹出窗口]
 | Rancher 字段 | 已弃用的端点
 
 | Auth 端点
-| https://login.chinacloudapi.cn/\{tenantID}/oauth2/authorize
+| \https://login.chinacloudapi.cn/\{tenantID}/oauth2/authorize
 
 | 端点
-| https://login.chinacloudapi.cn/
+| \https://login.chinacloudapi.cn/
 
 | Graph 端点
-| https://graph.chinacloudapi.cn/
+| \https://graph.chinacloudapi.cn/
 
 | Token 端点
-| https://login.chinacloudapi.cn/\{tenantID}/oauth2/token
+| \https://login.chinacloudapi.cn/\{tenantID}/oauth2/token
 |===
 
 |===
 | Rancher 字段 | 新端点
 
 | Auth 端点
-| https://login.partner.microsoftonline.cn/\{tenantID}/oauth2/v2.0/authorize
+| \https://login.partner.microsoftonline.cn/\{tenantID}/oauth2/v2.0/authorize
 
 | 端点
-| https://login.partner.microsoftonline.cn/
+| \https://login.partner.microsoftonline.cn/
 
 | Graph 端点
-| https://microsoftgraph.chinacloudapi.cn
+| \https://microsoftgraph.chinacloudapi.cn
 
 | Token 端点
-| https://login.partner.microsoftonline.cn/\{tenantID}/oauth2/v2.0/token
+| \https://login.partner.microsoftonline.cn/\{tenantID}/oauth2/v2.0/token
 |===
 
 == 已弃用的 Azure AD Graph API

--- a/versions/v2.9/modules/en/pages/cluster-deployment/infra-providers/vsphere/create-a-vm-template.adoc
+++ b/versions/v2.9/modules/en/pages/cluster-deployment/infra-providers/vsphere/create-a-vm-template.adoc
@@ -129,7 +129,7 @@ cloud-init clean -s -l
 
 === Windows Preparation
 
-Windows has a utility called https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep--generalize--a-windows-installation[sysprep] that is used to generalize an image and reset the same items listed above for Linux. The command is as follows:
+Windows has a utility called https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep\--generalize\--a-windows-installation?view=windows-11[sysprep] that is used to generalize an image and reset the same items listed above for Linux. The command is as follows:
 
 [,PowerShell]
 ----

--- a/versions/v2.9/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
+++ b/versions/v2.9/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
@@ -22,15 +22,12 @@ This Quick Start Guide is divided into different tasks for easier consumption.
 
 == Prerequisites
 
-* An https://metal.equinix.com/developers/docs/accounts/users/[Equinix Metal account]
-* An https://metal.equinix.com/developers/docs/accounts/projects/[Equinix Metal project]
+* An https://deploy.equinix.com/developers/docs/metal/identity-access-management/users/[Equinix Metal account]
+* An https://deploy.equinix.com/developers/docs/metal/projects/creating-a-project/[Equinix Metal project]
 
 === 1. Provision a Equinix Metal Host
 
-Begin deploying an Equinix Metal Host. Equinix Metal Servers can be provisioned from either the Equinix Metal console, API, or CLI. You can find instructions for each deployment type on the https://metal.equinix.com/developers/docs/deploy/on-demand/[Equinix Metal deployment documentation]. You can find additional documentation on Equinix Metal server types and prices below:
-
-* https://metal.equinix.com/developers/docs/servers/about/[Equinix Metal Server Types]
-* https://metal.equinix.com/developers/docs/servers/server-specs/[Equinix Metal Pricing]
+Begin deploying an Equinix Metal Host. Equinix Metal Servers can be provisioned from either the Equinix Metal console, API, or CLI. You can find instructions for each deployment type on the https://deploy.equinix.com/developers/docs/metal/deploy/on-demand/[Equinix Metal deployment documentation]. You can find additional information on Equinix Metal server types in the https://deploy.equinix.com/developers/docs/metal/hardware/standard-servers/[Equinix Metal Documentation].
 
 [NOTE]
 .Notes:

--- a/versions/v2.9/modules/en/pages/observability/istio/istio.adoc
+++ b/versions/v2.9/modules/en/pages/observability/istio/istio.adoc
@@ -50,7 +50,7 @@ For Istio installations `103.1.0+up1.19.6` and later, Kiali uses a token value f
 
 Our Istio installer includes a quick-start, all-in-one installation of https://www.jaegertracing.io/[Jaeger,] a tool used for tracing distributed systems.
 
-Note that this is not a production-qualified deployment of Jaeger. This deployment uses an in-memory storage component, while a persistent storage component is recommended for production. For more information on which deployment strategy you may need, refer to the https://www.jaegertracing.io/docs/latest/operator/#production-strategy[Jaeger documentation.]
+Note that this is not a production-qualified deployment of Jaeger. This deployment uses an in-memory storage component, while a persistent storage component is recommended for production. For more information on which deployment strategy you may need, refer to the https://www.jaegertracing.io/docs/1.65/operator/#production-strategy[Jaeger documentation.]
 
 == Prerequisites
 

--- a/versions/v2.9/modules/en/pages/observability/monitoring-and-dashboards/best-practices.adoc
+++ b/versions/v2.9/modules/en/pages/observability/monitoring-and-dashboards/best-practices.adoc
@@ -60,7 +60,7 @@ In general, you want to scrape data from all the workloads running in your clust
 
 === About Prometheus Exporters
 
-Many 3rd party workloads, such as databases, queues, and web-servers, already support exposing metrics in a Prometheus format, or offer exporters that translate between the tool's metrics and a format that Prometheus understands. You can usually add these exporters as additional sidecar containers to the workload's Pods. Many Helm charts already include options to deploy the correct exporter. You can find a curated list of exports by SysDig on https://promcat.io/[promcat.io] and on https://exporterhub.io/[ExporterHub].
+Many 3rd party workloads, such as databases, queues, and web-servers, already support exposing metrics in a Prometheus format, or offer exporters that translate between the tool's metrics and a format that Prometheus understands. You can usually add these exporters as additional sidecar containers to the workload's Pods. Many Helm charts already include options to deploy the correct exporter. You can find a curated list of exports on https://exporterhub.io/[ExporterHub].
 
 === Prometheus support in Programming Languages and Frameworks
 

--- a/versions/v2.9/modules/en/pages/observability/monitoring-and-dashboards/configuration/examples.adoc
+++ b/versions/v2.9/modules/en/pages/observability/monitoring-and-dashboards/configuration/examples.adoc
@@ -6,7 +6,7 @@ See the official prometheus-operator GitHub repo for an example https://github.c
 
 == PodMonitor
 
-See the https://prometheus-operator.dev/docs/user-guides/getting-started/#using-podmonitors[Prometheus Operator documentation] for an example PodMonitor and an example Prometheus resource that refers to a PodMonitor.
+See the https://prometheus-operator.dev/docs/developer/getting-started/#using-podmonitors[Prometheus Operator documentation] for an example PodMonitor and an example Prometheus resource that refers to a PodMonitor.
 
 == PrometheusRule
 
@@ -14,7 +14,7 @@ A PrometheusRule contains the alerting and recording rules that you would usuall
 
 For a more fine-grained approach, the `ruleSelector` field on a Prometheus resource can select which PrometheusRules should be loaded onto Prometheus, based on the labels attached to the PrometheusRules resources.
 
-See the https://prometheus-operator.dev/docs/user-guides/alerting/[Prometheus Operator documentation] for an example PrometheusRule.
+See the https://prometheus-operator.dev/docs/developer/alerting/[Prometheus Operator documentation] for an example PrometheusRule.
 
 == Alertmanager Config
 

--- a/versions/v2.9/modules/en/pages/rancher-admin/users/authn-and-authz/configure-azure-ad.adoc
+++ b/versions/v2.9/modules/en/pages/rancher-admin/users/authn-and-authz/configure-azure-ad.adoc
@@ -210,7 +210,7 @@ The following table maps the values you copied in the Azure portal to the fields
 | Key Value
 
 | Endpoint
-| https://login.microsoftonline.com/
+| \https://login.microsoftonline.com/
 |===
 +
 *For Custom Endpoints:*
@@ -300,32 +300,32 @@ If you upgrade to Rancher v2.7.0+ with an existing Azure AD setup, and choose to
 | Rancher Field | Deprecated Endpoints
 
 | Auth Endpoint
-| https://login.microsoftonline.com/\{tenantID}/oauth2/authorize
+| \https://login.microsoftonline.com/\{tenantID}/oauth2/authorize
 
 | Endpoint
-| https://login.microsoftonline.com/
+| \https://login.microsoftonline.com/
 
 | Graph Endpoint
-| https://graph.windows.net/
+| \https://graph.windows.net/
 
 | Token Endpoint
-| https://login.microsoftonline.com/\{tenantID}/oauth2/token
+| \https://login.microsoftonline.com/\{tenantID}/oauth2/token
 |===
 
 |===
 | Rancher Field | New Endpoints
 
 | Auth Endpoint
-| https://login.microsoftonline.com/\{tenantID}/oauth2/v2.0/authorize
+| \https://login.microsoftonline.com/\{tenantID}/oauth2/v2.0/authorize
 
 | Endpoint
-| https://login.microsoftonline.com/
+| \https://login.microsoftonline.com/
 
 | Graph Endpoint
-| https://graph.microsoft.com
+| \https://graph.microsoft.com
 
 | Token Endpoint
-| https://login.microsoftonline.com/\{tenantID}/oauth2/v2.0/token
+| \https://login.microsoftonline.com/\{tenantID}/oauth2/v2.0/token
 |===
 
 ==== China:
@@ -334,32 +334,32 @@ If you upgrade to Rancher v2.7.0+ with an existing Azure AD setup, and choose to
 | Rancher Field | Deprecated Endpoints
 
 | Auth Endpoint
-| https://login.chinacloudapi.cn/\{tenantID}/oauth2/authorize
+| \https://login.chinacloudapi.cn/\{tenantID}/oauth2/authorize
 
 | Endpoint
-| https://login.chinacloudapi.cn/
+| \https://login.chinacloudapi.cn/
 
 | Graph Endpoint
-| https://graph.chinacloudapi.cn/
+| \https://graph.chinacloudapi.cn/
 
 | Token Endpoint
-| https://login.chinacloudapi.cn/\{tenantID}/oauth2/token
+| \https://login.chinacloudapi.cn/\{tenantID}/oauth2/token
 |===
 
 |===
 | Rancher Field | New Endpoints
 
 | Auth Endpoint
-| https://login.partner.microsoftonline.cn/\{tenantID}/oauth2/v2.0/authorize
+| \https://login.partner.microsoftonline.cn/\{tenantID}/oauth2/v2.0/authorize
 
 | Endpoint
-| https://login.partner.microsoftonline.cn/
+| \https://login.partner.microsoftonline.cn/
 
 | Graph Endpoint
-| https://microsoftgraph.chinacloudapi.cn
+| \https://microsoftgraph.chinacloudapi.cn
 
 | Token Endpoint
-| https://login.partner.microsoftonline.cn/\{tenantID}/oauth2/v2.0/token
+| \https://login.partner.microsoftonline.cn/\{tenantID}/oauth2/v2.0/token
 |===
 
 == Filtering Users by Azure AD Auth Group Memberships

--- a/versions/v2.9/modules/zh/pages/cluster-deployment/infra-providers/vsphere/create-a-vm-template.adoc
+++ b/versions/v2.9/modules/zh/pages/cluster-deployment/infra-providers/vsphere/create-a-vm-template.adoc
@@ -130,7 +130,7 @@ cloud-init clean -s -l
 
 === Windows 准备
 
-Windows 有一个名为 https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep--generalize--a-windows-installation[sysprep] 的实用程序，用于一般化镜像并重置上述 Linux 项目。命令如下：
+Windows 有一个名为 https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep\--generalize\--a-windows-installation?view=windows-11[sysprep] 的实用程序，用于一般化镜像并重置上述 Linux 项目。命令如下：
 
 [,PowerShell]
 ----

--- a/versions/v2.9/modules/zh/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
+++ b/versions/v2.9/modules/zh/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
@@ -22,14 +22,14 @@
 
 == 先决条件
 
-* https://metal.equinix.com/developers/docs/accounts/users/[Equinix Metal 账号]
-* https://metal.equinix.com/developers/docs/accounts/projects/[Equinix Metal 项目]
+* https://deploy.equinix.com/developers/docs/metal/identity-access-management/users/[Equinix Metal 账号]
+* https://deploy.equinix.com/developers/docs/metal/projects/creating-a-project/[Equinix Metal 项目]
 
 === 1. 配置 Equinix Metal 主机
 
-开始部署 Equinix Metal 主机。你可以使用 Equinix Metal 控制台、CLI 或 API 来配置 Equinix Metal Server。如果你需要了解每种 Deployment 类型的说明，请参见 https://metal.equinix.com/developers/docs/deploy/on-demand/[Equinix Metal 部署]。以下链接介绍 Equinix Metal Server 的类型以及价格：
+开始部署 Equinix Metal 主机。你可以使用 Equinix Metal 控制台、CLI 或 API 来配置 Equinix Metal Server。如果你需要了解每种 Deployment 类型的说明，请参见 https://deploy.equinix.com/developers/docs/metal/deploy/on-demand/[Equinix Metal 部署]。以下链接介绍 Equinix Metal Server 的类型以及价格：
 
-* https://metal.equinix.com/developers/docs/servers/about/[Equinix Metal Server 类型]
+* https://deploy.equinix.com/developers/docs/metal/hardware/standard-servers/[Equinix Metal Server 类型]
 * https://metal.equinix.com/developers/docs/servers/server-specs/[Equinix Metal 价格]
 
 [NOTE]

--- a/versions/v2.9/modules/zh/pages/observability/istio/istio.adoc
+++ b/versions/v2.9/modules/zh/pages/observability/istio/istio.adoc
@@ -45,7 +45,7 @@ Kiali 是一个全面的可视化辅助工具，用于绘制整个服务网格�
 
 Jaeger 是用于跟踪分布式系统的工具。我们的 Istio 安装程序包括能快速启动的一体化 https://www.jaegertracing.io/[Jaeger] 安装。
 
-请注意，这不是符合 Jaeger 生产要求的部署。此部署使用在内存中的存储组件，而 Jaeger 推荐在生产环境中使用持久存储组件。有关你所需的部署策略的更多信息，请参阅 https://www.jaegertracing.io/docs/latest/operator/#production-strategy[Jaeger 文档]。
+请注意，这不是符合 Jaeger 生产要求的部署。此部署使用在内存中的存储组件，而 Jaeger 推荐在生产环境中使用持久存储组件。有关你所需的部署策略的更多信息，请参阅 https://www.jaegertracing.io/docs/1.65/operator/#production-strategy[Jaeger 文档]。
 
 == 先决条件
 

--- a/versions/v2.9/modules/zh/pages/observability/monitoring-and-dashboards/best-practices.adoc
+++ b/versions/v2.9/modules/zh/pages/observability/monitoring-and-dashboards/best-practices.adoc
@@ -60,7 +60,7 @@ Prometheus 不是用于长期存储指标的，它只用于短期存储。
 
 === 关于 Prometheus Exporters
 
-许多第三方工作负载（如数据库、队列或 Web 服务器）要么已经支持以 Prometheus 格式公开指标，要么有所谓的 exporter，来对工具的指标格式和 Prometheus 理解的指标格式进行转换。通常，你可以将这些 exporter 作为额外的 Sidecar 容器添加到工作负载的 Pod 中。很多 Helm Chart 已经包含了部署 exporter 的选项。此外，你还可以在 https://promcat.io/[promcat.io] 和 https://exporterhub.io/[ExporterHub] 上找到一个由 SysDig 策划的 exporter 列表。
+许多第三方工作负载（如数据库、队列或 Web 服务器）要么已经支持以 Prometheus 格式公开指标，要么有所谓的 exporter，来对工具的指标格式和 Prometheus 理解的指标格式进行转换。通常，你可以将这些 exporter 作为额外的 Sidecar 容器添加到工作负载的 Pod 中。很多 Helm Chart 已经包含了部署 exporter 的选项。此外，你还可以在 https://exporterhub.io/[ExporterHub] 上找到策划的 exporter 列表。
 
 === Prometheus 的编程语言和框架支持
 

--- a/versions/v2.9/modules/zh/pages/observability/monitoring-and-dashboards/configuration/examples.adoc
+++ b/versions/v2.9/modules/zh/pages/observability/monitoring-and-dashboards/configuration/examples.adoc
@@ -6,7 +6,7 @@
 
 == PodMonitor
 
-你可以在link:https://github.com/prometheus-operator/prometheus-operator/blob/master/example/user-guides/getting-started/example-app-pod-monitor.yaml[此处]找到 PodMonitor 示例，还可以在link:https://github.com/prometheus-operator/prometheus-operator/blob/master/example/user-guides/getting-started/prometheus-pod-monitor.yaml[此处]找到引用它的 Prometheus 资源示例。
+你可以在link:https://prometheus-operator.dev/docs/developer/getting-started/#using-podmonitors[此处]找到 PodMonitor 示例和引用它的 Prometheus 资源示例。
 
 == PrometheusRule
 
@@ -14,7 +14,7 @@ PrometheusRule 包含你通常放置在 https://prometheus.io/docs/prometheus/la
 
 要在集群中更细粒度地应用 PrometheusRules，你可以使用 Prometheus 资源的 ruleSelector 字段，从而根据添加到 PrometheusRules 资源的标签来选择要加载到 Prometheus 上的 PrometheusRule。
 
-你可以在link:https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/user-guides/alerting.md[此页面]找到 PrometheusRule 示例。
+你可以在link:https://prometheus-operator.dev/docs/developer/alerting/[此页面]找到 PrometheusRule 示例。
 
 == Alertmanager 配置
 

--- a/versions/v2.9/modules/zh/pages/rancher-admin/users/authn-and-authz/configure-azure-ad.adoc
+++ b/versions/v2.9/modules/zh/pages/rancher-admin/users/authn-and-authz/configure-azure-ad.adoc
@@ -201,7 +201,7 @@ Azure AD 帐户将被授予管理员权限，因为其详细信息将映射到 R
 | Key Value
 
 | 端点
-| https://login.microsoftonline.com/
+| \https://login.microsoftonline.com/
 |===
 +
 *对于自定义端点*：
@@ -286,32 +286,32 @@ image::azure-update-popup.png[Azure 更新弹出窗口]
 | Rancher 字段 | 已弃用的端点
 
 | Auth 端点
-| https://login.microsoftonline.com/\{tenantID}/oauth2/authorize
+| \https://login.microsoftonline.com/\{tenantID}/oauth2/authorize
 
 | 端点
-| https://login.microsoftonline.com/
+| \https://login.microsoftonline.com/
 
 | Graph 端点
-| https://graph.windows.net/
+| \https://graph.windows.net/
 
 | Token 端点
-| https://login.microsoftonline.com/\{tenantID}/oauth2/token
+| \https://login.microsoftonline.com/\{tenantID}/oauth2/token
 |===
 
 |===
 | Rancher 字段 | 新端点
 
 | Auth 端点
-| https://login.microsoftonline.com/\{tenantID}/oauth2/v2.0/authorize
+| \https://login.microsoftonline.com/\{tenantID}/oauth2/v2.0/authorize
 
 | 端点
-| https://login.microsoftonline.com/
+| \https://login.microsoftonline.com/
 
 | Graph 端点
-| https://graph.microsoft.com
+| \https://graph.microsoft.com
 
 | Token 端点
-| https://login.microsoftonline.com/\{tenantID}/oauth2/v2.0/token
+| \https://login.microsoftonline.com/\{tenantID}/oauth2/v2.0/token
 |===
 
 ==== 中国：
@@ -320,32 +320,32 @@ image::azure-update-popup.png[Azure 更新弹出窗口]
 | Rancher 字段 | 已弃用的端点
 
 | Auth 端点
-| https://login.chinacloudapi.cn/\{tenantID}/oauth2/authorize
+| \https://login.chinacloudapi.cn/\{tenantID}/oauth2/authorize
 
 | 端点
-| https://login.chinacloudapi.cn/
+| \https://login.chinacloudapi.cn/
 
 | Graph 端点
-| https://graph.chinacloudapi.cn/
+| \https://graph.chinacloudapi.cn/
 
 | Token 端点
-| https://login.chinacloudapi.cn/\{tenantID}/oauth2/token
+| \https://login.chinacloudapi.cn/\{tenantID}/oauth2/token
 |===
 
 |===
 | Rancher 字段 | 新端点
 
 | Auth 端点
-| https://login.partner.microsoftonline.cn/\{tenantID}/oauth2/v2.0/authorize
+| \https://login.partner.microsoftonline.cn/\{tenantID}/oauth2/v2.0/authorize
 
 | 端点
-| https://login.partner.microsoftonline.cn/
+| \https://login.partner.microsoftonline.cn/
 
 | Graph 端点
-| https://microsoftgraph.chinacloudapi.cn
+| \https://microsoftgraph.chinacloudapi.cn
 
 | Token 端点
-| https://login.partner.microsoftonline.cn/\{tenantID}/oauth2/v2.0/token
+| \https://login.partner.microsoftonline.cn/\{tenantID}/oauth2/v2.0/token
 |===
 
 == 已弃用的 Azure AD Graph API


### PR DESCRIPTION
## Description

- Promcat is [no longer active](https://github.com/sysdiglabs/promcat-resources/issues/265) so I removed the link completely.
- Jaeger has docs for v2 and v1. The v2 docs have a stable/static "latest" link, but the v1 docs which we point to don't. I've hardcoded it to the most recent released version. 