### PR TITLE
Updating the latest/v2.11 docs attribute list - CAPI release

### DIFF
--- a/versions/latest/antora.yml
+++ b/versions/latest/antora.yml
@@ -27,4 +27,4 @@ asciidoc:
     kubewarden-docs-version: 1.25
     elemental-docs-version: 1.6
     fleet-docs-version: v0.12
-    turtles-docs-version: v0.20
+    turtles-docs-version: v0.21

--- a/versions/v2.11/antora.yml
+++ b/versions/v2.11/antora.yml
@@ -27,4 +27,4 @@ asciidoc:
     kubewarden-docs-version: 1.25
     elemental-docs-version: 1.6
     fleet-docs-version: v0.12
-    turtles-docs-version: v0.20
+    turtles-docs-version: v0.21


### PR DESCRIPTION
Updating the latest/v2.11 docs attribute list with latest CAPI version release.