### PR TITLE
Fix mismatched CVE IDs

### DIFF
--- a/versions/latest/modules/en/pages/security/cves.adoc
+++ b/versions/latest/modules/en/pages/security/cves.adoc
@@ -1,5 +1,5 @@
 = Security Advisories and CVEs
-:revdate: 2025-09-03
+:revdate: 2025-09-04
 :page-revdate: {revdate}
 
 Rancher is committed to informing the community of security issues in our products. Rancher will publish security advisories and CVEs (Common Vulnerabilities and Exposures) for issues we have resolved. New security advisories are also published in Rancher's GitHub https://github.com/rancher/rancher/security/advisories[security page].
@@ -13,7 +13,7 @@ Rancher is committed to informing the community of security issues in our produc
 | 28 Aug 2025 
 | Rancher https://github.com/rancher/rancher/releases/tag/v2.12.1[v2.12.1], https://github.com/rancher/rancher/releases/tag/v2.11.5[v2.11.5], https://github.com/rancher/rancher/releases/tag/v2.10.9[v2.10.9] and https://github.com/rancher/rancher/releases/tag/v2.9.11[v2.9.11]
 
-| https://github.com/rancher/fleet/security/advisories/GHSA-6h9x-9j5v-7w9h[CVE-2023-32198] 
+| https://github.com/rancher/fleet/security/advisories/GHSA-6h9x-9j5v-7w9h[CVE-2024-52284] 
 | Following a recent https://github.com/rancher/fleet/pull/3403[change] excluding Helm values files from bundles, an edge case subsisted where the values files referenced in `fleet.yaml` with your directory name (e.g., `my-dir/values.yaml` instead of `values.yaml`) would not be excluded, which would potentially expose confidential data in bundle resources. Helm values files are now excluded from bundle resources regardless of how you reference them. 
 | 28 Aug 2025 
 | Rancher https://github.com/rancher/rancher/releases/tag/v2.12.1[v2.12.1], https://github.com/rancher/rancher/releases/tag/v2.11.5[v2.11.5] and https://github.com/rancher/rancher/releases/tag/v2.10.9[v2.10.9]

--- a/versions/latest/modules/zh/pages/security/cves.adoc
+++ b/versions/latest/modules/zh/pages/security/cves.adoc
@@ -1,5 +1,5 @@
 = 安全公告和 CVE
-:revdate: 2025-09-03
+:revdate: 2025-09-04
 :page-revdate: {revdate}
 
 Rancher 致力于向社区披露我们产品的安全问题。我们会针对已解决的问题发布安全公告和 CVE（Common Vulnerabilities and Exposures，通用漏洞披露）。Rancher GitHub 上的link:https://github.com/rancher/rancher/security/advisories[安全页面]也会发布新的安全公告。
@@ -13,7 +13,7 @@ Rancher 致力于向社区披露我们产品的安全问题。我们会针对已
 | 28 Aug 2025 
 | Rancher https://github.com/rancher/rancher/releases/tag/v2.12.1[v2.12.1], https://github.com/rancher/rancher/releases/tag/v2.11.5[v2.11.5], https://github.com/rancher/rancher/releases/tag/v2.10.9[v2.10.9] and https://github.com/rancher/rancher/releases/tag/v2.9.11[v2.9.11]
 
-| https://github.com/rancher/fleet/security/advisories/GHSA-6h9x-9j5v-7w9h[CVE-2023-32198] 
+| https://github.com/rancher/fleet/security/advisories/GHSA-6h9x-9j5v-7w9h[CVE-2024-52284] 
 | Following a recent https://github.com/rancher/fleet/pull/3403[change] excluding Helm values files from bundles, an edge case subsisted where the values files referenced in `fleet.yaml` with your directory name (e.g., `my-dir/values.yaml` instead of `values.yaml`) would not be excluded, which would potentially expose confidential data in bundle resources. Helm values files are now excluded from bundle resources regardless of how you reference them. 
 | 28 Aug 2025 
 | Rancher https://github.com/rancher/rancher/releases/tag/v2.12.1[v2.12.1], https://github.com/rancher/rancher/releases/tag/v2.11.5[v2.11.5] and https://github.com/rancher/rancher/releases/tag/v2.10.9[v2.10.9]

--- a/versions/v2.10/modules/en/pages/security/cves.adoc
+++ b/versions/v2.10/modules/en/pages/security/cves.adoc
@@ -1,5 +1,5 @@
 = Security Advisories and CVEs
-:revdate: 2025-09-03
+:revdate: 2025-09-04
 :page-revdate: {revdate}
 
 Rancher is committed to informing the community of security issues in our products. Rancher will publish security advisories and CVEs (Common Vulnerabilities and Exposures) for issues we have resolved. New security advisories are also published in Rancher's GitHub https://github.com/rancher/rancher/security/advisories[security page].
@@ -13,7 +13,7 @@ Rancher is committed to informing the community of security issues in our produc
 | 28 Aug 2025 
 | Rancher https://github.com/rancher/rancher/releases/tag/v2.12.1[v2.12.1], https://github.com/rancher/rancher/releases/tag/v2.11.5[v2.11.5], https://github.com/rancher/rancher/releases/tag/v2.10.9[v2.10.9] and https://github.com/rancher/rancher/releases/tag/v2.9.11[v2.9.11]
 
-| https://github.com/rancher/fleet/security/advisories/GHSA-6h9x-9j5v-7w9h[CVE-2023-32198] 
+| https://github.com/rancher/fleet/security/advisories/GHSA-6h9x-9j5v-7w9h[CVE-2024-52284] 
 | Following a recent https://github.com/rancher/fleet/pull/3403[change] excluding Helm values files from bundles, an edge case subsisted where the values files referenced in `fleet.yaml` with your directory name (e.g., `my-dir/values.yaml` instead of `values.yaml`) would not be excluded, which would potentially expose confidential data in bundle resources. Helm values files are now excluded from bundle resources regardless of how you reference them. 
 | 28 Aug 2025 
 | Rancher https://github.com/rancher/rancher/releases/tag/v2.12.1[v2.12.1], https://github.com/rancher/rancher/releases/tag/v2.11.5[v2.11.5] and https://github.com/rancher/rancher/releases/tag/v2.10.9[v2.10.9]
@@ -44,13 +44,13 @@ A limitation with the default `known_hosts` entries is that they are only provid
 | 24 Apr 2025 
 | Rancher https://github.com/rancher/rancher/releases/tag/v2.11.1[v2.11.1], https://github.com/rancher/rancher/releases/tag/v2.10.5[v2.10.5], and https://github.com/rancher/rancher/releases/tag/v2.9.9[v2.9.9]
 
-| https://github.com/rancher/rancher/security/advisories/GHSA-8h6m-wv39-239m[CVE-2025-22031] | A vulnerability was found where users could create a project and then gain access to arbitrary projects. As a fix, a new field has been added to projects called the `BackingNampespace`, which represents the namespace created for a project containing all resources needed for project operations. This includes resources such as ProjectRoleTemplateBindings, project-scoped secrets and workloads.
+| https://github.com/rancher/rancher/security/advisories/GHSA-8h6m-wv39-239m[CVE-2024-22031] | A vulnerability was found where users could create a project and then gain access to arbitrary projects. As a fix, a new field has been added to projects called the `BackingNampespace`, which represents the namespace created for a project containing all resources needed for project operations. This includes resources such as ProjectRoleTemplateBindings, project-scoped secrets and workloads.
 
     The field is populated automatically during project creation and is formatted as `<clusterID>-<project.Name>`. For example, if your project is named `project-abc123` in a cluster with ID `cluster-xyz789`, then the project will have the `BackingNampespace`: `cluster-xyz789-project-abc123`. Existing projects will not be migrated and only newly created projects will have the new namespace naming convention.
 | 24 Apr 2025 
 | Rancher https://github.com/rancher/rancher/releases/tag/v2.11.1[v2.11.1], https://github.com/rancher/rancher/releases/tag/v2.10.5[v2.10.5], and https://github.com/rancher/rancher/releases/tag/v2.9.9[v2.9.9]
 
-| https://github.com/rancher/steve/security/advisories/GHSA-95fc-g4gj-mqmx[CVE-2025-32198] | A vulnerability was found where users with permission to create a service in the Kubernetes cluster where Rancher is deployed can take over the Rancher UI, display their own UI, and gather sensitive information. This is only possible when the setting `ui-offline-preferred` is set to `remote`. This release introduces a patch, and the malicious user can no longer serve their own UI. If users can't upgrade, please make sure that only trustable users have access to create a service in the local cluster.
+| https://github.com/rancher/steve/security/advisories/GHSA-95fc-g4gj-mqmx[CVE-2023-32198] | A vulnerability was found where users with permission to create a service in the Kubernetes cluster where Rancher is deployed can take over the Rancher UI, display their own UI, and gather sensitive information. This is only possible when the setting `ui-offline-preferred` is set to `remote`. This release introduces a patch, and the malicious user can no longer serve their own UI. If users can't upgrade, please make sure that only trustable users have access to create a service in the local cluster.
 | 24 Apr 2025 
 | Rancher https://github.com/rancher/rancher/releases/tag/v2.11.1[v2.11.1], https://github.com/rancher/rancher/releases/tag/v2.10.5[v2.10.5], https://github.com/rancher/rancher/releases/tag/v2.9.9[v2.9.9], and https://github.com/rancher/rancher/releases/tag/v2.8.15[v2.8.15]
 
@@ -58,7 +58,7 @@ A limitation with the default `known_hosts` entries is that they are only provid
 | 31 Mar 2025 
 | Rancher https://github.com/rancher/rancher/releases/tag/v2.11.0[v2.11.0], https://github.com/rancher/rancher/releases/tag/v2.10.4[v2.10.4], https://github.com/rancher/rancher/releases/tag/v2.9.8[v2.9.8] and https://github.com/rancher/rancher/releases/tag/v2.8.14[v2.8.14]
 
-| https://github.com/rancher/rancher/security/advisories/GHSA-5qmp-9x47-92q8[CVE-2025-23389]
+| https://github.com/rancher/rancher/security/advisories/GHSA-mq23-vvg7-xfm4[CVE-2025-23389]
 a| A vulnerability in Rancher has been discovered, leading to a local user impersonation through SAML Authentication on first login.
 
 The issue occurs when a SAML authentication provider (AP) is configured (e.g. Keycloak). A newly created AP user can impersonate any user on Rancher by manipulating cookie values during their initial login to Rancher. This vulnerability could also be exploited if a Rancher user (present on the AP) is removed, either manually or automatically via the xref:rancher-admin/users/authn-and-authz/enable-user-retention.adoc[User Retention feature] with delete-inactive-user-after
@@ -72,7 +72,7 @@ This vulnerability affects those using external authentication providers as well
 | 27 Feb 2025
 | Rancher https://github.com/rancher/rancher/releases/tag/v2.10.3[v2.10.3], https://github.com/rancher/rancher/releases/tag/v2.9.7[v2.9.7] and https://github.com/rancher/rancher/releases/tag/v2.8.13[v2.8.13]
 
-| https://github.com/rancher/rancher/security/advisories/GHSA-mq23-vvg7-xfm4[CVE-2025-23387]
+| https://github.com/rancher/rancher/security/advisories/GHSA-5qmp-9x47-92q8[CVE-2025-23387]
 a| A vulnerability has been identified within Rancher where it is possible for an unauthenticated user to list all CLI authentication tokens and delete them before the CLI is able to get the token value. This effectively prevents users from logging in via the CLI when using rancher token as the execution command (instead of the token directly being in the kubeconfig).
 
 Note that this token is not the kubeconfig token and if an attacker is able to intercept it they can't use it to impersonate a real user since it is encrypted.

--- a/versions/v2.10/modules/zh/pages/security/cves.adoc
+++ b/versions/v2.10/modules/zh/pages/security/cves.adoc
@@ -1,5 +1,5 @@
 = 安全公告和 CVE
-:revdate: 2025-09-03
+:revdate: 2025-09-04
 :page-revdate: {revdate}
 
 Rancher 致力于向社区披露我们产品的安全问题。我们会针对已解决的问题发布安全公告和 CVE（Common Vulnerabilities and Exposures，通用漏洞披露）。Rancher GitHub 上的link:https://github.com/rancher/rancher/security/advisories[安全页面]也会发布新的安全公告。
@@ -13,7 +13,7 @@ Rancher 致力于向社区披露我们产品的安全问题。我们会针对已
 | 28 Aug 2025 
 | Rancher https://github.com/rancher/rancher/releases/tag/v2.12.1[v2.12.1], https://github.com/rancher/rancher/releases/tag/v2.11.5[v2.11.5], https://github.com/rancher/rancher/releases/tag/v2.10.9[v2.10.9] and https://github.com/rancher/rancher/releases/tag/v2.9.11[v2.9.11]
 
-| https://github.com/rancher/fleet/security/advisories/GHSA-6h9x-9j5v-7w9h[CVE-2023-32198] 
+| https://github.com/rancher/fleet/security/advisories/GHSA-6h9x-9j5v-7w9h[CVE-2024-52284] 
 | Following a recent https://github.com/rancher/fleet/pull/3403[change] excluding Helm values files from bundles, an edge case subsisted where the values files referenced in `fleet.yaml` with your directory name (e.g., `my-dir/values.yaml` instead of `values.yaml`) would not be excluded, which would potentially expose confidential data in bundle resources. Helm values files are now excluded from bundle resources regardless of how you reference them. 
 | 28 Aug 2025 
 | Rancher https://github.com/rancher/rancher/releases/tag/v2.12.1[v2.12.1], https://github.com/rancher/rancher/releases/tag/v2.11.5[v2.11.5] and https://github.com/rancher/rancher/releases/tag/v2.10.9[v2.10.9]
@@ -44,13 +44,13 @@ A limitation with the default `known_hosts` entries is that they are only provid
 | 24 Apr 2025 
 | Rancher https://github.com/rancher/rancher/releases/tag/v2.11.1[v2.11.1], https://github.com/rancher/rancher/releases/tag/v2.10.5[v2.10.5], and https://github.com/rancher/rancher/releases/tag/v2.9.9[v2.9.9]
 
-| https://github.com/rancher/rancher/security/advisories/GHSA-8h6m-wv39-239m[CVE-2025-22031] | A vulnerability was found where users could create a project and then gain access to arbitrary projects. As a fix, a new field has been added to projects called the `BackingNampespace`, which represents the namespace created for a project containing all resources needed for project operations. This includes resources such as ProjectRoleTemplateBindings, project-scoped secrets and workloads.
+| https://github.com/rancher/rancher/security/advisories/GHSA-8h6m-wv39-239m[CVE-2024-22031] | A vulnerability was found where users could create a project and then gain access to arbitrary projects. As a fix, a new field has been added to projects called the `BackingNampespace`, which represents the namespace created for a project containing all resources needed for project operations. This includes resources such as ProjectRoleTemplateBindings, project-scoped secrets and workloads.
 
     The field is populated automatically during project creation and is formatted as `<clusterID>-<project.Name>`. For example, if your project is named `project-abc123` in a cluster with ID `cluster-xyz789`, then the project will have the `BackingNampespace`: `cluster-xyz789-project-abc123`. Existing projects will not be migrated and only newly created projects will have the new namespace naming convention.
 | 24 Apr 2025 
 | Rancher https://github.com/rancher/rancher/releases/tag/v2.11.1[v2.11.1], https://github.com/rancher/rancher/releases/tag/v2.10.5[v2.10.5], and https://github.com/rancher/rancher/releases/tag/v2.9.9[v2.9.9]
 
-| https://github.com/rancher/steve/security/advisories/GHSA-95fc-g4gj-mqmx[CVE-2025-32198] | A vulnerability was found where users with permission to create a service in the Kubernetes cluster where Rancher is deployed can take over the Rancher UI, display their own UI, and gather sensitive information. This is only possible when the setting `ui-offline-preferred` is set to `remote`. This release introduces a patch, and the malicious user can no longer serve their own UI. If users can't upgrade, please make sure that only trustable users have access to create a service in the local cluster.
+| https://github.com/rancher/steve/security/advisories/GHSA-95fc-g4gj-mqmx[CVE-2023-32198] | A vulnerability was found where users with permission to create a service in the Kubernetes cluster where Rancher is deployed can take over the Rancher UI, display their own UI, and gather sensitive information. This is only possible when the setting `ui-offline-preferred` is set to `remote`. This release introduces a patch, and the malicious user can no longer serve their own UI. If users can't upgrade, please make sure that only trustable users have access to create a service in the local cluster.
 | 24 Apr 2025 
 | Rancher https://github.com/rancher/rancher/releases/tag/v2.11.1[v2.11.1], https://github.com/rancher/rancher/releases/tag/v2.10.5[v2.10.5], https://github.com/rancher/rancher/releases/tag/v2.9.9[v2.9.9], and https://github.com/rancher/rancher/releases/tag/v2.8.15[v2.8.15]
 
@@ -58,7 +58,7 @@ A limitation with the default `known_hosts` entries is that they are only provid
 | 31 Mar 2025 
 | Rancher https://github.com/rancher/rancher/releases/tag/v2.11.0[v2.11.0], https://github.com/rancher/rancher/releases/tag/v2.10.4[v2.10.4], https://github.com/rancher/rancher/releases/tag/v2.9.8[v2.9.8] and https://github.com/rancher/rancher/releases/tag/v2.8.14[v2.8.14]
 
-| https://github.com/rancher/rancher/security/advisories/GHSA-5qmp-9x47-92q8[CVE-2025-23389]
+| https://github.com/rancher/rancher/security/advisories/GHSA-mq23-vvg7-xfm4[CVE-2025-23389]
 a| A vulnerability in Rancher has been discovered, leading to a local user impersonation through SAML Authentication on first login.
 
 The issue occurs when a SAML authentication provider (AP) is configured (e.g. Keycloak). A newly created AP user can impersonate any user on Rancher by manipulating cookie values during their initial login to Rancher. This vulnerability could also be exploited if a Rancher user (present on the AP) is removed, either manually or automatically via the xref:rancher-admin/users/authn-and-authz/enable-user-retention.adoc[User Retention feature] with delete-inactive-user-after
@@ -72,7 +72,7 @@ This vulnerability affects those using external authentication providers as well
 | 27 Feb 2025
 | Rancher https://github.com/rancher/rancher/releases/tag/v2.10.3[v2.10.3], https://github.com/rancher/rancher/releases/tag/v2.9.7[v2.9.7] and https://github.com/rancher/rancher/releases/tag/v2.8.13[v2.8.13]
 
-| https://github.com/rancher/rancher/security/advisories/GHSA-mq23-vvg7-xfm4[CVE-2025-23387]
+| https://github.com/rancher/rancher/security/advisories/GHSA-5qmp-9x47-92q8[CVE-2025-23387]
 a| A vulnerability has been identified within Rancher where it is possible for an unauthenticated user to list all CLI authentication tokens and delete them before the CLI is able to get the token value. This effectively prevents users from logging in via the CLI when using rancher token as the execution command (instead of the token directly being in the kubeconfig).
 
 Note that this token is not the kubeconfig token and if an attacker is able to intercept it they can't use it to impersonate a real user since it is encrypted.

--- a/versions/v2.11/modules/en/pages/security/cves.adoc
+++ b/versions/v2.11/modules/en/pages/security/cves.adoc
@@ -1,5 +1,5 @@
 = Security Advisories and CVEs
-:revdate: 2025-09-03
+:revdate: 2025-09-04
 :page-revdate: {revdate}
 
 Rancher is committed to informing the community of security issues in our products. Rancher will publish security advisories and CVEs (Common Vulnerabilities and Exposures) for issues we have resolved. New security advisories are also published in Rancher's GitHub https://github.com/rancher/rancher/security/advisories[security page].
@@ -13,7 +13,7 @@ Rancher is committed to informing the community of security issues in our produc
 | 28 Aug 2025 
 | Rancher https://github.com/rancher/rancher/releases/tag/v2.12.1[v2.12.1], https://github.com/rancher/rancher/releases/tag/v2.11.5[v2.11.5], https://github.com/rancher/rancher/releases/tag/v2.10.9[v2.10.9] and https://github.com/rancher/rancher/releases/tag/v2.9.11[v2.9.11]
 
-| https://github.com/rancher/fleet/security/advisories/GHSA-6h9x-9j5v-7w9h[CVE-2023-32198] 
+| https://github.com/rancher/fleet/security/advisories/GHSA-6h9x-9j5v-7w9h[CVE-2024-52284] 
 | Following a recent https://github.com/rancher/fleet/pull/3403[change] excluding Helm values files from bundles, an edge case subsisted where the values files referenced in `fleet.yaml` with your directory name (e.g., `my-dir/values.yaml` instead of `values.yaml`) would not be excluded, which would potentially expose confidential data in bundle resources. Helm values files are now excluded from bundle resources regardless of how you reference them. 
 | 28 Aug 2025 
 | Rancher https://github.com/rancher/rancher/releases/tag/v2.12.1[v2.12.1], https://github.com/rancher/rancher/releases/tag/v2.11.5[v2.11.5] and https://github.com/rancher/rancher/releases/tag/v2.10.9[v2.10.9]
@@ -44,13 +44,13 @@ A limitation with the default `known_hosts` entries is that they are only provid
 | 24 Apr 2025 
 | Rancher https://github.com/rancher/rancher/releases/tag/v2.11.1[v2.11.1], https://github.com/rancher/rancher/releases/tag/v2.10.5[v2.10.5], and https://github.com/rancher/rancher/releases/tag/v2.9.9[v2.9.9]
 
-| https://github.com/rancher/rancher/security/advisories/GHSA-8h6m-wv39-239m[CVE-2025-22031] | A vulnerability was found where users could create a project and then gain access to arbitrary projects. As a fix, a new field has been added to projects called the `BackingNampespace`, which represents the namespace created for a project containing all resources needed for project operations. This includes resources such as ProjectRoleTemplateBindings, project-scoped secrets and workloads.
+| https://github.com/rancher/rancher/security/advisories/GHSA-8h6m-wv39-239m[CVE-2024-22031] | A vulnerability was found where users could create a project and then gain access to arbitrary projects. As a fix, a new field has been added to projects called the `BackingNampespace`, which represents the namespace created for a project containing all resources needed for project operations. This includes resources such as ProjectRoleTemplateBindings, project-scoped secrets and workloads.
 
     The field is populated automatically during project creation and is formatted as `<clusterID>-<project.Name>`. For example, if your project is named `project-abc123` in a cluster with ID `cluster-xyz789`, then the project will have the `BackingNampespace`: `cluster-xyz789-project-abc123`. Existing projects will not be migrated and only newly created projects will have the new namespace naming convention.
 | 24 Apr 2025 
 | Rancher https://github.com/rancher/rancher/releases/tag/v2.11.1[v2.11.1], https://github.com/rancher/rancher/releases/tag/v2.10.5[v2.10.5], and https://github.com/rancher/rancher/releases/tag/v2.9.9[v2.9.9]
 
-| https://github.com/rancher/steve/security/advisories/GHSA-95fc-g4gj-mqmx[CVE-2025-32198] | A vulnerability was found where users with permission to create a service in the Kubernetes cluster where Rancher is deployed can take over the Rancher UI, display their own UI, and gather sensitive information. This is only possible when the setting `ui-offline-preferred` is set to `remote`. This release introduces a patch, and the malicious user can no longer serve their own UI. If users can't upgrade, please make sure that only trustable users have access to create a service in the local cluster.
+| https://github.com/rancher/steve/security/advisories/GHSA-95fc-g4gj-mqmx[CVE-2023-32198] | A vulnerability was found where users with permission to create a service in the Kubernetes cluster where Rancher is deployed can take over the Rancher UI, display their own UI, and gather sensitive information. This is only possible when the setting `ui-offline-preferred` is set to `remote`. This release introduces a patch, and the malicious user can no longer serve their own UI. If users can't upgrade, please make sure that only trustable users have access to create a service in the local cluster.
 | 24 Apr 2025 
 | Rancher https://github.com/rancher/rancher/releases/tag/v2.11.1[v2.11.1], https://github.com/rancher/rancher/releases/tag/v2.10.5[v2.10.5], https://github.com/rancher/rancher/releases/tag/v2.9.9[v2.9.9], and https://github.com/rancher/rancher/releases/tag/v2.8.15[v2.8.15]
 

--- a/versions/v2.11/modules/zh/pages/security/cves.adoc
+++ b/versions/v2.11/modules/zh/pages/security/cves.adoc
@@ -1,5 +1,5 @@
 = 安全公告和 CVE
-:revdate: 2025-09-03
+:revdate: 2025-09-04
 :page-revdate: {revdate}
 
 Rancher 致力于向社区披露我们产品的安全问题。我们会针对已解决的问题发布安全公告和 CVE（Common Vulnerabilities and Exposures，通用漏洞披露）。Rancher GitHub 上的link:https://github.com/rancher/rancher/security/advisories[安全页面]也会发布新的安全公告。
@@ -13,7 +13,7 @@ Rancher 致力于向社区披露我们产品的安全问题。我们会针对已
 | 28 Aug 2025 
 | Rancher https://github.com/rancher/rancher/releases/tag/v2.12.1[v2.12.1], https://github.com/rancher/rancher/releases/tag/v2.11.5[v2.11.5], https://github.com/rancher/rancher/releases/tag/v2.10.9[v2.10.9] and https://github.com/rancher/rancher/releases/tag/v2.9.11[v2.9.11]
 
-| https://github.com/rancher/fleet/security/advisories/GHSA-6h9x-9j5v-7w9h[CVE-2023-32198] 
+| https://github.com/rancher/fleet/security/advisories/GHSA-6h9x-9j5v-7w9h[CVE-2024-52284] 
 | Following a recent https://github.com/rancher/fleet/pull/3403[change] excluding Helm values files from bundles, an edge case subsisted where the values files referenced in `fleet.yaml` with your directory name (e.g., `my-dir/values.yaml` instead of `values.yaml`) would not be excluded, which would potentially expose confidential data in bundle resources. Helm values files are now excluded from bundle resources regardless of how you reference them. 
 | 28 Aug 2025 
 | Rancher https://github.com/rancher/rancher/releases/tag/v2.12.1[v2.12.1], https://github.com/rancher/rancher/releases/tag/v2.11.5[v2.11.5] and https://github.com/rancher/rancher/releases/tag/v2.10.9[v2.10.9]
@@ -44,13 +44,13 @@ A limitation with the default `known_hosts` entries is that they are only provid
 | 24 Apr 2025 
 | Rancher https://github.com/rancher/rancher/releases/tag/v2.11.1[v2.11.1], https://github.com/rancher/rancher/releases/tag/v2.10.5[v2.10.5], and https://github.com/rancher/rancher/releases/tag/v2.9.9[v2.9.9]
 
-| https://github.com/rancher/rancher/security/advisories/GHSA-8h6m-wv39-239m[CVE-2025-22031] | A vulnerability was found where users could create a project and then gain access to arbitrary projects. As a fix, a new field has been added to projects called the `BackingNampespace`, which represents the namespace created for a project containing all resources needed for project operations. This includes resources such as ProjectRoleTemplateBindings, project-scoped secrets and workloads.
+| https://github.com/rancher/rancher/security/advisories/GHSA-8h6m-wv39-239m[CVE-2024-22031] | A vulnerability was found where users could create a project and then gain access to arbitrary projects. As a fix, a new field has been added to projects called the `BackingNampespace`, which represents the namespace created for a project containing all resources needed for project operations. This includes resources such as ProjectRoleTemplateBindings, project-scoped secrets and workloads.
 
     The field is populated automatically during project creation and is formatted as `<clusterID>-<project.Name>`. For example, if your project is named `project-abc123` in a cluster with ID `cluster-xyz789`, then the project will have the `BackingNampespace`: `cluster-xyz789-project-abc123`. Existing projects will not be migrated and only newly created projects will have the new namespace naming convention.
 | 24 Apr 2025 
 | Rancher https://github.com/rancher/rancher/releases/tag/v2.11.1[v2.11.1], https://github.com/rancher/rancher/releases/tag/v2.10.5[v2.10.5], and https://github.com/rancher/rancher/releases/tag/v2.9.9[v2.9.9]
 
-| https://github.com/rancher/steve/security/advisories/GHSA-95fc-g4gj-mqmx[CVE-2025-32198] | A vulnerability was found where users with permission to create a service in the Kubernetes cluster where Rancher is deployed can take over the Rancher UI, display their own UI, and gather sensitive information. This is only possible when the setting `ui-offline-preferred` is set to `remote`. This release introduces a patch, and the malicious user can no longer serve their own UI. If users can't upgrade, please make sure that only trustable users have access to create a service in the local cluster.
+| https://github.com/rancher/steve/security/advisories/GHSA-95fc-g4gj-mqmx[CVE-2023-32198] | A vulnerability was found where users with permission to create a service in the Kubernetes cluster where Rancher is deployed can take over the Rancher UI, display their own UI, and gather sensitive information. This is only possible when the setting `ui-offline-preferred` is set to `remote`. This release introduces a patch, and the malicious user can no longer serve their own UI. If users can't upgrade, please make sure that only trustable users have access to create a service in the local cluster.
 | 24 Apr 2025 
 | Rancher https://github.com/rancher/rancher/releases/tag/v2.11.1[v2.11.1], https://github.com/rancher/rancher/releases/tag/v2.10.5[v2.10.5], https://github.com/rancher/rancher/releases/tag/v2.9.9[v2.9.9], and https://github.com/rancher/rancher/releases/tag/v2.8.15[v2.8.15]
 

--- a/versions/v2.12/modules/en/pages/security/cves.adoc
+++ b/versions/v2.12/modules/en/pages/security/cves.adoc
@@ -1,5 +1,5 @@
 = Security Advisories and CVEs
-:revdate: 2025-09-03
+:revdate: 2025-09-04
 :page-revdate: {revdate}
 
 Rancher is committed to informing the community of security issues in our products. Rancher will publish security advisories and CVEs (Common Vulnerabilities and Exposures) for issues we have resolved. New security advisories are also published in Rancher's GitHub https://github.com/rancher/rancher/security/advisories[security page].
@@ -13,7 +13,7 @@ Rancher is committed to informing the community of security issues in our produc
 | 28 Aug 2025 
 | Rancher https://github.com/rancher/rancher/releases/tag/v2.12.1[v2.12.1], https://github.com/rancher/rancher/releases/tag/v2.11.5[v2.11.5], https://github.com/rancher/rancher/releases/tag/v2.10.9[v2.10.9] and https://github.com/rancher/rancher/releases/tag/v2.9.11[v2.9.11]
 
-| https://github.com/rancher/fleet/security/advisories/GHSA-6h9x-9j5v-7w9h[CVE-2023-32198] 
+| https://github.com/rancher/fleet/security/advisories/GHSA-6h9x-9j5v-7w9h[CVE-2024-52284] 
 | Following a recent https://github.com/rancher/fleet/pull/3403[change] excluding Helm values files from bundles, an edge case subsisted where the values files referenced in `fleet.yaml` with your directory name (e.g., `my-dir/values.yaml` instead of `values.yaml`) would not be excluded, which would potentially expose confidential data in bundle resources. Helm values files are now excluded from bundle resources regardless of how you reference them. 
 | 28 Aug 2025 
 | Rancher https://github.com/rancher/rancher/releases/tag/v2.12.1[v2.12.1], https://github.com/rancher/rancher/releases/tag/v2.11.5[v2.11.5] and https://github.com/rancher/rancher/releases/tag/v2.10.9[v2.10.9]

--- a/versions/v2.12/modules/zh/pages/security/cves.adoc
+++ b/versions/v2.12/modules/zh/pages/security/cves.adoc
@@ -1,5 +1,5 @@
 = 安全公告和 CVE
-:revdate: 2025-09-03
+:revdate: 2025-09-04
 :page-revdate: {revdate}
 
 Rancher 致力于向社区披露我们产品的安全问题。我们会针对已解决的问题发布安全公告和 CVE（Common Vulnerabilities and Exposures，通用漏洞披露）。Rancher GitHub 上的link:https://github.com/rancher/rancher/security/advisories[安全页面]也会发布新的安全公告。
@@ -13,7 +13,7 @@ Rancher 致力于向社区披露我们产品的安全问题。我们会针对已
 | 28 Aug 2025 
 | Rancher https://github.com/rancher/rancher/releases/tag/v2.12.1[v2.12.1], https://github.com/rancher/rancher/releases/tag/v2.11.5[v2.11.5], https://github.com/rancher/rancher/releases/tag/v2.10.9[v2.10.9] and https://github.com/rancher/rancher/releases/tag/v2.9.11[v2.9.11]
 
-| https://github.com/rancher/fleet/security/advisories/GHSA-6h9x-9j5v-7w9h[CVE-2023-32198] 
+| https://github.com/rancher/fleet/security/advisories/GHSA-6h9x-9j5v-7w9h[CVE-2024-52284] 
 | Following a recent https://github.com/rancher/fleet/pull/3403[change] excluding Helm values files from bundles, an edge case subsisted where the values files referenced in `fleet.yaml` with your directory name (e.g., `my-dir/values.yaml` instead of `values.yaml`) would not be excluded, which would potentially expose confidential data in bundle resources. Helm values files are now excluded from bundle resources regardless of how you reference them. 
 | 28 Aug 2025 
 | Rancher https://github.com/rancher/rancher/releases/tag/v2.12.1[v2.12.1], https://github.com/rancher/rancher/releases/tag/v2.11.5[v2.11.5] and https://github.com/rancher/rancher/releases/tag/v2.10.9[v2.10.9]

--- a/versions/v2.8/modules/en/pages/security/cves.adoc
+++ b/versions/v2.8/modules/en/pages/security/cves.adoc
@@ -1,5 +1,5 @@
 = Security Advisories and CVEs
-:revdate: 2025-09-03
+:revdate: 2025-09-04
 :page-revdate: {revdate}
 
 Rancher is committed to informing the community of security issues in our products. Rancher will publish security advisories and CVEs (Common Vulnerabilities and Exposures) for issues we have resolved. New security advisories are also published in Rancher's GitHub https://github.com/rancher/rancher/security/advisories[security page].
@@ -8,7 +8,7 @@ Rancher is committed to informing the community of security issues in our produc
 |===
 | ID | Description | Date | Resolution
 
-| https://github.com/rancher/steve/security/advisories/GHSA-95fc-g4gj-mqmx[CVE-2025-32198] | A vulnerability was found where users with permission to create a service in the Kubernetes cluster where Rancher is deployed can take over the Rancher UI, display their own UI, and gather sensitive information. This is only possible when the setting `ui-offline-preferred` is set to `remote`. This release introduces a patch, and the malicious user can no longer serve their own UI. If users can't upgrade, please make sure that only trustable users have access to create a service in the local cluster.
+| https://github.com/rancher/steve/security/advisories/GHSA-95fc-g4gj-mqmx[CVE-2023-32198] | A vulnerability was found where users with permission to create a service in the Kubernetes cluster where Rancher is deployed can take over the Rancher UI, display their own UI, and gather sensitive information. This is only possible when the setting `ui-offline-preferred` is set to `remote`. This release introduces a patch, and the malicious user can no longer serve their own UI. If users can't upgrade, please make sure that only trustable users have access to create a service in the local cluster.
 | 24 Apr 2025 
 | Rancher https://github.com/rancher/rancher/releases/tag/v2.11.1[v2.11.1], https://github.com/rancher/rancher/releases/tag/v2.10.5[v2.10.5], https://github.com/rancher/rancher/releases/tag/v2.9.9[v2.9.9], and https://github.com/rancher/rancher/releases/tag/v2.8.15[v2.8.15]
 
@@ -16,7 +16,7 @@ Rancher is committed to informing the community of security issues in our produc
 | 31 Mar 2025 
 | Rancher https://github.com/rancher/rancher/releases/tag/v2.11.0[v2.11.0], https://github.com/rancher/rancher/releases/tag/v2.10.4[v2.10.4], https://github.com/rancher/rancher/releases/tag/v2.9.8[v2.9.8] and https://github.com/rancher/rancher/releases/tag/v2.8.14[v2.8.14]
 
-| https://github.com/rancher/rancher/security/advisories/GHSA-5qmp-9x47-92q8[CVE-2025-23389]
+| https://github.com/rancher/rancher/security/advisories/GHSA-mq23-vvg7-xfm4[CVE-2025-23389]
 a| A vulnerability in Rancher has been discovered, leading to a local user impersonation through SAML Authentication on first login.
 
 The issue occurs when a SAML authentication provider (AP) is configured (e.g. Keycloak). A newly created AP user can impersonate any user on Rancher by manipulating cookie values during their initial login to Rancher. This vulnerability could also be exploited if a Rancher user (present on the AP) is removed, either manually or automatically via the xref:rancher-admin/users/authn-and-authz/enable-user-retention.adoc[User Retention feature] with delete-inactive-user-after
@@ -30,7 +30,7 @@ This vulnerability affects those using external authentication providers as well
 | 27 Feb 2025
 | Rancher https://github.com/rancher/rancher/releases/tag/v2.10.3[v2.10.3], https://github.com/rancher/rancher/releases/tag/v2.9.7[v2.9.7] and https://github.com/rancher/rancher/releases/tag/v2.8.13[v2.8.13]
 
-| https://github.com/rancher/rancher/security/advisories/GHSA-mq23-vvg7-xfm4[CVE-2025-23387]
+| https://github.com/rancher/rancher/security/advisories/GHSA-5qmp-9x47-92q8[CVE-2025-23387]
 a| A vulnerability has been identified within Rancher where it is possible for an unauthenticated user to list all CLI authentication tokens and delete them before the CLI is able to get the token value. This effectively prevents users from logging in via the CLI when using rancher token as the execution command (instead of the token directly being in the kubeconfig).
 
 Note that this token is not the kubeconfig token and if an attacker is able to intercept it they can't use it to impersonate a real user since it is encrypted.

--- a/versions/v2.8/modules/zh/pages/security/cves.adoc
+++ b/versions/v2.8/modules/zh/pages/security/cves.adoc
@@ -1,5 +1,5 @@
 = 安全公告和 CVE
-:revdate: 2025-09-03
+:revdate: 2025-09-04
 :page-revdate: {revdate}
 
 Rancher 致力于向社区披露我们产品的安全问题。我们会针对已解决的问题发布安全公告和 CVE（Common Vulnerabilities and Exposures，通用漏洞披露）。Rancher GitHub 上的link:https://github.com/rancher/rancher/security/advisories[安全页面]也会发布新的安全公告。
@@ -8,7 +8,7 @@ Rancher 致力于向社区披露我们产品的安全问题。我们会针对已
 |===
 | ID | 描述 | 日期 | 解决
 
-| https://github.com/rancher/steve/security/advisories/GHSA-95fc-g4gj-mqmx[CVE-2025-32198] | A vulnerability was found where users with permission to create a service in the Kubernetes cluster where Rancher is deployed can take over the Rancher UI, display their own UI, and gather sensitive information. This is only possible when the setting `ui-offline-preferred` is set to `remote`. This release introduces a patch, and the malicious user can no longer serve their own UI. If users can't upgrade, please make sure that only trustable users have access to create a service in the local cluster.
+| https://github.com/rancher/steve/security/advisories/GHSA-95fc-g4gj-mqmx[CVE-2023-32198] | A vulnerability was found where users with permission to create a service in the Kubernetes cluster where Rancher is deployed can take over the Rancher UI, display their own UI, and gather sensitive information. This is only possible when the setting `ui-offline-preferred` is set to `remote`. This release introduces a patch, and the malicious user can no longer serve their own UI. If users can't upgrade, please make sure that only trustable users have access to create a service in the local cluster.
 | 24 Apr 2025 
 | Rancher https://github.com/rancher/rancher/releases/tag/v2.11.1[v2.11.1], https://github.com/rancher/rancher/releases/tag/v2.10.5[v2.10.5], https://github.com/rancher/rancher/releases/tag/v2.9.9[v2.9.9], and https://github.com/rancher/rancher/releases/tag/v2.8.15[v2.8.15]
 
@@ -16,7 +16,7 @@ Rancher 致力于向社区披露我们产品的安全问题。我们会针对已
 | 31 Mar 2025 
 | Rancher https://github.com/rancher/rancher/releases/tag/v2.11.0[v2.11.0], https://github.com/rancher/rancher/releases/tag/v2.10.4[v2.10.4], https://github.com/rancher/rancher/releases/tag/v2.9.8[v2.9.8] and https://github.com/rancher/rancher/releases/tag/v2.8.14[v2.8.14]
 
-| https://github.com/rancher/rancher/security/advisories/GHSA-5qmp-9x47-92q8[CVE-2025-23389]
+| https://github.com/rancher/rancher/security/advisories/GHSA-mq23-vvg7-xfm4[CVE-2025-23389]
 a| A vulnerability in Rancher has been discovered, leading to a local user impersonation through SAML Authentication on first login.
 
 The issue occurs when a SAML authentication provider (AP) is configured (e.g. Keycloak). A newly created AP user can impersonate any user on Rancher by manipulating cookie values during their initial login to Rancher. This vulnerability could also be exploited if a Rancher user (present on the AP) is removed, either manually or automatically via the xref:rancher-admin/users/authn-and-authz/enable-user-retention.adoc[User Retention feature] with delete-inactive-user-after
@@ -30,7 +30,7 @@ This vulnerability affects those using external authentication providers as well
 | 27 Feb 2025
 | Rancher https://github.com/rancher/rancher/releases/tag/v2.10.3[v2.10.3], https://github.com/rancher/rancher/releases/tag/v2.9.7[v2.9.7] and https://github.com/rancher/rancher/releases/tag/v2.8.13[v2.8.13]
 
-| https://github.com/rancher/rancher/security/advisories/GHSA-mq23-vvg7-xfm4[CVE-2025-23387]
+| https://github.com/rancher/rancher/security/advisories/GHSA-5qmp-9x47-92q8[CVE-2025-23387]
 a| A vulnerability has been identified within Rancher where it is possible for an unauthenticated user to list all CLI authentication tokens and delete them before the CLI is able to get the token value. This effectively prevents users from logging in via the CLI when using rancher token as the execution command (instead of the token directly being in the kubeconfig).
 
 Note that this token is not the kubeconfig token and if an attacker is able to intercept it they can't use it to impersonate a real user since it is encrypted.

--- a/versions/v2.9/modules/en/pages/security/cves.adoc
+++ b/versions/v2.9/modules/en/pages/security/cves.adoc
@@ -1,5 +1,5 @@
 = Security Advisories and CVEs
-:revdate: 2025-09-03
+:revdate: 2025-09-04
 :page-revdate: {revdate}
 
 Rancher is committed to informing the community of security issues in our products. Rancher will publish security advisories and CVEs (Common Vulnerabilities and Exposures) for issues we have resolved. New security advisories are also published in Rancher's GitHub https://github.com/rancher/rancher/security/advisories[security page].
@@ -39,13 +39,13 @@ A limitation with the default `known_hosts` entries is that they are only provid
 | 24 Apr 2025 
 | Rancher https://github.com/rancher/rancher/releases/tag/v2.11.1[v2.11.1], https://github.com/rancher/rancher/releases/tag/v2.10.5[v2.10.5], and https://github.com/rancher/rancher/releases/tag/v2.9.9[v2.9.9]
 
-| https://github.com/rancher/rancher/security/advisories/GHSA-8h6m-wv39-239m[CVE-2025-22031] | A vulnerability was found where users could create a project and then gain access to arbitrary projects. As a fix, a new field has been added to projects called the `BackingNampespace`, which represents the namespace created for a project containing all resources needed for project operations. This includes resources such as ProjectRoleTemplateBindings, project-scoped secrets and workloads.
+| https://github.com/rancher/rancher/security/advisories/GHSA-8h6m-wv39-239m[CVE-2024-22031] | A vulnerability was found where users could create a project and then gain access to arbitrary projects. As a fix, a new field has been added to projects called the `BackingNampespace`, which represents the namespace created for a project containing all resources needed for project operations. This includes resources such as ProjectRoleTemplateBindings, project-scoped secrets and workloads.
 
     The field is populated automatically during project creation and is formatted as `<clusterID>-<project.Name>`. For example, if your project is named `project-abc123` in a cluster with ID `cluster-xyz789`, then the project will have the `BackingNampespace`: `cluster-xyz789-project-abc123`. Existing projects will not be migrated and only newly created projects will have the new namespace naming convention.
 | 24 Apr 2025 
 | Rancher https://github.com/rancher/rancher/releases/tag/v2.11.1[v2.11.1], https://github.com/rancher/rancher/releases/tag/v2.10.5[v2.10.5], and https://github.com/rancher/rancher/releases/tag/v2.9.9[v2.9.9]
 
-| https://github.com/rancher/steve/security/advisories/GHSA-95fc-g4gj-mqmx[CVE-2025-32198] | A vulnerability was found where users with permission to create a service in the Kubernetes cluster where Rancher is deployed can take over the Rancher UI, display their own UI, and gather sensitive information. This is only possible when the setting `ui-offline-preferred` is set to `remote`. This release introduces a patch, and the malicious user can no longer serve their own UI. If users can't upgrade, please make sure that only trustable users have access to create a service in the local cluster.
+| https://github.com/rancher/steve/security/advisories/GHSA-95fc-g4gj-mqmx[CVE-2023-32198] | A vulnerability was found where users with permission to create a service in the Kubernetes cluster where Rancher is deployed can take over the Rancher UI, display their own UI, and gather sensitive information. This is only possible when the setting `ui-offline-preferred` is set to `remote`. This release introduces a patch, and the malicious user can no longer serve their own UI. If users can't upgrade, please make sure that only trustable users have access to create a service in the local cluster.
 | 24 Apr 2025 
 | Rancher https://github.com/rancher/rancher/releases/tag/v2.11.1[v2.11.1], https://github.com/rancher/rancher/releases/tag/v2.10.5[v2.10.5], https://github.com/rancher/rancher/releases/tag/v2.9.9[v2.9.9], and https://github.com/rancher/rancher/releases/tag/v2.8.15[v2.8.15]
 
@@ -53,7 +53,7 @@ A limitation with the default `known_hosts` entries is that they are only provid
 | 31 Mar 2025 
 | Rancher https://github.com/rancher/rancher/releases/tag/v2.11.0[v2.11.0], https://github.com/rancher/rancher/releases/tag/v2.10.4[v2.10.4], https://github.com/rancher/rancher/releases/tag/v2.9.8[v2.9.8] and https://github.com/rancher/rancher/releases/tag/v2.8.14[v2.8.14]
 
-| https://github.com/rancher/rancher/security/advisories/GHSA-5qmp-9x47-92q8[CVE-2025-23389]
+| https://github.com/rancher/rancher/security/advisories/GHSA-mq23-vvg7-xfm4[CVE-2025-23389]
 a| A vulnerability in Rancher has been discovered, leading to a local user impersonation through SAML Authentication on first login.
 
 The issue occurs when a SAML authentication provider (AP) is configured (e.g. Keycloak). A newly created AP user can impersonate any user on Rancher by manipulating cookie values during their initial login to Rancher. This vulnerability could also be exploited if a Rancher user (present on the AP) is removed, either manually or automatically via the xref:rancher-admin/users/authn-and-authz/enable-user-retention.adoc[User Retention feature] with delete-inactive-user-after
@@ -67,7 +67,7 @@ This vulnerability affects those using external authentication providers as well
 | 27 Feb 2025
 | Rancher https://github.com/rancher/rancher/releases/tag/v2.10.3[v2.10.3], https://github.com/rancher/rancher/releases/tag/v2.9.7[v2.9.7] and https://github.com/rancher/rancher/releases/tag/v2.8.13[v2.8.13]
 
-| https://github.com/rancher/rancher/security/advisories/GHSA-mq23-vvg7-xfm4[CVE-2025-23387]
+| https://github.com/rancher/rancher/security/advisories/GHSA-5qmp-9x47-92q8[CVE-2025-23387]
 a| A vulnerability has been identified within Rancher where it is possible for an unauthenticated user to list all CLI authentication tokens and delete them before the CLI is able to get the token value. This effectively prevents users from logging in via the CLI when using rancher token as the execution command (instead of the token directly being in the kubeconfig).
 
 Note that this token is not the kubeconfig token and if an attacker is able to intercept it they can't use it to impersonate a real user since it is encrypted.

--- a/versions/v2.9/modules/zh/pages/security/cves.adoc
+++ b/versions/v2.9/modules/zh/pages/security/cves.adoc
@@ -1,5 +1,5 @@
 = 安全公告和 CVE
-:revdate: 2025-09-03
+:revdate: 2025-09-04
 :page-revdate: {revdate}
 
 Rancher 致力于向社区披露我们产品的安全问题。我们会针对已解决的问题发布安全公告和 CVE（Common Vulnerabilities and Exposures，通用漏洞披露）。Rancher GitHub 上的link:https://github.com/rancher/rancher/security/advisories[安全页面]也会发布新的安全公告。
@@ -39,13 +39,13 @@ A limitation with the default `known_hosts` entries is that they are only provid
 | 24 Apr 2025 
 | Rancher https://github.com/rancher/rancher/releases/tag/v2.11.1[v2.11.1], https://github.com/rancher/rancher/releases/tag/v2.10.5[v2.10.5], and https://github.com/rancher/rancher/releases/tag/v2.9.9[v2.9.9]
 
-| https://github.com/rancher/rancher/security/advisories/GHSA-8h6m-wv39-239m[CVE-2025-22031] | A vulnerability was found where users could create a project and then gain access to arbitrary projects. As a fix, a new field has been added to projects called the `BackingNampespace`, which represents the namespace created for a project containing all resources needed for project operations. This includes resources such as ProjectRoleTemplateBindings, project-scoped secrets and workloads.
+| https://github.com/rancher/rancher/security/advisories/GHSA-8h6m-wv39-239m[CVE-2024-22031] | A vulnerability was found where users could create a project and then gain access to arbitrary projects. As a fix, a new field has been added to projects called the `BackingNampespace`, which represents the namespace created for a project containing all resources needed for project operations. This includes resources such as ProjectRoleTemplateBindings, project-scoped secrets and workloads.
 
     The field is populated automatically during project creation and is formatted as `<clusterID>-<project.Name>`. For example, if your project is named `project-abc123` in a cluster with ID `cluster-xyz789`, then the project will have the `BackingNampespace`: `cluster-xyz789-project-abc123`. Existing projects will not be migrated and only newly created projects will have the new namespace naming convention.
 | 24 Apr 2025 
 | Rancher https://github.com/rancher/rancher/releases/tag/v2.11.1[v2.11.1], https://github.com/rancher/rancher/releases/tag/v2.10.5[v2.10.5], and https://github.com/rancher/rancher/releases/tag/v2.9.9[v2.9.9]
 
-| https://github.com/rancher/steve/security/advisories/GHSA-95fc-g4gj-mqmx[CVE-2025-32198] | A vulnerability was found where users with permission to create a service in the Kubernetes cluster where Rancher is deployed can take over the Rancher UI, display their own UI, and gather sensitive information. This is only possible when the setting `ui-offline-preferred` is set to `remote`. This release introduces a patch, and the malicious user can no longer serve their own UI. If users can't upgrade, please make sure that only trustable users have access to create a service in the local cluster.
+| https://github.com/rancher/steve/security/advisories/GHSA-95fc-g4gj-mqmx[CVE-2023-32198] | A vulnerability was found where users with permission to create a service in the Kubernetes cluster where Rancher is deployed can take over the Rancher UI, display their own UI, and gather sensitive information. This is only possible when the setting `ui-offline-preferred` is set to `remote`. This release introduces a patch, and the malicious user can no longer serve their own UI. If users can't upgrade, please make sure that only trustable users have access to create a service in the local cluster.
 | 24 Apr 2025 
 | Rancher https://github.com/rancher/rancher/releases/tag/v2.11.1[v2.11.1], https://github.com/rancher/rancher/releases/tag/v2.10.5[v2.10.5], https://github.com/rancher/rancher/releases/tag/v2.9.9[v2.9.9], and https://github.com/rancher/rancher/releases/tag/v2.8.15[v2.8.15]
 
@@ -53,7 +53,7 @@ A limitation with the default `known_hosts` entries is that they are only provid
 | 31 Mar 2025 
 | Rancher https://github.com/rancher/rancher/releases/tag/v2.11.0[v2.11.0], https://github.com/rancher/rancher/releases/tag/v2.10.4[v2.10.4], https://github.com/rancher/rancher/releases/tag/v2.9.8[v2.9.8] and https://github.com/rancher/rancher/releases/tag/v2.8.14[v2.8.14]
 
-| https://github.com/rancher/rancher/security/advisories/GHSA-5qmp-9x47-92q8[CVE-2025-23389]
+| https://github.com/rancher/rancher/security/advisories/GHSA-mq23-vvg7-xfm4[CVE-2025-23389]
 a| A vulnerability in Rancher has been discovered, leading to a local user impersonation through SAML Authentication on first login.
 
 The issue occurs when a SAML authentication provider (AP) is configured (e.g. Keycloak). A newly created AP user can impersonate any user on Rancher by manipulating cookie values during their initial login to Rancher. This vulnerability could also be exploited if a Rancher user (present on the AP) is removed, either manually or automatically via the xref:rancher-admin/users/authn-and-authz/enable-user-retention.adoc[User Retention feature] with delete-inactive-user-after
@@ -67,7 +67,7 @@ This vulnerability affects those using external authentication providers as well
 | 27 Feb 2025
 | Rancher https://github.com/rancher/rancher/releases/tag/v2.10.3[v2.10.3], https://github.com/rancher/rancher/releases/tag/v2.9.7[v2.9.7] and https://github.com/rancher/rancher/releases/tag/v2.8.13[v2.8.13]
 
-| https://github.com/rancher/rancher/security/advisories/GHSA-mq23-vvg7-xfm4[CVE-2025-23387]
+| https://github.com/rancher/rancher/security/advisories/GHSA-5qmp-9x47-92q8[CVE-2025-23387]
 a| A vulnerability has been identified within Rancher where it is possible for an unauthenticated user to list all CLI authentication tokens and delete them before the CLI is able to get the token value. This effectively prevents users from logging in via the CLI when using rancher token as the execution command (instead of the token directly being in the kubeconfig).
 
 Note that this token is not the kubeconfig token and if an attacker is able to intercept it they can't use it to impersonate a real user since it is encrypted.


### PR DESCRIPTION
This PR updates the CVE IDs to match what's listed on the advisory link.