### PR TITLE
Fixing {blank} typo in Equinix Metal Quick Start

### DIFF
--- a/versions/latest/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
+++ b/versions/latest/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
@@ -13,12 +13,9 @@
 The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. The Docker install is not recommended for production environments. For comprehensive setup instructions, see xref:installation-and-upgrade/installation-and-upgrade.adoc[Installation].
 ====
 
-
 == Quick Start Outline
 
 This Quick Start Guide is divided into different tasks for easier consumption.
-
-{blank} +
 
 == Prerequisites
 
@@ -38,7 +35,6 @@ Begin deploying an Equinix Metal Host. Equinix Metal Servers can be provisioned 
 * For a full list of port requirements, refer to xref:cluster-deployment/node-requirements.adoc[Docker Installation].
 * Provision the host according to our xref:installation-and-upgrade/requirements/requirements.adoc[Requirements].
 ====
-
 
 === 2. Install Rancher
 
@@ -65,8 +61,6 @@ Replace `<SERVER_IP>` with your host IP address.
 . Set the *Rancher Server URL*. The URL can either be an IP address or a host name. However, each node added to your cluster must be able to connect to this URL. +
  +
 If you use a hostname in the URL, this hostname must be resolvable by DNS on the nodes you want to add to you cluster.
-
-{blank} +
 
 === 4. Create the Cluster
 

--- a/versions/latest/modules/zh/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
+++ b/versions/latest/modules/zh/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
@@ -18,8 +18,6 @@
 
 本指南划分为不同任务，以便于使用。
 
-{blank} +
-
 == 先决条件
 
 * https://deploy.equinix.com/developers/docs/metal/identity-access-management/users/[Equinix Metal 账号]
@@ -68,8 +66,6 @@ sudo docker run -d --restart=unless-stopped -p 80:80 -p 443:443 --privileged ran
 . 设置 *Rancher Server URL*。URL 可以是 IP 地址或主机名。需要注意，添加到集群中的每个节点都必须能够连接到此 URL。 +
  +
 如果你在 URL 中使用主机名，则此主机名必须在 DNS 中解析到你需要添加到集群的节点上。
-
-{blank} +
 
 === 4. 创建集群
 

--- a/versions/latest/modules/zh/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
+++ b/versions/latest/modules/zh/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
@@ -66,7 +66,7 @@ sudo docker run -d --restart=unless-stopped -p 80:80 -p 443:443 --privileged ran
 . 设置 *Rancher Server URL*。URL 可以是 IP 地址或主机名。需要注意，添加到集群中的每个节点都必须能够连接到此 URL。 +
  +
 如果你在 URL 中使用主机名，则此主机名必须在 DNS 中解析到你需要添加到集群的节点上。
-
+ 
 === 4. 创建集群
 
 欢迎使用 Rancher！现在，你可以创建你的第一个 Kubernetes 集群了。

--- a/versions/v2.10/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
+++ b/versions/v2.10/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
@@ -13,12 +13,9 @@
 The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. The Docker install is not recommended for production environments. For comprehensive setup instructions, see xref:installation-and-upgrade/installation-and-upgrade.adoc[Installation].
 ====
 
-
 == Quick Start Outline
 
 This Quick Start Guide is divided into different tasks for easier consumption.
-
-{blank} +
 
 == Prerequisites
 
@@ -38,7 +35,6 @@ Begin deploying an Equinix Metal Host. Equinix Metal Servers can be provisioned 
 * For a full list of port requirements, refer to xref:cluster-deployment/node-requirements.adoc[Docker Installation].
 * Provision the host according to our xref:installation-and-upgrade/requirements/requirements.adoc[Requirements].
 ====
-
 
 === 2. Install Rancher
 
@@ -65,8 +61,6 @@ Replace `<SERVER_IP>` with your host IP address.
 . Set the *Rancher Server URL*. The URL can either be an IP address or a host name. However, each node added to your cluster must be able to connect to this URL. +
  +
 If you use a hostname in the URL, this hostname must be resolvable by DNS on the nodes you want to add to you cluster.
-
-{blank} +
 
 === 4. Create the Cluster
 

--- a/versions/v2.10/modules/zh/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
+++ b/versions/v2.10/modules/zh/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
@@ -18,8 +18,6 @@
 
 本指南划分为不同任务，以便于使用。
 
-{blank} +
-
 == 先决条件
 
 * https://deploy.equinix.com/developers/docs/metal/identity-access-management/users/[Equinix Metal 账号]
@@ -68,8 +66,6 @@ sudo docker run -d --restart=unless-stopped -p 80:80 -p 443:443 --privileged ran
 . 设置 *Rancher Server URL*。URL 可以是 IP 地址或主机名。需要注意，添加到集群中的每个节点都必须能够连接到此 URL。 +
  +
 如果你在 URL 中使用主机名，则此主机名必须在 DNS 中解析到你需要添加到集群的节点上。
-
-{blank} +
 
 === 4. 创建集群
 

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
@@ -13,12 +13,9 @@
 The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. The Docker install is not recommended for production environments. For comprehensive setup instructions, see xref:installation-and-upgrade/installation-and-upgrade.adoc[Installation].
 ====
 
-
 == Quick Start Outline
 
 This Quick Start Guide is divided into different tasks for easier consumption.
-
-{blank} +
 
 == Prerequisites
 
@@ -38,7 +35,6 @@ Begin deploying an Equinix Metal Host. Equinix Metal Servers can be provisioned 
 * For a full list of port requirements, refer to xref:cluster-deployment/node-requirements.adoc[Docker Installation].
 * Provision the host according to our xref:installation-and-upgrade/requirements/requirements.adoc[Requirements].
 ====
-
 
 === 2. Install Rancher
 
@@ -65,8 +61,6 @@ Replace `<SERVER_IP>` with your host IP address.
 . Set the *Rancher Server URL*. The URL can either be an IP address or a host name. However, each node added to your cluster must be able to connect to this URL. +
  +
 If you use a hostname in the URL, this hostname must be resolvable by DNS on the nodes you want to add to you cluster.
-
-{blank} +
 
 === 4. Create the Cluster
 

--- a/versions/v2.11/modules/zh/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
+++ b/versions/v2.11/modules/zh/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
@@ -18,8 +18,6 @@
 
 本指南划分为不同任务，以便于使用。
 
-{blank} +
-
 == 先决条件
 
 * https://deploy.equinix.com/developers/docs/metal/identity-access-management/users/[Equinix Metal 账号]
@@ -68,8 +66,6 @@ sudo docker run -d --restart=unless-stopped -p 80:80 -p 443:443 --privileged ran
 . 设置 *Rancher Server URL*。URL 可以是 IP 地址或主机名。需要注意，添加到集群中的每个节点都必须能够连接到此 URL。 +
  +
 如果你在 URL 中使用主机名，则此主机名必须在 DNS 中解析到你需要添加到集群的节点上。
-
-{blank} +
 
 === 4. 创建集群
 

--- a/versions/v2.8/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
+++ b/versions/v2.8/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
@@ -13,12 +13,9 @@
 The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. The Docker install is not recommended for production environments. For comprehensive setup instructions, see xref:installation-and-upgrade/installation-and-upgrade.adoc[Installation].
 ====
 
-
 == Quick Start Outline
 
 This Quick Start Guide is divided into different tasks for easier consumption.
-
-{blank} +
 
 == Prerequisites
 
@@ -38,7 +35,6 @@ Begin deploying an Equinix Metal Host. Equinix Metal Servers can be provisioned 
 * For a full list of port requirements, refer to xref:cluster-deployment/node-requirements.adoc[Docker Installation].
 * Provision the host according to our xref:installation-and-upgrade/requirements/requirements.adoc[Requirements].
 ====
-
 
 === 2. Install Rancher
 
@@ -65,8 +61,6 @@ Replace `<SERVER_IP>` with your host IP address.
 . Set the *Rancher Server URL*. The URL can either be an IP address or a host name. However, each node added to your cluster must be able to connect to this URL. +
  +
 If you use a hostname in the URL, this hostname must be resolvable by DNS on the nodes you want to add to you cluster.
-
-{blank} +
 
 === 4. Create the Cluster
 

--- a/versions/v2.8/modules/zh/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
+++ b/versions/v2.8/modules/zh/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
@@ -18,8 +18,6 @@
 
 本指南划分为不同任务，以便于使用。
 
-{blank} +
-
 == 先决条件
 
 * https://deploy.equinix.com/developers/docs/metal/identity-access-management/users/[Equinix Metal 账号]
@@ -68,8 +66,6 @@ sudo docker run -d --restart=unless-stopped -p 80:80 -p 443:443 --privileged ran
 . 设置 *Rancher Server URL*。URL 可以是 IP 地址或主机名。需要注意，添加到集群中的每个节点都必须能够连接到此 URL。 +
  +
 如果你在 URL 中使用主机名，则此主机名必须在 DNS 中解析到你需要添加到集群的节点上。
-
-{blank} +
 
 === 4. 创建集群
 

--- a/versions/v2.9/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
+++ b/versions/v2.9/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
@@ -13,12 +13,9 @@
 The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. The Docker install is not recommended for production environments. For comprehensive setup instructions, see xref:installation-and-upgrade/installation-and-upgrade.adoc[Installation].
 ====
 
-
 == Quick Start Outline
 
 This Quick Start Guide is divided into different tasks for easier consumption.
-
-{blank} +
 
 == Prerequisites
 
@@ -38,7 +35,6 @@ Begin deploying an Equinix Metal Host. Equinix Metal Servers can be provisioned 
 * For a full list of port requirements, refer to xref:cluster-deployment/node-requirements.adoc[Docker Installation].
 * Provision the host according to our xref:installation-and-upgrade/requirements/requirements.adoc[Requirements].
 ====
-
 
 === 2. Install Rancher
 
@@ -65,8 +61,6 @@ Replace `<SERVER_IP>` with your host IP address.
 . Set the *Rancher Server URL*. The URL can either be an IP address or a host name. However, each node added to your cluster must be able to connect to this URL. +
  +
 If you use a hostname in the URL, this hostname must be resolvable by DNS on the nodes you want to add to you cluster.
-
-{blank} +
 
 === 4. Create the Cluster
 

--- a/versions/v2.9/modules/zh/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
+++ b/versions/v2.9/modules/zh/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
@@ -18,8 +18,6 @@
 
 本指南划分为不同任务，以便于使用。
 
-{blank} +
-
 == 先决条件
 
 * https://deploy.equinix.com/developers/docs/metal/identity-access-management/users/[Equinix Metal 账号]
@@ -68,8 +66,6 @@ sudo docker run -d --restart=unless-stopped -p 80:80 -p 443:443 --privileged ran
 . 设置 *Rancher Server URL*。URL 可以是 IP 地址或主机名。需要注意，添加到集群中的每个节点都必须能够连接到此 URL。 +
  +
 如果你在 URL 中使用主机名，则此主机名必须在 DNS 中解析到你需要添加到集群的节点上。
-
-{blank} +
 
 === 4. 创建集群
 


### PR DESCRIPTION
Refer to the unequal blank space between headings in [Equinix metal](https://documentation.suse.com/cloudnative/rancher-manager/latest/en/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.html)