### PR TITLE
Updating "About rancher-selinux"

### DIFF
--- a/versions/latest/modules/en/pages/security/selinux-rpm/about-rancher-selinux.adoc
+++ b/versions/latest/modules/en/pages/security/selinux-rpm/about-rancher-selinux.adoc
@@ -1,8 +1,8 @@
 = About rancher-selinux
 
-To allow Rancher to work with SELinux, some functionality has to be manually enabled for the SELinux nodes. To help with that, Rancher provides a SELinux RPM.
+To allow Rancher to work with SELinux, some functionality has to be manually enabled for the SELinux nodes. To help with that, Rancher provides an SELinux RPM.
 
-The `rancher-selinux` RPM only contains policies for the https://github.com/rancher/charts/tree/dev-v2.5/charts/rancher-logging[rancher-logging application.]
+The `rancher-selinux` RPM contains a set of SELinux policies designed to grant the necessary privileges to various Rancher components running on Linux systems with SELinux enabled.
 
 The `rancher-selinux` GitHub repository is https://github.com/rancher/rancher-selinux[here.]
 

--- a/versions/latest/modules/zh/pages/security/selinux-rpm/about-rancher-selinux.adoc
+++ b/versions/latest/modules/zh/pages/security/selinux-rpm/about-rancher-selinux.adoc
@@ -2,7 +2,7 @@
 
 要让 Rancher 使用 SELinux，你必须手动为 SELinux 节点启用一些功能。为了解决这个问题，Rancher 提供了一个 SELinux RPM。
 
-`rancher-selinux` RPM 仅包含 https://github.com/rancher/charts/tree/dev-v2.5/charts/rancher-logging[rancher-logging 应用程序]的策略。
+The `rancher-selinux` RPM contains a set of SELinux policies designed to grant the necessary privileges to various Rancher components running on Linux systems with SELinux enabled.
 
 `rancher-selinux` 的 GitHub 仓库在link:https://github.com/rancher/rancher-selinux[这里]。
 

--- a/versions/v2.10/modules/en/pages/security/selinux-rpm/about-rancher-selinux.adoc
+++ b/versions/v2.10/modules/en/pages/security/selinux-rpm/about-rancher-selinux.adoc
@@ -1,8 +1,8 @@
 = About rancher-selinux
 
-To allow Rancher to work with SELinux, some functionality has to be manually enabled for the SELinux nodes. To help with that, Rancher provides a SELinux RPM.
+To allow Rancher to work with SELinux, some functionality has to be manually enabled for the SELinux nodes. To help with that, Rancher provides an SELinux RPM.
 
-The `rancher-selinux` RPM only contains policies for the https://github.com/rancher/charts/tree/dev-v2.5/charts/rancher-logging[rancher-logging application.]
+The `rancher-selinux` RPM contains a set of SELinux policies designed to grant the necessary privileges to various Rancher components running on Linux systems with SELinux enabled.
 
 The `rancher-selinux` GitHub repository is https://github.com/rancher/rancher-selinux[here.]
 

--- a/versions/v2.10/modules/zh/pages/security/selinux-rpm/about-rancher-selinux.adoc
+++ b/versions/v2.10/modules/zh/pages/security/selinux-rpm/about-rancher-selinux.adoc
@@ -2,7 +2,7 @@
 
 要让 Rancher 使用 SELinux，你必须手动为 SELinux 节点启用一些功能。为了解决这个问题，Rancher 提供了一个 SELinux RPM。
 
-`rancher-selinux` RPM 仅包含 https://github.com/rancher/charts/tree/dev-v2.5/charts/rancher-logging[rancher-logging 应用程序]的策略。
+The `rancher-selinux` RPM contains a set of SELinux policies designed to grant the necessary privileges to various Rancher components running on Linux systems with SELinux enabled.
 
 `rancher-selinux` 的 GitHub 仓库在link:https://github.com/rancher/rancher-selinux[这里]。
 

--- a/versions/v2.11/modules/en/pages/security/selinux-rpm/about-rancher-selinux.adoc
+++ b/versions/v2.11/modules/en/pages/security/selinux-rpm/about-rancher-selinux.adoc
@@ -1,8 +1,8 @@
 = About rancher-selinux
 
-To allow Rancher to work with SELinux, some functionality has to be manually enabled for the SELinux nodes. To help with that, Rancher provides a SELinux RPM.
+To allow Rancher to work with SELinux, some functionality has to be manually enabled for the SELinux nodes. To help with that, Rancher provides an SELinux RPM.
 
-The `rancher-selinux` RPM only contains policies for the https://github.com/rancher/charts/tree/dev-v2.5/charts/rancher-logging[rancher-logging application.]
+The `rancher-selinux` RPM contains a set of SELinux policies designed to grant the necessary privileges to various Rancher components running on Linux systems with SELinux enabled.
 
 The `rancher-selinux` GitHub repository is https://github.com/rancher/rancher-selinux[here.]
 

--- a/versions/v2.11/modules/zh/pages/security/selinux-rpm/about-rancher-selinux.adoc
+++ b/versions/v2.11/modules/zh/pages/security/selinux-rpm/about-rancher-selinux.adoc
@@ -2,7 +2,7 @@
 
 要让 Rancher 使用 SELinux，你必须手动为 SELinux 节点启用一些功能。为了解决这个问题，Rancher 提供了一个 SELinux RPM。
 
-`rancher-selinux` RPM 仅包含 https://github.com/rancher/charts/tree/dev-v2.5/charts/rancher-logging[rancher-logging 应用程序]的策略。
+The `rancher-selinux` RPM contains a set of SELinux policies designed to grant the necessary privileges to various Rancher components running on Linux systems with SELinux enabled.
 
 `rancher-selinux` 的 GitHub 仓库在link:https://github.com/rancher/rancher-selinux[这里]。
 

--- a/versions/v2.8/modules/en/pages/security/selinux-rpm/about-rancher-selinux.adoc
+++ b/versions/v2.8/modules/en/pages/security/selinux-rpm/about-rancher-selinux.adoc
@@ -1,8 +1,8 @@
 = About rancher-selinux
 
-To allow Rancher to work with SELinux, some functionality has to be manually enabled for the SELinux nodes. To help with that, Rancher provides a SELinux RPM.
+To allow Rancher to work with SELinux, some functionality has to be manually enabled for the SELinux nodes. To help with that, Rancher provides an SELinux RPM.
 
-The `rancher-selinux` RPM only contains policies for the https://github.com/rancher/charts/tree/dev-v2.5/charts/rancher-logging[rancher-logging application.]
+The `rancher-selinux` RPM contains a set of SELinux policies designed to grant the necessary privileges to various Rancher components running on Linux systems with SELinux enabled.
 
 The `rancher-selinux` GitHub repository is https://github.com/rancher/rancher-selinux[here.]
 

--- a/versions/v2.8/modules/zh/pages/security/selinux-rpm/about-rancher-selinux.adoc
+++ b/versions/v2.8/modules/zh/pages/security/selinux-rpm/about-rancher-selinux.adoc
@@ -2,7 +2,7 @@
 
 要让 Rancher 使用 SELinux，你必须手动为 SELinux 节点启用一些功能。为了解决这个问题，Rancher 提供了一个 SELinux RPM。
 
-`rancher-selinux` RPM 仅包含 https://github.com/rancher/charts/tree/dev-v2.5/charts/rancher-logging[rancher-logging 应用程序]的策略。
+The `rancher-selinux` RPM contains a set of SELinux policies designed to grant the necessary privileges to various Rancher components running on Linux systems with SELinux enabled.
 
 `rancher-selinux` 的 GitHub 仓库在link:https://github.com/rancher/rancher-selinux[这里]。
 

--- a/versions/v2.9/modules/en/pages/security/selinux-rpm/about-rancher-selinux.adoc
+++ b/versions/v2.9/modules/en/pages/security/selinux-rpm/about-rancher-selinux.adoc
@@ -1,8 +1,8 @@
 = About rancher-selinux
 
-To allow Rancher to work with SELinux, some functionality has to be manually enabled for the SELinux nodes. To help with that, Rancher provides a SELinux RPM.
+To allow Rancher to work with SELinux, some functionality has to be manually enabled for the SELinux nodes. To help with that, Rancher provides an SELinux RPM.
 
-The `rancher-selinux` RPM only contains policies for the https://github.com/rancher/charts/tree/dev-v2.5/charts/rancher-logging[rancher-logging application.]
+The `rancher-selinux` RPM contains a set of SELinux policies designed to grant the necessary privileges to various Rancher components running on Linux systems with SELinux enabled.
 
 The `rancher-selinux` GitHub repository is https://github.com/rancher/rancher-selinux[here.]
 

--- a/versions/v2.9/modules/zh/pages/security/selinux-rpm/about-rancher-selinux.adoc
+++ b/versions/v2.9/modules/zh/pages/security/selinux-rpm/about-rancher-selinux.adoc
@@ -2,7 +2,7 @@
 
 要让 Rancher 使用 SELinux，你必须手动为 SELinux 节点启用一些功能。为了解决这个问题，Rancher 提供了一个 SELinux RPM。
 
-`rancher-selinux` RPM 仅包含 https://github.com/rancher/charts/tree/dev-v2.5/charts/rancher-logging[rancher-logging 应用程序]的策略。
+The `rancher-selinux` RPM contains a set of SELinux policies designed to grant the necessary privileges to various Rancher components running on Linux systems with SELinux enabled.
 
 `rancher-selinux` 的 GitHub 仓库在link:https://github.com/rancher/rancher-selinux[这里]。
 


### PR DESCRIPTION
Updating outdated information with [GH definition of `rancher-selinux`](https://github.com/rancher/rancher-selinux#:~:text=rancher%2Dselinux%20contains%20a%20set%20of%20SELinux%20policies%20designed%20to%20grant%20the%20necessary%20privileges%20to%20various%20Rancher%20components%20running%20on%20Linux%20systems%20with%20SELinux%20enabled.) referenced on Slack thread.