### PR TITLE
Sync Community PR #1941 (Remove RKE- /getting-started section)

### DIFF
--- a/versions/latest/modules/en/pages/installation-and-upgrade/install-rancher.adoc
+++ b/versions/latest/modules/en/pages/installation-and-upgrade/install-rancher.adoc
@@ -1,5 +1,5 @@
 = Install/Upgrade {rancher-product-name} on a Kubernetes Cluster
-:revdate: 2025-03-17
+:revdate: 2025-08-25
 :page-revdate: {revdate}
 :description: Learn how to install Rancher in development and production environments. Read about single node and high availability installation
 
@@ -19,7 +19,6 @@ Rancher can be installed on any Kubernetes cluster. This cluster can use upstrea
 
 For help setting up a Kubernetes cluster, we provide these tutorials:
 
-* *RKE:* For the tutorial to install an RKE Kubernetes cluster, refer to xref:installation-and-upgrade/install-kubernetes/rke1-for-rancher.adoc[this page.] For help setting up the infrastructure for a high-availability RKE cluster, refer to xref:installation-and-upgrade/infrastructure-setup/ha-rke1-kubernetes-cluster.adoc[this page.]
 * *K3s:* For the tutorial to install a K3s Kubernetes cluster, refer to xref:installation-and-upgrade/install-kubernetes/k3s-for-rancher.adoc[this page.] For help setting up the infrastructure for a high-availability K3s cluster, refer to xref:installation-and-upgrade/infrastructure-setup/ha-k3s-kubernetes-cluster.adoc[this page.]
 * *RKE2:* For the tutorial to install an RKE2 Kubernetes cluster, refer to xref:installation-and-upgrade/install-kubernetes/rke2-for-rancher.adoc[this page.] For help setting up the infrastructure for a high-availability RKE2 cluster, refer to xref:installation-and-upgrade/infrastructure-setup/ha-rke2-kubernetes-cluster.adoc[this page.]
 * *Amazon EKS:* For details on how to install Rancher on Amazon EKS, including how to install an Ingress controller so that the Rancher server can be accessed, refer to xref:installation-and-upgrade/hosted-kubernetes/rancher-on-amazon-eks.adoc[this page.]
@@ -30,7 +29,7 @@ For help setting up a Kubernetes cluster, we provide these tutorials:
 
 The Rancher UI and API are exposed through an Ingress. This means the Kubernetes cluster that you install Rancher in must contain an Ingress controller.
 
-For RKE, RKE2, and K3s installations, you don't have to install the Ingress controller manually because one is installed by default.
+For RKE2 and K3s installations, you don't have to install the Ingress controller manually because one is installed by default.
 
 For distributions that do not include an Ingress Controller by default, like a hosted Kubernetes cluster such as EKS, GKE, or AKS, you have to deploy an Ingress controller first. Note that the Rancher Helm chart does not set an `ingressClassName` on the ingress by default. Because of this, you have to configure the Ingress controller to also watch ingresses without an `ingressClassName`.
 

--- a/versions/latest/modules/en/pages/installation-and-upgrade/references/feature-flags.adoc
+++ b/versions/latest/modules/en/pages/installation-and-upgrade/references/feature-flags.adoc
@@ -1,5 +1,5 @@
 = Feature Flags
-:revdate: 2025-06-20
+:revdate: 2025-08-25
 :page-revdate: {revdate}
 
 With feature flags, you can try out optional or experimental features, and enable legacy features that are being phased out.
@@ -25,7 +25,6 @@ The following is a list of feature flags available in Rancher. If you've upgrade
 * `legacy`: Enables a set of features from 2.5.x and earlier, that are slowly being phased out in favor of newer implementations. These are a mix of deprecated features as well as features that will eventually be available to newer versions. This flag is disabled by default on new Rancher installations. If you're upgrading from a previous version of Rancher, this flag is enabled.
 * `managed-system-upgrade-controller`: Enables the installation of the system-upgrade-controller app in downstream RKE2/K3s clusters, currently limited to imported clusters and the local cluster, with plans to expand support to node-driver clusters.
 * `multi-cluster-management`: Allows multi-cluster provisioning and management of Kubernetes clusters. This flag can only be set at install time. It can't be enabled or disabled later.
-* `rke1-custom-node-cleanup`: Enables cleanup of deleted RKE1 custom nodes. We recommend that you keep this flag enabled, to prevent removed nodes from attempting to rejoin the cluster.
 * `rke2`: Enables provisioning RKE2 clusters. This flag is enabled by default.
 * `token-hashing`: Enables token hashing. Once enabled, existing tokens will be hashed and all new tokens will be hashed automatically with the SHA256 algorithm. Once a token is hashed it can't be undone. This flag can't be disabled after its enabled. See xref:api/api-tokens.adoc#_token_hashing[API Tokens] for more information.
 * `uiextension`: Enables UI extensions. This flag is enabled by default. Enabling or disabling the flag forces the Rancher pod to restart. The first time this flag is set to `true`, it creates a CRD and enables the controllers and endpoints necessary for the feature to work. If set to `false`, it disables the previously mentioned controllers and endpoints. Setting `uiextension` to `false` has no effect on the CRD -- it does not create a CRD if it does not yet exist, nor does it delete the CRD if it already exists.
@@ -95,12 +94,6 @@ The following table shows the availability and default values for some feature f
 | `true`
 | GA
 | v2.10.0
-|
-
-| `rke1-custom-node-cleanup`
-| `true`
-| GA
-| v2.6.0
 |
 
 | `rke2`

--- a/versions/latest/modules/en/pages/installation-and-upgrade/references/helm-chart-options.adoc
+++ b/versions/latest/modules/en/pages/installation-and-upgrade/references/helm-chart-options.adoc
@@ -1,5 +1,5 @@
 = {rancher-product-name} Helm Chart Options
-:revdate: 2025-07-11
+:revdate: 2025-08-25
 :page-revdate: {revdate}
 :keywords: ["rancher helm chart", "rancher helm options", "rancher helm chart options", "helm chart rancher", "helm options rancher", "helm chart options rancher"]
 
@@ -375,16 +375,6 @@ Your load balancer must support long lived websocket connections and will need t
 === Configuring Ingress for External TLS when Using NGINX v0.22
 
 In NGINX v0.22, the behavior of NGINX has https://github.com/kubernetes/ingress-nginx/blob/06efac9f0b6f8f84b553f58ccecf79dc42c75cc6/Changelog.md[changed] regarding forwarding headers and external TLS termination. Therefore, in the scenario that you are using external TLS termination configuration with NGINX v0.22, you must enable the `use-forwarded-headers` option for ingress:
-
-For RKE installations, edit the `cluster.yml` to add the following settings.
-
-[,yaml]
-----
-ingress:
-  provider: nginx
-  options:
-    use-forwarded-headers: 'true'
-----
 
 For RKE2 installations, you can create a custom `rke2-ingress-nginx-config.yaml` file at `/var/lib/rancher/rke2/server/manifests/rke2-ingress-nginx-config.yaml` containing this required setting to enable using forwarded headers with external TLS termination. Without this required setting applied, the external LB will continuously respond with redirect loops it receives from the ingress controller. (This can be created before or after rancher is installed, rke2 server agent will notice this addition and automatically apply it.)
 

--- a/versions/latest/modules/en/pages/installation-and-upgrade/references/tls-settings.adoc
+++ b/versions/latest/modules/en/pages/installation-and-upgrade/references/tls-settings.adoc
@@ -1,5 +1,5 @@
 = TLS Settings
-:revdate: 2024-09-23
+:revdate: 2025-08-25
 :page-revdate: {revdate}
 
 Changing the default TLS settings depends on the chosen installation method.
@@ -8,7 +8,7 @@ Changing the default TLS settings depends on the chosen installation method.
 
 When you install Rancher inside of a Kubernetes cluster, TLS is offloaded at the cluster's ingress controller. The possible TLS settings depend on the used ingress controller:
 
-* nginx-ingress-controller (default for RKE1 and RKE2): https://kubernetes.github.io/ingress-nginx/user-guide/tls/#default-tls-version-and-ciphers[Default TLS Version and Ciphers].
+* nginx-ingress-controller (default for RKE2): https://kubernetes.github.io/ingress-nginx/user-guide/tls/#default-tls-version-and-ciphers[Default TLS Version and Ciphers].
 * traefik (default for K3s): https://doc.traefik.io/traefik/https/tls/#tls-options[TLS Options].
 
 == Running Rancher in a single Docker container

--- a/versions/latest/modules/en/pages/installation-and-upgrade/troubleshooting/troubleshooting.adoc
+++ b/versions/latest/modules/en/pages/installation-and-upgrade/troubleshooting/troubleshooting.adoc
@@ -1,5 +1,5 @@
 = Troubleshooting the {rancher-product-name} Server Kubernetes Cluster
-:revdate: 2024-09-27
+:revdate: 2025-08-25
 :page-revdate: {revdate}
 
 This section describes how to troubleshoot an installation of Rancher on a Kubernetes cluster.
@@ -166,17 +166,9 @@ See https://docs.docker.com/install/linux/linux-postinstall/#manage-docker-as-a-
  $ nc xxx.xxx.xxx.xxx 22
  SSH-2.0-OpenSSH_6.6.1p1 Ubuntu-2ubuntu2.10
 
-== Failed to dial ssh using address [xxx.xxx.xxx.xxx:xx]: Error configuring SSH: ssh: no key found
-
-The key file specified as `ssh_key_path` cannot be accessed. Make sure that you specified the private key file (not the public key, `.pub`), and that the user that is running the `rke` command can access the private key file.
-
 == Failed to dial ssh using address [xxx.xxx.xxx.xxx:xx]: ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain
 
 The key file specified as `ssh_key_path` is not correct for accessing the node. Double-check if you specified the correct `ssh_key_path` for the node and if you specified the correct user to connect with.
-
-== Failed to dial ssh using address [xxx.xxx.xxx.xxx:xx]: Error configuring SSH: ssh: cannot decode encrypted private keys
-
-If you want to use encrypted private keys, you should use `ssh-agent` to load your keys with your passphrase. If the `SSH_AUTH_SOCK` environment variable is found in the environment where the `rke` command is run, it will be used automatically to connect to the node.
 
 == Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
 

--- a/versions/latest/modules/en/pages/installation-and-upgrade/upgrades.adoc
+++ b/versions/latest/modules/en/pages/installation-and-upgrade/upgrades.adoc
@@ -1,12 +1,10 @@
 = Upgrades
-:revdate: 2025-03-09
+:revdate: 2025-08-25
 :page-revdate: {revdate}
 
 The following instructions will guide you through upgrading a Rancher server that was installed on a Kubernetes cluster with Helm. These steps also apply to air-gapped installs with Helm.
 
 For the instructions to upgrade Rancher installed with Docker, refer to xref:[this page.]
-
-To upgrade the components in your Kubernetes cluster, or the definition of the https://rancher.com/docs/rke/latest/en/config-options/services/[Kubernetes services] or https://rancher.com/docs/rke/latest/en/config-options/add-ons/[add-ons], refer to the https://rancher.com/docs/rke/latest/en/upgrades/[upgrade documentation for RKE], the Rancher Kubernetes Engine.
 
 == Prerequisites
 
@@ -14,7 +12,7 @@ To upgrade the components in your Kubernetes cluster, or the definition of the h
 
 Helm should be run from the same location as your kubeconfig file, or the same location where you run your kubectl commands from.
 
-If you installed Kubernetes with RKE, the config will have been created in the directory you ran `rke up` in.
+If you installed Kubernetes with RKE2/K3s, the Kubeconfig is stored in the `/etc/rancher/rke2/rke2.yaml` or `/etc/rancher/k3s/k3s.yaml` directory depending on your chosen distribution.
 
 The kubeconfig can also be manually targeted for the intended cluster with the `--kubeconfig` tag (see: https://helm.sh/docs/helm/helm/)
 

--- a/versions/latest/modules/zh/pages/installation-and-upgrade/install-rancher.adoc
+++ b/versions/latest/modules/zh/pages/installation-and-upgrade/install-rancher.adoc
@@ -1,5 +1,5 @@
 = 在 Kubernetes 集群上安装/升级 {rancher-product-name}
-:revdate: 2025-03-17
+:revdate: 2025-08-25
 :page-revdate: {revdate}
 :description: 了解如何在开发和生产环境中安装 Rancher。了解单节点和高可用安装
 
@@ -19,7 +19,6 @@ Rancher 可以安装在任何 Kubernetes 集群上。这个集群可以使用上
 
 你可参考以下教程，以获得设置 Kubernetes 集群的帮助：
 
-* *RKE*：xref:installation-and-upgrade/install-kubernetes/rke1-for-rancher.adoc[安装 RKE Kubernetes 集群的教程]；xref:installation-and-upgrade/infrastructure-setup/ha-rke1-kubernetes-cluster.adoc[为高可用 RKE 集群设置基础设施的教程]。
 * *K3s*：xref:installation-and-upgrade/install-kubernetes/k3s-for-rancher.adoc[安装 K3s Kubernetes 集群的教程]；xref:installation-and-upgrade/infrastructure-setup/ha-k3s-kubernetes-cluster.adoc[设置高可用 K3s 集群的基础设施的教程]。
 * *RKE2:* ：xref:installation-and-upgrade/install-kubernetes/rke2-for-rancher.adoc[安装 RKE2 Kubernetes 集群的教程]；xref:installation-and-upgrade/infrastructure-setup/ha-rke2-kubernetes-cluster.adoc[设置高可用 RKE2 集群的基础设施的教程]。
 * *Amazon EKS*：xref:installation-and-upgrade/hosted-kubernetes/rancher-on-amazon-eks.adoc[在 Amazon EKS 上安装 Rancher 以及如何安装 Ingress Controller 以访问 Rancher Server]。
@@ -30,7 +29,7 @@ Rancher 可以安装在任何 Kubernetes 集群上。这个集群可以使用上
 
 Rancher UI 和 API 通过 Ingress 公开。换言之，安装 Rancher 的 Kubernetes 集群必须包含一个 Ingress Controller。
 
-对于 RKE、RKE2 和 K3s，你不需要手动安装 Ingress Controller，因为它是默认安装的。
+对于 RKE2 和 K3s，你不需要手动安装 Ingress Controller，因为它是默认安装的。
 
 对于默认不包含 Ingress Controller 的发行版（例如 EKS、GKE 或 AKS 等托管 Kubernetes 集群），你必须先部署 Ingress Controller。请注意，Rancher Helm Chart 默认情况下不会在 Ingress 上设置 `ingressClassName`。因此，你必须将 Ingress Controller 配置为在没有 `ingressClassName` 的情况下也可以监视 Ingress。
 

--- a/versions/latest/modules/zh/pages/installation-and-upgrade/references/feature-flags.adoc
+++ b/versions/latest/modules/zh/pages/installation-and-upgrade/references/feature-flags.adoc
@@ -1,5 +1,5 @@
 = 功能开关
-:revdate: 2025-06-20
+:revdate: 2025-08-25
 :page-revdate: {revdate}
 
 使用功能开关（Feature Flag），你可以试用可选或实验性的功能并启用正在逐步淘汰的旧版功能。
@@ -25,7 +25,6 @@
 * `legacy`：启用 2.5.x 及更早版本的一组功能，这些功能正逐渐被新的实现淘汰。它们是已弃用以及后续可用于新版本的功能组合。新的 Rancher 安装会默认禁用此标志。如果你从以前版本的 Rancher 升级，此标志会启用。
 * `managed-system-upgrade-controller`: Enables the installation of the system-upgrade-controller app in downstream RKE2/K3s clusters, currently limited to imported clusters and the local cluster, with plans to expand support to node-driver clusters.
 * `multi-cluster-management`：允许配置和管理多个 Kubernetes 集群。此标志只能在安装时设置。后续无法启用或禁用它。
-* `rke1-custom-node-cleanup`：清除已删除的 RKE1 自定义节点。建议你启用此标志，以防止已删除的节点尝试重新加入集群。
 * `rke2`：启用配置 RKE2 集群。此标志默认启用。
 * `token-hashing`：启用令牌哈希。启用后，会使用 SHA256 算法对现有 Token 和所有新 Token 进行哈希处理。一旦对 Token 进行哈希处理，就无法撤消操作。此标志在启用后无法禁用。有关详细信息，请参阅 xref:api/api-tokens.adoc#_令牌哈希[API 令牌]。
 * `unsupported-storage-drivers`：允许启用非默认启用的存储提供程序和卷插件。有关详细信息，请参阅xref:rancher-admin/experimental-features/unsupported-storage-drivers.adoc[允许使用不受支持的存储驱动程序]。
@@ -93,12 +92,6 @@
 | `true`
 | GA
 | v2.10.0
-|
-
-| `rke1-custom-node-cleanup`
-| `true`
-| GA
-| v2.6.0
 |
 
 | `rke2`

--- a/versions/latest/modules/zh/pages/installation-and-upgrade/references/tls-settings.adoc
+++ b/versions/latest/modules/zh/pages/installation-and-upgrade/references/tls-settings.adoc
@@ -1,5 +1,5 @@
 = TLS 设置
-:revdate: 2024-09-25
+:revdate: 2025-08-25
 :page-revdate: {revdate}
 
 更改默认 TLS 设置的方法取决于它的安装方式。
@@ -8,7 +8,7 @@
 
 当你在 Kubernetes 集群内安装 Rancher 时，TLS 会在集群的 Ingress Controller 上卸载。可用的 TLS 设置取决于使用的 Ingress Controller：
 
-* nginx-ingress-controller（RKE1 和 RKE2 默认）：link:https://kubernetes.github.io/ingress-nginx/user-guide/tls/#default-tls-version-and-ciphers[默认的 TLS 版本和密码]。
+* nginx-ingress-controller（RKE2 默认）：link:https://kubernetes.github.io/ingress-nginx/user-guide/tls/#default-tls-version-and-ciphers[默认的 TLS 版本和密码]。
 * traefik（K3s 默认）：link:https://doc.traefik.io/traefik/https/tls/#tls-options[TLS 选项]。
 
 == 在单个 Docker 容器中运行 Rancher

--- a/versions/latest/modules/zh/pages/installation-and-upgrade/troubleshooting/troubleshooting.adoc
+++ b/versions/latest/modules/zh/pages/installation-and-upgrade/troubleshooting/troubleshooting.adoc
@@ -1,5 +1,5 @@
 = {rancher-product-name} Server Kubernetes 集群的问题排查
-:revdate: 2024-09-27
+:revdate: 2025-08-25
 :page-revdate: {revdate}
 
 本文介绍如何对安装在 Kubernetes 集群上的 Rancher 进行故障排除。
@@ -166,17 +166,9 @@ Error: validation failed: unable to recognize "": no matches for kind "Issuer" i
  $ nc xxx.xxx.xxx.xxx 22
  SSH-2.0-OpenSSH_6.6.1p1 Ubuntu-2ubuntu2.10
 
-== Failed to dial ssh using address [xxx.xxx.xxx.xxx:xx]: Error configuring SSH: ssh: no key found
-
-`ssh_key_path` 密钥文件无法访问：请确保你已经指定了私钥文件（不是公钥 `.pub`），而且运行 `rke` 命令的用户可以访问该私钥文件。
-
 == Failed to dial ssh using address [xxx.xxx.xxx.xxx:xx]: ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain
 
 `ssh_key_path` 密钥文件不是访问节点的正确文件：请仔细检查，确保你已为节点指定了正确的 `ssh_key_path` 和连接用户。
-
-== Failed to dial ssh using address [xxx.xxx.xxx.xxx:xx]: Error configuring SSH: ssh: cannot decode encrypted private keys
-
-如需使用加密的私钥，请使用 `ssh-agent` 来使用密码来加载密钥。如果在运行 `rke` 命令的环境中找到 `SSH_AUTH_SOCK` 环境变量，它将自动用于连接到节点。
 
 == Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
 

--- a/versions/latest/modules/zh/pages/installation-and-upgrade/upgrades.adoc
+++ b/versions/latest/modules/zh/pages/installation-and-upgrade/upgrades.adoc
@@ -1,12 +1,10 @@
 = 升级
-:revdate: 2025-03-17
+:revdate: 2025-08-25
 :page-revdate: {revdate}
 
 本文介绍如何升级使用 Helm 安装在 Kubernetes 集群上的 Rancher Server。这些步骤也适用于使用 Helm 进行的离线安装。
 
 有关使用 Docker 安装的 Rancher 的升级说明，请参见xref:[本页。]
-
-如需升级 Kubernetes 集群中的组件，或 https://rancher.com/docs/rke/latest/en/config-options/services/[Kubernetes services] 或 https://rancher.com/docs/rke/latest/en/config-options/add-ons/[附加组件（add-on）]的定义，请参见 https://rancher.com/docs/rke/latest/en/upgrades/[RKE 升级文档]的 Rancher Kubernetes 引擎。
 
 == 先决条件
 
@@ -14,7 +12,7 @@
 
 Helm 的运行位置，应该与你的 kubeconfig 文件，或你运行 kubectl 命令的位置相同。
 
-如果你在安装 Kubernetes 时使用了 RKE，那么 config 将会在你运行 `rke up` 的目录下创建。
+If you installed Kubernetes with RKE2/K3s, the Kubeconfig is stored in the `/etc/rancher/rke2/rke2.yaml` or `/etc/rancher/k3s/k3s.yaml` directory depending on your chosen distribution.
 
 kubeconfig 也可以通过 `--kubeconfig` 标签（详情请参见 https://helm.sh/docs/helm/helm/ ）来手动指定所需的集群。
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/install-rancher.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/install-rancher.adoc
@@ -1,5 +1,5 @@
 = Install/Upgrade {rancher-product-name} on a Kubernetes Cluster
-:revdate: 2025-08-05
+:revdate: 2025-08-25
 :page-revdate: {revdate}
 :description: Learn how to install Rancher in development and production environments. Read about single node and high availability installation
 
@@ -19,7 +19,6 @@ Rancher can be installed on any Kubernetes cluster. This cluster can use upstrea
 
 For help setting up a Kubernetes cluster, we provide these tutorials:
 
-* *RKE:* For the tutorial to install an RKE Kubernetes cluster, refer to xref:installation-and-upgrade/install-kubernetes/rke1-for-rancher.adoc[this page.] For help setting up the infrastructure for a high-availability RKE cluster, refer to xref:installation-and-upgrade/infrastructure-setup/ha-rke1-kubernetes-cluster.adoc[this page.]
 * *K3s:* For the tutorial to install a K3s Kubernetes cluster, refer to xref:installation-and-upgrade/install-kubernetes/k3s-for-rancher.adoc[this page.] For help setting up the infrastructure for a high-availability K3s cluster, refer to xref:installation-and-upgrade/infrastructure-setup/ha-k3s-kubernetes-cluster.adoc[this page.]
 * *RKE2:* For the tutorial to install an RKE2 Kubernetes cluster, refer to xref:installation-and-upgrade/install-kubernetes/rke2-for-rancher.adoc[this page.] For help setting up the infrastructure for a high-availability RKE2 cluster, refer to xref:installation-and-upgrade/infrastructure-setup/ha-rke2-kubernetes-cluster.adoc[this page.]
 * *Amazon EKS:* For details on how to install Rancher on Amazon EKS, including how to install an Ingress controller so that the Rancher server can be accessed, refer to xref:installation-and-upgrade/hosted-kubernetes/rancher-on-amazon-eks.adoc[this page.]
@@ -30,7 +29,7 @@ For help setting up a Kubernetes cluster, we provide these tutorials:
 
 The Rancher UI and API are exposed through an Ingress. This means the Kubernetes cluster that you install Rancher in must contain an Ingress controller.
 
-For RKE, RKE2, and K3s installations, you don't have to install the Ingress controller manually because one is installed by default.
+For RKE2 and K3s installations, you don't have to install the Ingress controller manually because one is installed by default.
 
 For distributions that do not include an Ingress Controller by default, like a hosted Kubernetes cluster such as EKS, GKE, or AKS, you have to deploy an Ingress controller first. Note that the Rancher Helm chart does not set an `ingressClassName` on the ingress by default. Because of this, you have to configure the Ingress controller to also watch ingresses without an `ingressClassName`.
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/references/feature-flags.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/references/feature-flags.adoc
@@ -1,5 +1,5 @@
 = Feature Flags
-:revdate: 2025-08-05
+:revdate: 2025-08-25
 :page-revdate: {revdate}
 
 With feature flags, you can try out optional or experimental features, and enable legacy features that are being phased out.
@@ -25,7 +25,6 @@ The following is a list of feature flags available in Rancher. If you've upgrade
 * `legacy`: Enables a set of features from 2.5.x and earlier, that are slowly being phased out in favor of newer implementations. These are a mix of deprecated features as well as features that will eventually be available to newer versions. This flag is disabled by default on new Rancher installations. If you're upgrading from a previous version of Rancher, this flag is enabled.
 * `managed-system-upgrade-controller`: Enables the installation of the system-upgrade-controller app in downstream RKE2/K3s clusters, currently limited to imported clusters and the local cluster, with plans to expand support to node-driver clusters.
 * `multi-cluster-management`: Allows multi-cluster provisioning and management of Kubernetes clusters. This flag can only be set at install time. It can't be enabled or disabled later.
-* `rke1-custom-node-cleanup`: Enables cleanup of deleted RKE1 custom nodes. We recommend that you keep this flag enabled, to prevent removed nodes from attempting to rejoin the cluster.
 * `rke2`: Enables provisioning RKE2 clusters. This flag is enabled by default.
 * `token-hashing`: Enables token hashing. Once enabled, existing tokens will be hashed and all new tokens will be hashed automatically with the SHA256 algorithm. Once a token is hashed it can't be undone. This flag can't be disabled after its enabled. See xref:api/api-tokens.adoc#_token_hashing[API Tokens] for more information.
 * `uiextension`: Enables UI extensions. This flag is enabled by default. Enabling or disabling the flag forces the Rancher pod to restart. The first time this flag is set to `true`, it creates a CRD and enables the controllers and endpoints necessary for the feature to work. If set to `false`, it disables the previously mentioned controllers and endpoints. Setting `uiextension` to `false` has no effect on the CRD -- it does not create a CRD if it does not yet exist, nor does it delete the CRD if it already exists.
@@ -95,12 +94,6 @@ The following table shows the availability and default values for some feature f
 | `true`
 | GA
 | v2.10.0
-|
-
-| `rke1-custom-node-cleanup`
-| `true`
-| GA
-| v2.6.0
 |
 
 | `rke2`

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/references/helm-chart-options.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/references/helm-chart-options.adoc
@@ -1,5 +1,5 @@
 = {rancher-product-name} Helm Chart Options
-:revdate: 2025-08-05
+:revdate: 2025-08-25
 :page-revdate: {revdate}
 :keywords: ["rancher helm chart", "rancher helm options", "rancher helm chart options", "helm chart rancher", "helm options rancher", "helm chart options rancher"]
 
@@ -375,16 +375,6 @@ Your load balancer must support long lived websocket connections and will need t
 === Configuring Ingress for External TLS when Using NGINX v0.22
 
 In NGINX v0.22, the behavior of NGINX has https://github.com/kubernetes/ingress-nginx/blob/06efac9f0b6f8f84b553f58ccecf79dc42c75cc6/Changelog.md[changed] regarding forwarding headers and external TLS termination. Therefore, in the scenario that you are using external TLS termination configuration with NGINX v0.22, you must enable the `use-forwarded-headers` option for ingress:
-
-For RKE installations, edit the `cluster.yml` to add the following settings.
-
-[,yaml]
-----
-ingress:
-  provider: nginx
-  options:
-    use-forwarded-headers: 'true'
-----
 
 For RKE2 installations, you can create a custom `rke2-ingress-nginx-config.yaml` file at `/var/lib/rancher/rke2/server/manifests/rke2-ingress-nginx-config.yaml` containing this required setting to enable using forwarded headers with external TLS termination. Without this required setting applied, the external LB will continuously respond with redirect loops it receives from the ingress controller. (This can be created before or after rancher is installed, rke2 server agent will notice this addition and automatically apply it.)
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/references/tls-settings.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/references/tls-settings.adoc
@@ -1,5 +1,5 @@
 = TLS Settings
-:revdate: 2025-08-05
+:revdate: 2025-08-25
 :page-revdate: {revdate}
 
 Changing the default TLS settings depends on the chosen installation method.
@@ -8,7 +8,7 @@ Changing the default TLS settings depends on the chosen installation method.
 
 When you install Rancher inside of a Kubernetes cluster, TLS is offloaded at the cluster's ingress controller. The possible TLS settings depend on the used ingress controller:
 
-* nginx-ingress-controller (default for RKE1 and RKE2): https://kubernetes.github.io/ingress-nginx/user-guide/tls/#default-tls-version-and-ciphers[Default TLS Version and Ciphers].
+* nginx-ingress-controller (default for RKE2): https://kubernetes.github.io/ingress-nginx/user-guide/tls/#default-tls-version-and-ciphers[Default TLS Version and Ciphers].
 * traefik (default for K3s): https://doc.traefik.io/traefik/https/tls/#tls-options[TLS Options].
 
 == Running Rancher in a single Docker container

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/troubleshooting/troubleshooting.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/troubleshooting/troubleshooting.adoc
@@ -1,5 +1,5 @@
 = Troubleshooting the {rancher-product-name} Server Kubernetes Cluster
-:revdate: 2025-08-05
+:revdate: 2025-08-25
 :page-revdate: {revdate}
 
 This section describes how to troubleshoot an installation of Rancher on a Kubernetes cluster.
@@ -166,17 +166,9 @@ See https://docs.docker.com/install/linux/linux-postinstall/#manage-docker-as-a-
  $ nc xxx.xxx.xxx.xxx 22
  SSH-2.0-OpenSSH_6.6.1p1 Ubuntu-2ubuntu2.10
 
-== Failed to dial ssh using address [xxx.xxx.xxx.xxx:xx]: Error configuring SSH: ssh: no key found
-
-The key file specified as `ssh_key_path` cannot be accessed. Make sure that you specified the private key file (not the public key, `.pub`), and that the user that is running the `rke` command can access the private key file.
-
 == Failed to dial ssh using address [xxx.xxx.xxx.xxx:xx]: ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain
 
 The key file specified as `ssh_key_path` is not correct for accessing the node. Double-check if you specified the correct `ssh_key_path` for the node and if you specified the correct user to connect with.
-
-== Failed to dial ssh using address [xxx.xxx.xxx.xxx:xx]: Error configuring SSH: ssh: cannot decode encrypted private keys
-
-If you want to use encrypted private keys, you should use `ssh-agent` to load your keys with your passphrase. If the `SSH_AUTH_SOCK` environment variable is found in the environment where the `rke` command is run, it will be used automatically to connect to the node.
 
 == Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/upgrades.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/upgrades.adoc
@@ -1,12 +1,10 @@
 = Upgrades
-:revdate: 2025-08-05
+:revdate: 2025-08-25
 :page-revdate: {revdate}
 
 The following instructions will guide you through upgrading a Rancher server that was installed on a Kubernetes cluster with Helm. These steps also apply to air-gapped installs with Helm.
 
 For the instructions to upgrade Rancher installed with Docker, refer to xref:[this page.]
-
-To upgrade the components in your Kubernetes cluster, or the definition of the https://rancher.com/docs/rke/latest/en/config-options/services/[Kubernetes services] or https://rancher.com/docs/rke/latest/en/config-options/add-ons/[add-ons], refer to the https://rancher.com/docs/rke/latest/en/upgrades/[upgrade documentation for RKE], the Rancher Kubernetes Engine.
 
 == Prerequisites
 
@@ -14,7 +12,7 @@ To upgrade the components in your Kubernetes cluster, or the definition of the h
 
 Helm should be run from the same location as your kubeconfig file, or the same location where you run your kubectl commands from.
 
-If you installed Kubernetes with RKE, the config will have been created in the directory you ran `rke up` in.
+If you installed Kubernetes with RKE2/K3s, the Kubeconfig is stored in the `/etc/rancher/rke2/rke2.yaml` or `/etc/rancher/k3s/k3s.yaml` directory depending on your chosen distribution.
 
 The kubeconfig can also be manually targeted for the intended cluster with the `--kubeconfig` tag (see: https://helm.sh/docs/helm/helm/)
 

--- a/versions/v2.12/modules/zh/pages/installation-and-upgrade/install-rancher.adoc
+++ b/versions/v2.12/modules/zh/pages/installation-and-upgrade/install-rancher.adoc
@@ -1,5 +1,5 @@
 = 在 Kubernetes 集群上安装/升级 {rancher-product-name}
-:revdate: 2025-08-05
+:revdate: 2025-08-25
 :page-revdate: {revdate}
 :description: 了解如何在开发和生产环境中安装 Rancher。了解单节点和高可用安装
 
@@ -19,7 +19,6 @@ Rancher 可以安装在任何 Kubernetes 集群上。这个集群可以使用上
 
 你可参考以下教程，以获得设置 Kubernetes 集群的帮助：
 
-* *RKE*：xref:installation-and-upgrade/install-kubernetes/rke1-for-rancher.adoc[安装 RKE Kubernetes 集群的教程]；xref:installation-and-upgrade/infrastructure-setup/ha-rke1-kubernetes-cluster.adoc[为高可用 RKE 集群设置基础设施的教程]。
 * *K3s*：xref:installation-and-upgrade/install-kubernetes/k3s-for-rancher.adoc[安装 K3s Kubernetes 集群的教程]；xref:installation-and-upgrade/infrastructure-setup/ha-k3s-kubernetes-cluster.adoc[设置高可用 K3s 集群的基础设施的教程]。
 * *RKE2:* ：xref:installation-and-upgrade/install-kubernetes/rke2-for-rancher.adoc[安装 RKE2 Kubernetes 集群的教程]；xref:installation-and-upgrade/infrastructure-setup/ha-rke2-kubernetes-cluster.adoc[设置高可用 RKE2 集群的基础设施的教程]。
 * *Amazon EKS*：xref:installation-and-upgrade/hosted-kubernetes/rancher-on-amazon-eks.adoc[在 Amazon EKS 上安装 Rancher 以及如何安装 Ingress Controller 以访问 Rancher Server]。
@@ -30,7 +29,7 @@ Rancher 可以安装在任何 Kubernetes 集群上。这个集群可以使用上
 
 Rancher UI 和 API 通过 Ingress 公开。换言之，安装 Rancher 的 Kubernetes 集群必须包含一个 Ingress Controller。
 
-对于 RKE、RKE2 和 K3s，你不需要手动安装 Ingress Controller，因为它是默认安装的。
+对于 RKE2 和 K3s，你不需要手动安装 Ingress Controller，因为它是默认安装的。
 
 对于默认不包含 Ingress Controller 的发行版（例如 EKS、GKE 或 AKS 等托管 Kubernetes 集群），你必须先部署 Ingress Controller。请注意，Rancher Helm Chart 默认情况下不会在 Ingress 上设置 `ingressClassName`。因此，你必须将 Ingress Controller 配置为在没有 `ingressClassName` 的情况下也可以监视 Ingress。
 

--- a/versions/v2.12/modules/zh/pages/installation-and-upgrade/references/feature-flags.adoc
+++ b/versions/v2.12/modules/zh/pages/installation-and-upgrade/references/feature-flags.adoc
@@ -1,5 +1,5 @@
 = 功能开关
-:revdate: 2025-08-05
+:revdate: 2025-08-25
 :page-revdate: {revdate}
 
 使用功能开关（Feature Flag），你可以试用可选或实验性的功能并启用正在逐步淘汰的旧版功能。
@@ -25,7 +25,6 @@
 * `legacy`：启用 2.5.x 及更早版本的一组功能，这些功能正逐渐被新的实现淘汰。它们是已弃用以及后续可用于新版本的功能组合。新的 Rancher 安装会默认禁用此标志。如果你从以前版本的 Rancher 升级，此标志会启用。
 * `managed-system-upgrade-controller`: Enables the installation of the system-upgrade-controller app in downstream RKE2/K3s clusters, currently limited to imported clusters and the local cluster, with plans to expand support to node-driver clusters.
 * `multi-cluster-management`：允许配置和管理多个 Kubernetes 集群。此标志只能在安装时设置。后续无法启用或禁用它。
-* `rke1-custom-node-cleanup`：清除已删除的 RKE1 自定义节点。建议你启用此标志，以防止已删除的节点尝试重新加入集群。
 * `rke2`：启用配置 RKE2 集群。此标志默认启用。
 * `token-hashing`：启用令牌哈希。启用后，会使用 SHA256 算法对现有 Token 和所有新 Token 进行哈希处理。一旦对 Token 进行哈希处理，就无法撤消操作。此标志在启用后无法禁用。有关详细信息，请参阅 xref:api/api-tokens.adoc#_令牌哈希[API 令牌]。
 * `unsupported-storage-drivers`：允许启用非默认启用的存储提供程序和卷插件。有关详细信息，请参阅xref:rancher-admin/experimental-features/unsupported-storage-drivers.adoc[允许使用不受支持的存储驱动程序]。
@@ -93,12 +92,6 @@
 | `true`
 | GA
 | v2.10.0
-|
-
-| `rke1-custom-node-cleanup`
-| `true`
-| GA
-| v2.6.0
 |
 
 | `rke2`

--- a/versions/v2.12/modules/zh/pages/installation-and-upgrade/references/tls-settings.adoc
+++ b/versions/v2.12/modules/zh/pages/installation-and-upgrade/references/tls-settings.adoc
@@ -1,5 +1,5 @@
 = TLS 设置
-:revdate: 2025-08-05
+:revdate: 2025-08-25
 :page-revdate: {revdate}
 
 更改默认 TLS 设置的方法取决于它的安装方式。
@@ -8,7 +8,7 @@
 
 当你在 Kubernetes 集群内安装 Rancher 时，TLS 会在集群的 Ingress Controller 上卸载。可用的 TLS 设置取决于使用的 Ingress Controller：
 
-* nginx-ingress-controller（RKE1 和 RKE2 默认）：link:https://kubernetes.github.io/ingress-nginx/user-guide/tls/#default-tls-version-and-ciphers[默认的 TLS 版本和密码]。
+* nginx-ingress-controller（RKE2 默认）：link:https://kubernetes.github.io/ingress-nginx/user-guide/tls/#default-tls-version-and-ciphers[默认的 TLS 版本和密码]。
 * traefik（K3s 默认）：link:https://doc.traefik.io/traefik/https/tls/#tls-options[TLS 选项]。
 
 == 在单个 Docker 容器中运行 Rancher

--- a/versions/v2.12/modules/zh/pages/installation-and-upgrade/troubleshooting/troubleshooting.adoc
+++ b/versions/v2.12/modules/zh/pages/installation-and-upgrade/troubleshooting/troubleshooting.adoc
@@ -1,5 +1,5 @@
 = {rancher-product-name} Server Kubernetes 集群的问题排查
-:revdate: 2025-08-05
+:revdate: 2025-08-25
 :page-revdate: {revdate}
 
 本文介绍如何对安装在 Kubernetes 集群上的 Rancher 进行故障排除。
@@ -166,17 +166,9 @@ Error: validation failed: unable to recognize "": no matches for kind "Issuer" i
  $ nc xxx.xxx.xxx.xxx 22
  SSH-2.0-OpenSSH_6.6.1p1 Ubuntu-2ubuntu2.10
 
-== Failed to dial ssh using address [xxx.xxx.xxx.xxx:xx]: Error configuring SSH: ssh: no key found
-
-`ssh_key_path` 密钥文件无法访问：请确保你已经指定了私钥文件（不是公钥 `.pub`），而且运行 `rke` 命令的用户可以访问该私钥文件。
-
 == Failed to dial ssh using address [xxx.xxx.xxx.xxx:xx]: ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain
 
 `ssh_key_path` 密钥文件不是访问节点的正确文件：请仔细检查，确保你已为节点指定了正确的 `ssh_key_path` 和连接用户。
-
-== Failed to dial ssh using address [xxx.xxx.xxx.xxx:xx]: Error configuring SSH: ssh: cannot decode encrypted private keys
-
-如需使用加密的私钥，请使用 `ssh-agent` 来使用密码来加载密钥。如果在运行 `rke` 命令的环境中找到 `SSH_AUTH_SOCK` 环境变量，它将自动用于连接到节点。
 
 == Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
 

--- a/versions/v2.12/modules/zh/pages/installation-and-upgrade/upgrades.adoc
+++ b/versions/v2.12/modules/zh/pages/installation-and-upgrade/upgrades.adoc
@@ -1,12 +1,10 @@
 = 升级
-:revdate: 2025-08-05
+:revdate: 2025-08-25
 :page-revdate: {revdate}
 
 本文介绍如何升级使用 Helm 安装在 Kubernetes 集群上的 Rancher Server。这些步骤也适用于使用 Helm 进行的离线安装。
 
 有关使用 Docker 安装的 Rancher 的升级说明，请参见xref:[本页。]
-
-如需升级 Kubernetes 集群中的组件，或 https://rancher.com/docs/rke/latest/en/config-options/services/[Kubernetes services] 或 https://rancher.com/docs/rke/latest/en/config-options/add-ons/[附加组件（add-on）]的定义，请参见 https://rancher.com/docs/rke/latest/en/upgrades/[RKE 升级文档]的 Rancher Kubernetes 引擎。
 
 == 先决条件
 
@@ -14,7 +12,7 @@
 
 Helm 的运行位置，应该与你的 kubeconfig 文件，或你运行 kubectl 命令的位置相同。
 
-如果你在安装 Kubernetes 时使用了 RKE，那么 config 将会在你运行 `rke up` 的目录下创建。
+If you installed Kubernetes with RKE2/K3s, the Kubeconfig is stored in the `/etc/rancher/rke2/rke2.yaml` or `/etc/rancher/k3s/k3s.yaml` directory depending on your chosen distribution.
 
 kubeconfig 也可以通过 `--kubeconfig` 标签（详情请参见 https://helm.sh/docs/helm/helm/ ）来手动指定所需的集群。
 


### PR DESCRIPTION
Fixes #409

Note, the `kubeconfig` -> `Kubeconfig` changes from https://github.com/rancher/rancher-docs/pull/1941/files#diff-4119c3539804c285583de1fe21321a2b6ac5114ecf2e1bad5ae15a1a8665cfcdR17 were not applied to installation-and-upgrade/upgrades.adoc since it's a proper noun.