### PR TITLE
Fix list formatting

### DIFF
--- a/versions/latest/modules/en/pages/rancher-admin/scc-registration.adoc
+++ b/versions/latest/modules/en/pages/rancher-admin/scc-registration.adoc
@@ -7,7 +7,6 @@ Since Rancher v2.12.1, SUSE Rancher Prime customers can now register Rancher Man
 == Prerequisites
 
 * Registering your Rancher Manager instance with SCC requires a SUSE account. If you don't have a SUSE account yet, https://www.suse.com/account/create/[create one].
-
 * You must have access to your organization. Ask your organization's administrator to add you to the account. See the https://scc.suse.com/docs/userguide#UG-Requesting-Access-to-an-Organizations-Account[SCC documentation] and https://scc.suse.com/docs/help#how-to-add-user[SCC FAQ] for details. If you know your organization's registration code, enter it when prompted.
 
 == Register with SUSE Customer Center
@@ -21,6 +20,7 @@ You have the option to register your Rancher Manager instance with SCC <<Online 
 You can register online through the Rancher UI or with Helm.
 
 Before proceeding, you must have the registration code for your Rancher Manager subscription on SCC. To get the registration code:
+
 . Log in to SCC.
 . Navigate to **My Organizations** and click on the organization with your Rancher Manager subscription.
 . Find your Registration code under *Organization* > *Subscriptions* > *Subscription Information*.
@@ -29,13 +29,13 @@ Before proceeding, you must have the registration code for your Rancher Manager 
 
 . From the Rancher UI, copy the registration code into the *Registration code* field and click *Register*. If successful, the *Status* becomes *Active*, and the *Product Name*, *Expiration date* and *Registration mode* are displayed.
 +
-image::online-scc-registration.png[]
+image::online-scc-registration.png[Register with SCC using online method]
 
 ==== Helm
 
 After you have your registration code, you can register your Rancher Manager instance through Helm by passing the argument `--set registration.enabled=true --set registration.regCode=<REGISTRATION-CODE-FROM_SCC>` in the Helm install command `helm install rancher rancher-prime/rancher`.
 
-You can also update `values.yaml`,  enabling registration and adding your registration code.
+You can also update `values.yaml`, enabling registration and adding your registration code.
 
 [,yaml]
 ----
@@ -62,7 +62,7 @@ An SCC Organization Admin must get your registration certificate, as regular use
 .. Click *Download Offline Certificate* and save the registration certificate file.
 . Return to the Rancher UI, click *Upload certificate and register* to upload the registration certificate. If successful, the *Status* becomes *Active*, and the *Product Name*, *Expiration date* and *Registration mode* are displayed.
 +
-image::offline-scc-registration.png[]
+image::offline-scc-registration.png[Register with SCC using offline method]
 
 ==== Helm
 

--- a/versions/latest/modules/zh/pages/rancher-admin/scc-registration.adoc
+++ b/versions/latest/modules/zh/pages/rancher-admin/scc-registration.adoc
@@ -7,7 +7,6 @@ Since Rancher v2.12.1, SUSE Rancher Prime customers can now register Rancher Man
 == Prerequisites
 
 * Registering your Rancher Manager instance with SCC requires a SUSE account. If you don't have a SUSE account yet, https://www.suse.com/account/create/[create one].
-
 * You must have access to your organization. Ask your organization's administrator to add you to the account. See the https://scc.suse.com/docs/userguide#UG-Requesting-Access-to-an-Organizations-Account[SCC documentation] and https://scc.suse.com/docs/help#how-to-add-user[SCC FAQ] for details. If you know your organization's registration code, enter it when prompted.
 
 == Register with SUSE Customer Center
@@ -21,6 +20,7 @@ You have the option to register your Rancher Manager instance with SCC <<Online 
 You can register online through the Rancher UI or with Helm.
 
 Before proceeding, you must have the registration code for your Rancher Manager subscription on SCC. To get the registration code:
+
 . Log in to SCC.
 . Navigate to **My Organizations** and click on the organization with your Rancher Manager subscription.
 . Find your Registration code under *Organization* > *Subscriptions* > *Subscription Information*.
@@ -29,13 +29,13 @@ Before proceeding, you must have the registration code for your Rancher Manager 
 
 . From the Rancher UI, copy the registration code into the *Registration code* field and click *Register*. If successful, the *Status* becomes *Active*, and the *Product Name*, *Expiration date* and *Registration mode* are displayed.
 +
-image::online-scc-registration.png[]
+image::online-scc-registration.png[Register with SCC using online method]
 
 ==== Helm
 
 After you have your registration code, you can register your Rancher Manager instance through Helm by passing the argument `--set registration.enabled=true --set registration.regCode=<REGISTRATION-CODE-FROM_SCC>` in the Helm install command `helm install rancher rancher-prime/rancher`.
 
-You can also update `values.yaml`,  enabling registration and adding your registration code.
+You can also update `values.yaml`, enabling registration and adding your registration code.
 
 [,yaml]
 ----
@@ -62,7 +62,7 @@ An SCC Organization Admin must get your registration certificate, as regular use
 .. Click *Download Offline Certificate* and save the registration certificate file.
 . Return to the Rancher UI, click *Upload certificate and register* to upload the registration certificate. If successful, the *Status* becomes *Active*, and the *Product Name*, *Expiration date* and *Registration mode* are displayed.
 +
-image::offline-scc-registration.png[]
+image::offline-scc-registration.png[Register with SCC using offline method]
 
 ==== Helm
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/scc-registration.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/scc-registration.adoc
@@ -7,7 +7,6 @@ Since Rancher v2.12.1, SUSE Rancher Prime customers can now register Rancher Man
 == Prerequisites
 
 * Registering your Rancher Manager instance with SCC requires a SUSE account. If you don't have a SUSE account yet, https://www.suse.com/account/create/[create one].
-
 * You must have access to your organization. Ask your organization's administrator to add you to the account. See the https://scc.suse.com/docs/userguide#UG-Requesting-Access-to-an-Organizations-Account[SCC documentation] and https://scc.suse.com/docs/help#how-to-add-user[SCC FAQ] for details. If you know your organization's registration code, enter it when prompted.
 
 == Register with SUSE Customer Center
@@ -21,6 +20,7 @@ You have the option to register your Rancher Manager instance with SCC <<Online 
 You can register online through the Rancher UI or with Helm.
 
 Before proceeding, you must have the registration code for your Rancher Manager subscription on SCC. To get the registration code:
+
 . Log in to SCC.
 . Navigate to **My Organizations** and click on the organization with your Rancher Manager subscription.
 . Find your Registration code under *Organization* > *Subscriptions* > *Subscription Information*.
@@ -29,13 +29,13 @@ Before proceeding, you must have the registration code for your Rancher Manager 
 
 . From the Rancher UI, copy the registration code into the *Registration code* field and click *Register*. If successful, the *Status* becomes *Active*, and the *Product Name*, *Expiration date* and *Registration mode* are displayed.
 +
-image::online-scc-registration.png[]
+image::online-scc-registration.png[Register with SCC using online method]
 
 ==== Helm
 
 After you have your registration code, you can register your Rancher Manager instance through Helm by passing the argument `--set registration.enabled=true --set registration.regCode=<REGISTRATION-CODE-FROM_SCC>` in the Helm install command `helm install rancher rancher-prime/rancher`.
 
-You can also update `values.yaml`,  enabling registration and adding your registration code.
+You can also update `values.yaml`, enabling registration and adding your registration code.
 
 [,yaml]
 ----
@@ -62,7 +62,7 @@ An SCC Organization Admin must get your registration certificate, as regular use
 .. Click *Download Offline Certificate* and save the registration certificate file.
 . Return to the Rancher UI, click *Upload certificate and register* to upload the registration certificate. If successful, the *Status* becomes *Active*, and the *Product Name*, *Expiration date* and *Registration mode* are displayed.
 +
-image::offline-scc-registration.png[]
+image::offline-scc-registration.png[Register with SCC using offline method]
 
 ==== Helm
 

--- a/versions/v2.12/modules/zh/pages/rancher-admin/scc-registration.adoc
+++ b/versions/v2.12/modules/zh/pages/rancher-admin/scc-registration.adoc
@@ -7,7 +7,6 @@ Since Rancher v2.12.1, SUSE Rancher Prime customers can now register Rancher Man
 == Prerequisites
 
 * Registering your Rancher Manager instance with SCC requires a SUSE account. If you don't have a SUSE account yet, https://www.suse.com/account/create/[create one].
-
 * You must have access to your organization. Ask your organization's administrator to add you to the account. See the https://scc.suse.com/docs/userguide#UG-Requesting-Access-to-an-Organizations-Account[SCC documentation] and https://scc.suse.com/docs/help#how-to-add-user[SCC FAQ] for details. If you know your organization's registration code, enter it when prompted.
 
 == Register with SUSE Customer Center
@@ -21,6 +20,7 @@ You have the option to register your Rancher Manager instance with SCC <<Online 
 You can register online through the Rancher UI or with Helm.
 
 Before proceeding, you must have the registration code for your Rancher Manager subscription on SCC. To get the registration code:
+
 . Log in to SCC.
 . Navigate to **My Organizations** and click on the organization with your Rancher Manager subscription.
 . Find your Registration code under *Organization* > *Subscriptions* > *Subscription Information*.
@@ -29,13 +29,13 @@ Before proceeding, you must have the registration code for your Rancher Manager 
 
 . From the Rancher UI, copy the registration code into the *Registration code* field and click *Register*. If successful, the *Status* becomes *Active*, and the *Product Name*, *Expiration date* and *Registration mode* are displayed.
 +
-image::online-scc-registration.png[]
+image::online-scc-registration.png[Register with SCC using online method]
 
 ==== Helm
 
 After you have your registration code, you can register your Rancher Manager instance through Helm by passing the argument `--set registration.enabled=true --set registration.regCode=<REGISTRATION-CODE-FROM_SCC>` in the Helm install command `helm install rancher rancher-prime/rancher`.
 
-You can also update `values.yaml`,  enabling registration and adding your registration code.
+You can also update `values.yaml`, enabling registration and adding your registration code.
 
 [,yaml]
 ----
@@ -62,7 +62,7 @@ An SCC Organization Admin must get your registration certificate, as regular use
 .. Click *Download Offline Certificate* and save the registration certificate file.
 . Return to the Rancher UI, click *Upload certificate and register* to upload the registration certificate. If successful, the *Status* becomes *Active*, and the *Product Name*, *Expiration date* and *Registration mode* are displayed.
 +
-image::offline-scc-registration.png[]
+image::offline-scc-registration.png[Register with SCC using offline method]
 
 ==== Helm
 


### PR DESCRIPTION
The list in the [Online Registration](https://documentation.suse.com/cloudnative/rancher-manager/latest/en/rancher-admin/scc-registration.html#_online_registration) section of the SCC page is rendered as continuous line.

<img width="993" height="171" alt="scc" src="https://github.com/user-attachments/assets/8311db39-9e75-48b1-8346-e925faa70c12" />

The PR also adds alt text to the images, which were missing.

I didn't update revdate due to the changes not altering the meaning of content.
