### PR TITLE
Add Augst 2025 Release CVE's 

### DIFF
--- a/versions/latest/modules/en/pages/security/cves.adoc
+++ b/versions/latest/modules/en/pages/security/cves.adoc
@@ -1,5 +1,5 @@
 = Security Advisories and CVEs
-:revdate: 2025-08-18
+:revdate: 2025-09-03
 :page-revdate: {revdate}
 
 Rancher is committed to informing the community of security issues in our products. Rancher will publish security advisories and CVEs (Common Vulnerabilities and Exposures) for issues we have resolved. New security advisories are also published in Rancher's GitHub https://github.com/rancher/rancher/security/advisories[security page].

--- a/versions/latest/modules/en/pages/security/cves.adoc
+++ b/versions/latest/modules/en/pages/security/cves.adoc
@@ -8,6 +8,16 @@ Rancher is committed to informing the community of security issues in our produc
 |===
 | ID | Description | Date | Resolution
 
+| https://github.com/rancher/rancher/security/advisories/GHSA-4h45-jpvh-6p5j[CVE-2024-58259] 
+| POSTs to the Rancher API endpoints are now limited to 1 Mi; this is configurable through the settings if you need a larger limit. The Rancher authentication endpoints are configured independently of the main public API (as you might need bigger payloads in the other API endpoints). Suppose you need to increase the maximum allowed payload for authentication. In that case, you can set the environment variable `CATTLE_AUTH_API_BODY_LIMIT` to a quantity, e.g., 2 Mi, which would allow larger payloads for the authentication endpoints. 
+| 28 Aug 2025 
+| Rancher https://github.com/rancher/rancher/releases/tag/v2.12.1[v2.12.1], https://github.com/rancher/rancher/releases/tag/v2.11.5[v2.11.5], https://github.com/rancher/rancher/releases/tag/v2.10.9[v2.10.9] and https://github.com/rancher/rancher/releases/tag/v2.9.11[v2.9.11]
+
+| https://github.com/rancher/fleet/security/advisories/GHSA-6h9x-9j5v-7w9h[CVE-2023-32198] 
+| Following a recent https://github.com/rancher/fleet/pull/3403[change] excluding Helm values files from bundles, an edge case subsisted where the values files referenced in `fleet.yaml` with your directory name (e.g., `my-dir/values.yaml` instead of `values.yaml`) would not be excluded, which would potentially expose confidential data in bundle resources. Helm values files are now excluded from bundle resources regardless of how you reference them. 
+| 28 Aug 2025 
+| Rancher https://github.com/rancher/rancher/releases/tag/v2.12.1[v2.12.1], https://github.com/rancher/rancher/releases/tag/v2.11.5[v2.11.5] and https://github.com/rancher/rancher/releases/tag/v2.10.9[v2.10.9]
+
 | https://github.com/rancher/fleet/security/advisories/GHSA-xgpc-q899-67p8[CVE-2025-23390] 
 a| This vulnerability only affects customers using xref:integrations/fleet/fleet.adoc[Continuous Delivery with Fleet] where Fleet does not validate a server's certificate when connecting through SSH. This can allow for a main-in-the-middle-attack against Fleet. The fix provides a new `insecureSkipHostKeyChecks` value for the `fleet` Helm chart. The default value is set to *`true` (opt-in) for Rancher v2.9 - v2.11* for backward compatibility. The default value is set to *`false` (opt-out) for Rancher v2.12 and later*, and Fleet v0.13 and later.
 

--- a/versions/latest/modules/zh/pages/security/cves.adoc
+++ b/versions/latest/modules/zh/pages/security/cves.adoc
@@ -8,6 +8,16 @@ Rancher 致力于向社区披露我们产品的安全问题。我们会针对已
 |===
 | ID | 描述 | 日期 | 解决
 
+| https://github.com/rancher/rancher/security/advisories/GHSA-4h45-jpvh-6p5j[CVE-2024-58259] 
+| POSTs to the Rancher API endpoints are now limited to 1 Mi; this is configurable through the settings if you need a larger limit. The Rancher authentication endpoints are configured independently of the main public API (as you might need bigger payloads in the other API endpoints). Suppose you need to increase the maximum allowed payload for authentication. In that case, you can set the environment variable `CATTLE_AUTH_API_BODY_LIMIT` to a quantity, e.g., 2 Mi, which would allow larger payloads for the authentication endpoints. 
+| 28 Aug 2025 
+| Rancher https://github.com/rancher/rancher/releases/tag/v2.12.1[v2.12.1], https://github.com/rancher/rancher/releases/tag/v2.11.5[v2.11.5], https://github.com/rancher/rancher/releases/tag/v2.10.9[v2.10.9] and https://github.com/rancher/rancher/releases/tag/v2.9.11[v2.9.11]
+
+| https://github.com/rancher/fleet/security/advisories/GHSA-6h9x-9j5v-7w9h[CVE-2023-32198] 
+| Following a recent https://github.com/rancher/fleet/pull/3403[change] excluding Helm values files from bundles, an edge case subsisted where the values files referenced in `fleet.yaml` with your directory name (e.g., `my-dir/values.yaml` instead of `values.yaml`) would not be excluded, which would potentially expose confidential data in bundle resources. Helm values files are now excluded from bundle resources regardless of how you reference them. 
+| 28 Aug 2025 
+| Rancher https://github.com/rancher/rancher/releases/tag/v2.12.1[v2.12.1], https://github.com/rancher/rancher/releases/tag/v2.11.5[v2.11.5] and https://github.com/rancher/rancher/releases/tag/v2.10.9[v2.10.9]
+
 | https://github.com/rancher/fleet/security/advisories/GHSA-xgpc-q899-67p8[CVE-2025-23390] 
 a| This vulnerability only affects customers using xref:integrations/fleet/fleet.adoc[Continuous Delivery with Fleet] where Fleet does not validate a server's certificate when connecting through SSH. This can allow for a main-in-the-middle-attack against Fleet. The fix provides a new `insecureSkipHostKeyChecks` value for the `fleet` Helm chart. The default value is set to *`true` (opt-in) for Rancher v2.9 - v2.11* for backward compatibility. The default value is set to *`false` (opt-out) for Rancher v2.12 and later*, and Fleet v0.13 and later.
 

--- a/versions/latest/modules/zh/pages/security/cves.adoc
+++ b/versions/latest/modules/zh/pages/security/cves.adoc
@@ -1,5 +1,5 @@
 = 安全公告和 CVE
-:revdate: 2025-08-18
+:revdate: 2025-09-03
 :page-revdate: {revdate}
 
 Rancher 致力于向社区披露我们产品的安全问题。我们会针对已解决的问题发布安全公告和 CVE（Common Vulnerabilities and Exposures，通用漏洞披露）。Rancher GitHub 上的link:https://github.com/rancher/rancher/security/advisories[安全页面]也会发布新的安全公告。

--- a/versions/v2.10/modules/en/pages/security/cves.adoc
+++ b/versions/v2.10/modules/en/pages/security/cves.adoc
@@ -8,6 +8,16 @@ Rancher is committed to informing the community of security issues in our produc
 |===
 | ID | Description | Date | Resolution
 
+| https://github.com/rancher/rancher/security/advisories/GHSA-4h45-jpvh-6p5j[CVE-2024-58259] 
+| POSTs to the Rancher API endpoints are now limited to 1 Mi; this is configurable through the settings if you need a larger limit. The Rancher authentication endpoints are configured independently of the main public API (as you might need bigger payloads in the other API endpoints). Suppose you need to increase the maximum allowed payload for authentication. In that case, you can set the environment variable `CATTLE_AUTH_API_BODY_LIMIT` to a quantity, e.g., 2 Mi, which would allow larger payloads for the authentication endpoints. 
+| 28 Aug 2025 
+| Rancher https://github.com/rancher/rancher/releases/tag/v2.12.1[v2.12.1], https://github.com/rancher/rancher/releases/tag/v2.11.5[v2.11.5], https://github.com/rancher/rancher/releases/tag/v2.10.9[v2.10.9] and https://github.com/rancher/rancher/releases/tag/v2.9.11[v2.9.11]
+
+| https://github.com/rancher/fleet/security/advisories/GHSA-6h9x-9j5v-7w9h[CVE-2023-32198] 
+| Following a recent https://github.com/rancher/fleet/pull/3403[change] excluding Helm values files from bundles, an edge case subsisted where the values files referenced in `fleet.yaml` with your directory name (e.g., `my-dir/values.yaml` instead of `values.yaml`) would not be excluded, which would potentially expose confidential data in bundle resources. Helm values files are now excluded from bundle resources regardless of how you reference them. 
+| 28 Aug 2025 
+| Rancher https://github.com/rancher/rancher/releases/tag/v2.12.1[v2.12.1], https://github.com/rancher/rancher/releases/tag/v2.11.5[v2.11.5] and https://github.com/rancher/rancher/releases/tag/v2.10.9[v2.10.9]
+
 | https://github.com/rancher/fleet/security/advisories/GHSA-xgpc-q899-67p8[CVE-2025-23390] 
 a| This vulnerability only affects customers using xref:integrations/fleet/fleet.adoc[Continuous Delivery with Fleet] where Fleet does not validate a server's certificate when connecting through SSH. This can allow for a main-in-the-middle-attack against Fleet. The fix provides a new `insecureSkipHostKeyChecks` value for the `fleet` Helm chart. The default value is set to *`true` (opt-in) for Rancher v2.9 - v2.11* for backward compatibility. The default value is set to *`false` (opt-out) for Rancher v2.12 and later*, and Fleet v0.13 and later.
 

--- a/versions/v2.10/modules/en/pages/security/cves.adoc
+++ b/versions/v2.10/modules/en/pages/security/cves.adoc
@@ -1,5 +1,5 @@
 = Security Advisories and CVEs
-:revdate: 2025-04-28
+:revdate: 2025-09-03
 :page-revdate: {revdate}
 
 Rancher is committed to informing the community of security issues in our products. Rancher will publish security advisories and CVEs (Common Vulnerabilities and Exposures) for issues we have resolved. New security advisories are also published in Rancher's GitHub https://github.com/rancher/rancher/security/advisories[security page].

--- a/versions/v2.10/modules/zh/pages/security/cves.adoc
+++ b/versions/v2.10/modules/zh/pages/security/cves.adoc
@@ -8,6 +8,16 @@ Rancher 致力于向社区披露我们产品的安全问题。我们会针对已
 |===
 | ID | 描述 | 日期 | 解决
 
+| https://github.com/rancher/rancher/security/advisories/GHSA-4h45-jpvh-6p5j[CVE-2024-58259] 
+| POSTs to the Rancher API endpoints are now limited to 1 Mi; this is configurable through the settings if you need a larger limit. The Rancher authentication endpoints are configured independently of the main public API (as you might need bigger payloads in the other API endpoints). Suppose you need to increase the maximum allowed payload for authentication. In that case, you can set the environment variable `CATTLE_AUTH_API_BODY_LIMIT` to a quantity, e.g., 2 Mi, which would allow larger payloads for the authentication endpoints. 
+| 28 Aug 2025 
+| Rancher https://github.com/rancher/rancher/releases/tag/v2.12.1[v2.12.1], https://github.com/rancher/rancher/releases/tag/v2.11.5[v2.11.5], https://github.com/rancher/rancher/releases/tag/v2.10.9[v2.10.9] and https://github.com/rancher/rancher/releases/tag/v2.9.11[v2.9.11]
+
+| https://github.com/rancher/fleet/security/advisories/GHSA-6h9x-9j5v-7w9h[CVE-2023-32198] 
+| Following a recent https://github.com/rancher/fleet/pull/3403[change] excluding Helm values files from bundles, an edge case subsisted where the values files referenced in `fleet.yaml` with your directory name (e.g., `my-dir/values.yaml` instead of `values.yaml`) would not be excluded, which would potentially expose confidential data in bundle resources. Helm values files are now excluded from bundle resources regardless of how you reference them. 
+| 28 Aug 2025 
+| Rancher https://github.com/rancher/rancher/releases/tag/v2.12.1[v2.12.1], https://github.com/rancher/rancher/releases/tag/v2.11.5[v2.11.5] and https://github.com/rancher/rancher/releases/tag/v2.10.9[v2.10.9]
+
 | https://github.com/rancher/fleet/security/advisories/GHSA-xgpc-q899-67p8[CVE-2025-23390] 
 a| This vulnerability only affects customers using xref:integrations/fleet/fleet.adoc[Continuous Delivery with Fleet] where Fleet does not validate a server's certificate when connecting through SSH. This can allow for a main-in-the-middle-attack against Fleet. The fix provides a new `insecureSkipHostKeyChecks` value for the `fleet` Helm chart. The default value is set to *`true` (opt-in) for Rancher v2.9 - v2.11* for backward compatibility. The default value is set to *`false` (opt-out) for Rancher v2.12 and later*, and Fleet v0.13 and later.
 

--- a/versions/v2.10/modules/zh/pages/security/cves.adoc
+++ b/versions/v2.10/modules/zh/pages/security/cves.adoc
@@ -1,5 +1,5 @@
 = 安全公告和 CVE
-:revdate: 2025-06-20
+:revdate: 2025-09-03
 :page-revdate: {revdate}
 
 Rancher 致力于向社区披露我们产品的安全问题。我们会针对已解决的问题发布安全公告和 CVE（Common Vulnerabilities and Exposures，通用漏洞披露）。Rancher GitHub 上的link:https://github.com/rancher/rancher/security/advisories[安全页面]也会发布新的安全公告。

--- a/versions/v2.11/modules/en/pages/security/cves.adoc
+++ b/versions/v2.11/modules/en/pages/security/cves.adoc
@@ -8,6 +8,16 @@ Rancher is committed to informing the community of security issues in our produc
 |===
 | ID | Description | Date | Resolution
 
+| https://github.com/rancher/rancher/security/advisories/GHSA-4h45-jpvh-6p5j[CVE-2024-58259] 
+| POSTs to the Rancher API endpoints are now limited to 1 Mi; this is configurable through the settings if you need a larger limit. The Rancher authentication endpoints are configured independently of the main public API (as you might need bigger payloads in the other API endpoints). Suppose you need to increase the maximum allowed payload for authentication. In that case, you can set the environment variable `CATTLE_AUTH_API_BODY_LIMIT` to a quantity, e.g., 2 Mi, which would allow larger payloads for the authentication endpoints. 
+| 28 Aug 2025 
+| Rancher https://github.com/rancher/rancher/releases/tag/v2.12.1[v2.12.1], https://github.com/rancher/rancher/releases/tag/v2.11.5[v2.11.5], https://github.com/rancher/rancher/releases/tag/v2.10.9[v2.10.9] and https://github.com/rancher/rancher/releases/tag/v2.9.11[v2.9.11]
+
+| https://github.com/rancher/fleet/security/advisories/GHSA-6h9x-9j5v-7w9h[CVE-2023-32198] 
+| Following a recent https://github.com/rancher/fleet/pull/3403[change] excluding Helm values files from bundles, an edge case subsisted where the values files referenced in `fleet.yaml` with your directory name (e.g., `my-dir/values.yaml` instead of `values.yaml`) would not be excluded, which would potentially expose confidential data in bundle resources. Helm values files are now excluded from bundle resources regardless of how you reference them. 
+| 28 Aug 2025 
+| Rancher https://github.com/rancher/rancher/releases/tag/v2.12.1[v2.12.1], https://github.com/rancher/rancher/releases/tag/v2.11.5[v2.11.5] and https://github.com/rancher/rancher/releases/tag/v2.10.9[v2.10.9]
+
 | https://github.com/rancher/fleet/security/advisories/GHSA-xgpc-q899-67p8[CVE-2025-23390] 
 a| This vulnerability only affects customers using xref:integrations/fleet/fleet.adoc[Continuous Delivery with Fleet] where Fleet does not validate a server's certificate when connecting through SSH. This can allow for a main-in-the-middle-attack against Fleet. The fix provides a new `insecureSkipHostKeyChecks` value for the `fleet` Helm chart. The default value is set to *`true` (opt-in) for Rancher v2.9 - v2.11* for backward compatibility. The default value is set to *`false` (opt-out) for Rancher v2.12 and later*, and Fleet v0.13 and later.
 

--- a/versions/v2.11/modules/en/pages/security/cves.adoc
+++ b/versions/v2.11/modules/en/pages/security/cves.adoc
@@ -1,5 +1,5 @@
 = Security Advisories and CVEs
-:revdate: 2025-04-28
+:revdate: 2025-09-03
 :page-revdate: {revdate}
 
 Rancher is committed to informing the community of security issues in our products. Rancher will publish security advisories and CVEs (Common Vulnerabilities and Exposures) for issues we have resolved. New security advisories are also published in Rancher's GitHub https://github.com/rancher/rancher/security/advisories[security page].

--- a/versions/v2.11/modules/zh/pages/security/cves.adoc
+++ b/versions/v2.11/modules/zh/pages/security/cves.adoc
@@ -8,6 +8,16 @@ Rancher 致力于向社区披露我们产品的安全问题。我们会针对已
 |===
 | ID | 描述 | 日期 | 解决
 
+| https://github.com/rancher/rancher/security/advisories/GHSA-4h45-jpvh-6p5j[CVE-2024-58259] 
+| POSTs to the Rancher API endpoints are now limited to 1 Mi; this is configurable through the settings if you need a larger limit. The Rancher authentication endpoints are configured independently of the main public API (as you might need bigger payloads in the other API endpoints). Suppose you need to increase the maximum allowed payload for authentication. In that case, you can set the environment variable `CATTLE_AUTH_API_BODY_LIMIT` to a quantity, e.g., 2 Mi, which would allow larger payloads for the authentication endpoints. 
+| 28 Aug 2025 
+| Rancher https://github.com/rancher/rancher/releases/tag/v2.12.1[v2.12.1], https://github.com/rancher/rancher/releases/tag/v2.11.5[v2.11.5], https://github.com/rancher/rancher/releases/tag/v2.10.9[v2.10.9] and https://github.com/rancher/rancher/releases/tag/v2.9.11[v2.9.11]
+
+| https://github.com/rancher/fleet/security/advisories/GHSA-6h9x-9j5v-7w9h[CVE-2023-32198] 
+| Following a recent https://github.com/rancher/fleet/pull/3403[change] excluding Helm values files from bundles, an edge case subsisted where the values files referenced in `fleet.yaml` with your directory name (e.g., `my-dir/values.yaml` instead of `values.yaml`) would not be excluded, which would potentially expose confidential data in bundle resources. Helm values files are now excluded from bundle resources regardless of how you reference them. 
+| 28 Aug 2025 
+| Rancher https://github.com/rancher/rancher/releases/tag/v2.12.1[v2.12.1], https://github.com/rancher/rancher/releases/tag/v2.11.5[v2.11.5] and https://github.com/rancher/rancher/releases/tag/v2.10.9[v2.10.9]
+
 | https://github.com/rancher/fleet/security/advisories/GHSA-xgpc-q899-67p8[CVE-2025-23390] 
 a| This vulnerability only affects customers using xref:integrations/fleet/fleet.adoc[Continuous Delivery with Fleet] where Fleet does not validate a server's certificate when connecting through SSH. This can allow for a main-in-the-middle-attack against Fleet. The fix provides a new `insecureSkipHostKeyChecks` value for the `fleet` Helm chart. The default value is set to *`true` (opt-in) for Rancher v2.9 - v2.11* for backward compatibility. The default value is set to *`false` (opt-out) for Rancher v2.12 and later*, and Fleet v0.13 and later.
 

--- a/versions/v2.11/modules/zh/pages/security/cves.adoc
+++ b/versions/v2.11/modules/zh/pages/security/cves.adoc
@@ -1,5 +1,5 @@
 = 安全公告和 CVE
-:revdate: 2025-06-20
+:revdate: 2025-09-03
 :page-revdate: {revdate}
 
 Rancher 致力于向社区披露我们产品的安全问题。我们会针对已解决的问题发布安全公告和 CVE（Common Vulnerabilities and Exposures，通用漏洞披露）。Rancher GitHub 上的link:https://github.com/rancher/rancher/security/advisories[安全页面]也会发布新的安全公告。

--- a/versions/v2.12/modules/en/pages/security/cves.adoc
+++ b/versions/v2.12/modules/en/pages/security/cves.adoc
@@ -1,5 +1,5 @@
 = Security Advisories and CVEs
-:revdate: 2025-08-18
+:revdate: 2025-09-03
 :page-revdate: {revdate}
 
 Rancher is committed to informing the community of security issues in our products. Rancher will publish security advisories and CVEs (Common Vulnerabilities and Exposures) for issues we have resolved. New security advisories are also published in Rancher's GitHub https://github.com/rancher/rancher/security/advisories[security page].

--- a/versions/v2.12/modules/en/pages/security/cves.adoc
+++ b/versions/v2.12/modules/en/pages/security/cves.adoc
@@ -8,6 +8,16 @@ Rancher is committed to informing the community of security issues in our produc
 |===
 | ID | Description | Date | Resolution
 
+| https://github.com/rancher/rancher/security/advisories/GHSA-4h45-jpvh-6p5j[CVE-2024-58259] 
+| POSTs to the Rancher API endpoints are now limited to 1 Mi; this is configurable through the settings if you need a larger limit. The Rancher authentication endpoints are configured independently of the main public API (as you might need bigger payloads in the other API endpoints). Suppose you need to increase the maximum allowed payload for authentication. In that case, you can set the environment variable `CATTLE_AUTH_API_BODY_LIMIT` to a quantity, e.g., 2 Mi, which would allow larger payloads for the authentication endpoints. 
+| 28 Aug 2025 
+| Rancher https://github.com/rancher/rancher/releases/tag/v2.12.1[v2.12.1], https://github.com/rancher/rancher/releases/tag/v2.11.5[v2.11.5], https://github.com/rancher/rancher/releases/tag/v2.10.9[v2.10.9] and https://github.com/rancher/rancher/releases/tag/v2.9.11[v2.9.11]
+
+| https://github.com/rancher/fleet/security/advisories/GHSA-6h9x-9j5v-7w9h[CVE-2023-32198] 
+| Following a recent https://github.com/rancher/fleet/pull/3403[change] excluding Helm values files from bundles, an edge case subsisted where the values files referenced in `fleet.yaml` with your directory name (e.g., `my-dir/values.yaml` instead of `values.yaml`) would not be excluded, which would potentially expose confidential data in bundle resources. Helm values files are now excluded from bundle resources regardless of how you reference them. 
+| 28 Aug 2025 
+| Rancher https://github.com/rancher/rancher/releases/tag/v2.12.1[v2.12.1], https://github.com/rancher/rancher/releases/tag/v2.11.5[v2.11.5] and https://github.com/rancher/rancher/releases/tag/v2.10.9[v2.10.9]
+
 | https://github.com/rancher/fleet/security/advisories/GHSA-xgpc-q899-67p8[CVE-2025-23390] 
 a| This vulnerability only affects customers using xref:integrations/fleet/fleet.adoc[Continuous Delivery with Fleet] where Fleet does not validate a server's certificate when connecting through SSH. This can allow for a main-in-the-middle-attack against Fleet. The fix provides a new `insecureSkipHostKeyChecks` value for the `fleet` Helm chart. The default value is set to *`true` (opt-in) for Rancher v2.9 - v2.11* for backward compatibility. The default value is set to *`false` (opt-out) for Rancher v2.12 and later*, and Fleet v0.13 and later.
 

--- a/versions/v2.12/modules/zh/pages/security/cves.adoc
+++ b/versions/v2.12/modules/zh/pages/security/cves.adoc
@@ -8,6 +8,16 @@ Rancher 致力于向社区披露我们产品的安全问题。我们会针对已
 |===
 | ID | 描述 | 日期 | 解决
 
+| https://github.com/rancher/rancher/security/advisories/GHSA-4h45-jpvh-6p5j[CVE-2024-58259] 
+| POSTs to the Rancher API endpoints are now limited to 1 Mi; this is configurable through the settings if you need a larger limit. The Rancher authentication endpoints are configured independently of the main public API (as you might need bigger payloads in the other API endpoints). Suppose you need to increase the maximum allowed payload for authentication. In that case, you can set the environment variable `CATTLE_AUTH_API_BODY_LIMIT` to a quantity, e.g., 2 Mi, which would allow larger payloads for the authentication endpoints. 
+| 28 Aug 2025 
+| Rancher https://github.com/rancher/rancher/releases/tag/v2.12.1[v2.12.1], https://github.com/rancher/rancher/releases/tag/v2.11.5[v2.11.5], https://github.com/rancher/rancher/releases/tag/v2.10.9[v2.10.9] and https://github.com/rancher/rancher/releases/tag/v2.9.11[v2.9.11]
+
+| https://github.com/rancher/fleet/security/advisories/GHSA-6h9x-9j5v-7w9h[CVE-2023-32198] 
+| Following a recent https://github.com/rancher/fleet/pull/3403[change] excluding Helm values files from bundles, an edge case subsisted where the values files referenced in `fleet.yaml` with your directory name (e.g., `my-dir/values.yaml` instead of `values.yaml`) would not be excluded, which would potentially expose confidential data in bundle resources. Helm values files are now excluded from bundle resources regardless of how you reference them. 
+| 28 Aug 2025 
+| Rancher https://github.com/rancher/rancher/releases/tag/v2.12.1[v2.12.1], https://github.com/rancher/rancher/releases/tag/v2.11.5[v2.11.5] and https://github.com/rancher/rancher/releases/tag/v2.10.9[v2.10.9]
+
 | https://github.com/rancher/fleet/security/advisories/GHSA-xgpc-q899-67p8[CVE-2025-23390] 
 a| This vulnerability only affects customers using xref:integrations/fleet/fleet.adoc[Continuous Delivery with Fleet] where Fleet does not validate a server's certificate when connecting through SSH. This can allow for a main-in-the-middle-attack against Fleet. The fix provides a new `insecureSkipHostKeyChecks` value for the `fleet` Helm chart. The default value is set to *`true` (opt-in) for Rancher v2.9 - v2.11* for backward compatibility. The default value is set to *`false` (opt-out) for Rancher v2.12 and later*, and Fleet v0.13 and later.
 

--- a/versions/v2.12/modules/zh/pages/security/cves.adoc
+++ b/versions/v2.12/modules/zh/pages/security/cves.adoc
@@ -1,5 +1,5 @@
 = 安全公告和 CVE
-:revdate: 2025-08-18
+:revdate: 2025-09-03
 :page-revdate: {revdate}
 
 Rancher 致力于向社区披露我们产品的安全问题。我们会针对已解决的问题发布安全公告和 CVE（Common Vulnerabilities and Exposures，通用漏洞披露）。Rancher GitHub 上的link:https://github.com/rancher/rancher/security/advisories[安全页面]也会发布新的安全公告。

--- a/versions/v2.9/modules/en/pages/security/cves.adoc
+++ b/versions/v2.9/modules/en/pages/security/cves.adoc
@@ -8,6 +8,11 @@ Rancher is committed to informing the community of security issues in our produc
 |===
 | ID | Description | Date | Resolution
 
+| https://github.com/rancher/rancher/security/advisories/GHSA-4h45-jpvh-6p5j[CVE-2024-58259] 
+| POSTs to the Rancher API endpoints are now limited to 1 Mi; this is configurable through the settings if you need a larger limit. The Rancher authentication endpoints are configured independently of the main public API (as you might need bigger payloads in the other API endpoints). Suppose you need to increase the maximum allowed payload for authentication. In that case, you can set the environment variable `CATTLE_AUTH_API_BODY_LIMIT` to a quantity, e.g., 2 Mi, which would allow larger payloads for the authentication endpoints. 
+| 28 Aug 2025 
+| Rancher https://github.com/rancher/rancher/releases/tag/v2.12.1[v2.12.1], https://github.com/rancher/rancher/releases/tag/v2.11.5[v2.11.5], https://github.com/rancher/rancher/releases/tag/v2.10.9[v2.10.9] and https://github.com/rancher/rancher/releases/tag/v2.9.11[v2.9.11]
+
 | https://github.com/rancher/fleet/security/advisories/GHSA-xgpc-q899-67p8[CVE-2025-23390] 
 a| This vulnerability only affects customers using xref:integrations/fleet/fleet.adoc[Continuous Delivery with Fleet] where Fleet does not validate a server's certificate when connecting through SSH. This can allow for a main-in-the-middle-attack against Fleet. The fix provides a new `insecureSkipHostKeyChecks` value for the `fleet` Helm chart. The default value is set to *`true` (opt-in) for Rancher v2.9 - v2.11* for backward compatibility. The default value is set to *`false` (opt-out) for Rancher v2.12 and later*, and Fleet v0.13 and later.
 

--- a/versions/v2.9/modules/en/pages/security/cves.adoc
+++ b/versions/v2.9/modules/en/pages/security/cves.adoc
@@ -1,5 +1,5 @@
 = Security Advisories and CVEs
-:revdate: 2025-04-28
+:revdate: 2025-09-03
 :page-revdate: {revdate}
 
 Rancher is committed to informing the community of security issues in our products. Rancher will publish security advisories and CVEs (Common Vulnerabilities and Exposures) for issues we have resolved. New security advisories are also published in Rancher's GitHub https://github.com/rancher/rancher/security/advisories[security page].

--- a/versions/v2.9/modules/zh/pages/security/cves.adoc
+++ b/versions/v2.9/modules/zh/pages/security/cves.adoc
@@ -8,6 +8,11 @@ Rancher 致力于向社区披露我们产品的安全问题。我们会针对已
 |===
 | ID | 描述 | 日期 | 解决
 
+| https://github.com/rancher/rancher/security/advisories/GHSA-4h45-jpvh-6p5j[CVE-2024-58259] 
+| POSTs to the Rancher API endpoints are now limited to 1 Mi; this is configurable through the settings if you need a larger limit. The Rancher authentication endpoints are configured independently of the main public API (as you might need bigger payloads in the other API endpoints). Suppose you need to increase the maximum allowed payload for authentication. In that case, you can set the environment variable `CATTLE_AUTH_API_BODY_LIMIT` to a quantity, e.g., 2 Mi, which would allow larger payloads for the authentication endpoints. 
+| 28 Aug 2025 
+| Rancher https://github.com/rancher/rancher/releases/tag/v2.12.1[v2.12.1], https://github.com/rancher/rancher/releases/tag/v2.11.5[v2.11.5], https://github.com/rancher/rancher/releases/tag/v2.10.9[v2.10.9] and https://github.com/rancher/rancher/releases/tag/v2.9.11[v2.9.11]
+
 | https://github.com/rancher/fleet/security/advisories/GHSA-xgpc-q899-67p8[CVE-2025-23390] 
 a| This vulnerability only affects customers using xref:integrations/fleet/fleet.adoc[Continuous Delivery with Fleet] where Fleet does not validate a server's certificate when connecting through SSH. This can allow for a main-in-the-middle-attack against Fleet. The fix provides a new `insecureSkipHostKeyChecks` value for the `fleet` Helm chart. The default value is set to *`true` (opt-in) for Rancher v2.9 - v2.11* for backward compatibility. The default value is set to *`false` (opt-out) for Rancher v2.12 and later*, and Fleet v0.13 and later.
 

--- a/versions/v2.9/modules/zh/pages/security/cves.adoc
+++ b/versions/v2.9/modules/zh/pages/security/cves.adoc
@@ -1,5 +1,5 @@
 = 安全公告和 CVE
-:revdate: 2025-06-20
+:revdate: 2025-09-03
 :page-revdate: {revdate}
 
 Rancher 致力于向社区披露我们产品的安全问题。我们会针对已解决的问题发布安全公告和 CVE（Common Vulnerabilities and Exposures，通用漏洞披露）。Rancher GitHub 上的link:https://github.com/rancher/rancher/security/advisories[安全页面]也会发布新的安全公告。


### PR DESCRIPTION
- Update the [CVE page](https://documentation.suse.com/cloudnative/rancher-manager/latest/en/security/cves.html) for the August 2025 release. 
  - [x]   en
  - [x]   zh