### PR TITLE
Fix broken links and escape example links

### DIFF
--- a/versions/latest/modules/en/pages/rancher-admin/users/authn-and-authz/configure-active-directory.adoc
+++ b/versions/latest/modules/en/pages/rancher-admin/users/authn-and-authz/configure-active-directory.adoc
@@ -1,6 +1,6 @@
 = Configure Active Directory (AD)
 :page-languages: [en, zh]
-:revdate: 2025-03-17
+:revdate: 2025-09-22
 :page-revdate: {revdate}
 
 If your organization uses Microsoft Active Directory as central user repository, you can configure Rancher to communicate with an Active Directory server to authenticate users. This allows Rancher admins to control access to clusters and projects based on users and groups managed externally in the Active Directory, while allowing end-users to authenticate with their AD credentials when logging in to the Rancher UI.
@@ -205,7 +205,7 @@ You will still be able to login using the locally configured `admin` account and
 
 In order to successfully configure AD authentication it is crucial that you provide the correct configuration pertaining to the hierarchy and schema of your AD server.
 
-The https://manpages.ubuntu.com/manpages/kinetic/en/man1/ldapsearch.1.html[`ldapsearch`] tool allows you to query your AD server to learn about the schema used for user and group objects.
+The https://manpages.ubuntu.com/manpages/noble/en/man1/ldapsearch.1.html[`ldapsearch`] tool allows you to query your AD server to learn about the schema used for user and group objects.
 
 For the purpose of the example commands provided below we will assume:
 

--- a/versions/latest/modules/en/pages/rancher-admin/users/authn-and-authz/configure-oidc-provider.adoc
+++ b/versions/latest/modules/en/pages/rancher-admin/users/authn-and-authz/configure-oidc-provider.adoc
@@ -1,6 +1,6 @@
 = Configure Rancher as an OIDC provider
 :page-languages: [en, zh]
-:revdate: 2025-08-27
+:revdate: 2025-09-22
 :page-revdate: {revdate}
 
 Rancher can function as a standard OpenID Connect (OIDC) provider, allowing external applications to use Rancher for authentication.
@@ -8,13 +8,13 @@ This can be used for enabling single sign-on (SSO) across Rancher Prime componen
 
 The OIDC provider can be enabled with the `oidc-provider` feature flag. When this flag is on the following endpoints are available:
 
-- `https://{rancher-url}/oidc/authorize`: This endpoint initiates the authentication flow. If a user is already logged into Rancher, it returns an authorization code. Otherwise, it redirects the user to the Rancher login page. Authorization codes and related request information are securely stored in session secrets. Codes are single-use and expire after 10 minutes.
+- `+https://{rancher-url}/oidc/authorize+`: This endpoint initiates the authentication flow. If a user is already logged into Rancher, it returns an authorization code. Otherwise, it redirects the user to the Rancher login page. Authorization codes and related request information are securely stored in session secrets. Codes are single-use and expire after 10 minutes.
 
-- `https://{rancher-url}/oidc/token`: This endpoint exchanges an authorization code for an `id_token`, `access_token`, and `refresh_token`.
+- `+https://{rancher-url}/oidc/token+`: This endpoint exchanges an authorization code for an `id_token`, `access_token`, and `refresh_token`.
 
-- `https://{rancher-url}/oidc/.well-known/openid-configuration`: This endpoint returns a JSON document containing the OIDC provider's configuration, including endpoint URLs, supported scopes, claims, and other relevant details.
+- `+https://{rancher-url}/oidc/.well-known/openid-configuration+`: This endpoint returns a JSON document containing the OIDC provider's configuration, including endpoint URLs, supported scopes, claims, and other relevant details.
 
-- `https://{rancher-url}/oidc/userinfo`: This endpoint provides information about the authenticated user.
+- `+https://{rancher-url}/oidc/userinfo+`: This endpoint provides information about the authenticated user.
 
 The OIDC provider supports the OIDC Authentication Code Flow with PKCE.
 

--- a/versions/latest/modules/zh/pages/rancher-admin/users/authn-and-authz/configure-active-directory.adoc
+++ b/versions/latest/modules/zh/pages/rancher-admin/users/authn-and-authz/configure-active-directory.adoc
@@ -1,6 +1,6 @@
 = 配置 Active Directory (AD)
 :page-languages: [en, zh]
-:revdate: 2025-03-17
+:revdate: 2025-09-22
 :page-revdate: {revdate}
 
 如果你的组织使用 Microsoft Active Directory 作为中心用户仓库，你可以将 Rancher 配置为与 Active Directory 服务器通信，从而对用户进行身份验证。这使 Rancher 管理员可以对外部用户系统中的用户和组进行集群和项目的访问控制，同时允许最终用户在登录 Rancher UI 时使用 Active Directory 凭证进行身份验证。
@@ -205,7 +205,7 @@ Rancher 使用 LDAP 查询来搜索和检索关于 Active Directory 中的用户
 
 为了成功配置 AD 身份验证，你必须提供 AD 服务器的层次结构和 Schema 的正确配置。
 
-https://manpages.ubuntu.com/manpages/kinetic/en/man1/ldapsearch.1.html[`ldapsearch`] 工具允许你查询你的 AD 服务器，从而了解用于用户和组对象的 Schema。
+https://manpages.ubuntu.com/manpages/noble/en/man1/ldapsearch.1.html[`ldapsearch`] 工具允许你查询你的 AD 服务器，从而了解用于用户和组对象的 Schema。
 
 在下面的示例命令中，我们假设：
 

--- a/versions/latest/modules/zh/pages/rancher-admin/users/authn-and-authz/configure-oidc-provider.adoc
+++ b/versions/latest/modules/zh/pages/rancher-admin/users/authn-and-authz/configure-oidc-provider.adoc
@@ -1,6 +1,6 @@
 = Configure Rancher as an OIDC provider
 :page-languages: [en, zh]
-:revdate: 2025-08-27
+:revdate: 2025-09-22
 :page-revdate: {revdate}
 
 Rancher can function as a standard OpenID Connect (OIDC) provider, allowing external applications to use Rancher for authentication.
@@ -8,13 +8,13 @@ This can be used for enabling single sign-on (SSO) across Rancher Prime componen
 
 The OIDC provider can be enabled with the `oidc-provider` feature flag. When this flag is on the following endpoints are available:
 
-- `https://{rancher-url}/oidc/authorize`: This endpoint initiates the authentication flow. If a user is already logged into Rancher, it returns an authorization code. Otherwise, it redirects the user to the Rancher login page. Authorization codes and related request information are securely stored in session secrets. Codes are single-use and expire after 10 minutes.
+- `+https://{rancher-url}/oidc/authorize+`: This endpoint initiates the authentication flow. If a user is already logged into Rancher, it returns an authorization code. Otherwise, it redirects the user to the Rancher login page. Authorization codes and related request information are securely stored in session secrets. Codes are single-use and expire after 10 minutes.
 
-- `https://{rancher-url}/oidc/token`: This endpoint exchanges an authorization code for an `id_token`, `access_token`, and `refresh_token`.
+- `+https://{rancher-url}/oidc/token+`: This endpoint exchanges an authorization code for an `id_token`, `access_token`, and `refresh_token`.
 
-- `https://{rancher-url}/oidc/.well-known/openid-configuration`: This endpoint returns a JSON document containing the OIDC provider's configuration, including endpoint URLs, supported scopes, claims, and other relevant details.
+- `+https://{rancher-url}/oidc/.well-known/openid-configuration+`: This endpoint returns a JSON document containing the OIDC provider's configuration, including endpoint URLs, supported scopes, claims, and other relevant details.
 
-- `https://{rancher-url}/oidc/userinfo`: This endpoint provides information about the authenticated user.
+- `+https://{rancher-url}/oidc/userinfo+`: This endpoint provides information about the authenticated user.
 
 The OIDC provider supports the OIDC Authentication Code Flow with PKCE.
 

--- a/versions/v2.10/modules/en/pages/rancher-admin/users/authn-and-authz/configure-active-directory.adoc
+++ b/versions/v2.10/modules/en/pages/rancher-admin/users/authn-and-authz/configure-active-directory.adoc
@@ -1,6 +1,6 @@
 = Configure Active Directory (AD)
 :page-languages: [en, zh]
-:revdate: 2025-03-17
+:revdate: 2025-09-22
 :page-revdate: {revdate}
 
 If your organization uses Microsoft Active Directory as central user repository, you can configure Rancher to communicate with an Active Directory server to authenticate users. This allows Rancher admins to control access to clusters and projects based on users and groups managed externally in the Active Directory, while allowing end-users to authenticate with their AD credentials when logging in to the Rancher UI.
@@ -205,7 +205,7 @@ You will still be able to login using the locally configured `admin` account and
 
 In order to successfully configure AD authentication it is crucial that you provide the correct configuration pertaining to the hierarchy and schema of your AD server.
 
-The https://manpages.ubuntu.com/manpages/kinetic/en/man1/ldapsearch.1.html[`ldapsearch`] tool allows you to query your AD server to learn about the schema used for user and group objects.
+The https://manpages.ubuntu.com/manpages/noble/en/man1/ldapsearch.1.html[`ldapsearch`] tool allows you to query your AD server to learn about the schema used for user and group objects.
 
 For the purpose of the example commands provided below we will assume:
 

--- a/versions/v2.10/modules/zh/pages/rancher-admin/users/authn-and-authz/configure-active-directory.adoc
+++ b/versions/v2.10/modules/zh/pages/rancher-admin/users/authn-and-authz/configure-active-directory.adoc
@@ -1,6 +1,6 @@
 = 配置 Active Directory (AD)
 :page-languages: [en, zh]
-:revdate: 2025-03-17
+:revdate: 2025-09-22
 :page-revdate: {revdate}
 
 如果你的组织使用 Microsoft Active Directory 作为中心用户仓库，你可以将 Rancher 配置为与 Active Directory 服务器通信，从而对用户进行身份验证。这使 Rancher 管理员可以对外部用户系统中的用户和组进行集群和项目的访问控制，同时允许最终用户在登录 Rancher UI 时使用 Active Directory 凭证进行身份验证。
@@ -205,7 +205,7 @@ Rancher 使用 LDAP 查询来搜索和检索关于 Active Directory 中的用户
 
 为了成功配置 AD 身份验证，你必须提供 AD 服务器的层次结构和 Schema 的正确配置。
 
-https://manpages.ubuntu.com/manpages/kinetic/en/man1/ldapsearch.1.html[`ldapsearch`] 工具允许你查询你的 AD 服务器，从而了解用于用户和组对象的 Schema。
+https://manpages.ubuntu.com/manpages/noble/en/man1/ldapsearch.1.html[`ldapsearch`] 工具允许你查询你的 AD 服务器，从而了解用于用户和组对象的 Schema。
 
 在下面的示例命令中，我们假设：
 

--- a/versions/v2.11/modules/en/pages/rancher-admin/users/authn-and-authz/configure-active-directory.adoc
+++ b/versions/v2.11/modules/en/pages/rancher-admin/users/authn-and-authz/configure-active-directory.adoc
@@ -1,6 +1,6 @@
 = Configure Active Directory (AD)
 :page-languages: [en, zh]
-:revdate: 2025-04-21
+:revdate: 2025-09-22
 :page-revdate: {revdate}
 
 If your organization uses Microsoft Active Directory as central user repository, you can configure Rancher to communicate with an Active Directory server to authenticate users. This allows Rancher admins to control access to clusters and projects based on users and groups managed externally in the Active Directory, while allowing end-users to authenticate with their AD credentials when logging in to the Rancher UI.
@@ -205,7 +205,7 @@ You will still be able to login using the locally configured `admin` account and
 
 In order to successfully configure AD authentication it is crucial that you provide the correct configuration pertaining to the hierarchy and schema of your AD server.
 
-The https://manpages.ubuntu.com/manpages/kinetic/en/man1/ldapsearch.1.html[`ldapsearch`] tool allows you to query your AD server to learn about the schema used for user and group objects.
+The https://manpages.ubuntu.com/manpages/noble/en/man1/ldapsearch.1.html[`ldapsearch`] tool allows you to query your AD server to learn about the schema used for user and group objects.
 
 For the purpose of the example commands provided below we will assume:
 

--- a/versions/v2.11/modules/zh/pages/rancher-admin/users/authn-and-authz/configure-active-directory.adoc
+++ b/versions/v2.11/modules/zh/pages/rancher-admin/users/authn-and-authz/configure-active-directory.adoc
@@ -1,6 +1,6 @@
 = 配置 Active Directory (AD)
 :page-languages: [en, zh]
-:revdate: 2025-03-17
+:revdate: 2025-09-22
 :page-revdate: {revdate}
 
 如果你的组织使用 Microsoft Active Directory 作为中心用户仓库，你可以将 Rancher 配置为与 Active Directory 服务器通信，从而对用户进行身份验证。这使 Rancher 管理员可以对外部用户系统中的用户和组进行集群和项目的访问控制，同时允许最终用户在登录 Rancher UI 时使用 Active Directory 凭证进行身份验证。
@@ -205,7 +205,7 @@ Rancher 使用 LDAP 查询来搜索和检索关于 Active Directory 中的用户
 
 为了成功配置 AD 身份验证，你必须提供 AD 服务器的层次结构和 Schema 的正确配置。
 
-https://manpages.ubuntu.com/manpages/kinetic/en/man1/ldapsearch.1.html[`ldapsearch`] 工具允许你查询你的 AD 服务器，从而了解用于用户和组对象的 Schema。
+https://manpages.ubuntu.com/manpages/noble/en/man1/ldapsearch.1.html[`ldapsearch`] 工具允许你查询你的 AD 服务器，从而了解用于用户和组对象的 Schema。
 
 在下面的示例命令中，我们假设：
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/configure-active-directory.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/configure-active-directory.adoc
@@ -1,6 +1,6 @@
 = Configure Active Directory (AD)
 :page-languages: [en, zh]
-:revdate: 2025-08-05
+:revdate: 2025-09-22
 :page-revdate: {revdate}
 
 If your organization uses Microsoft Active Directory as central user repository, you can configure Rancher to communicate with an Active Directory server to authenticate users. This allows Rancher admins to control access to clusters and projects based on users and groups managed externally in the Active Directory, while allowing end-users to authenticate with their AD credentials when logging in to the Rancher UI.
@@ -205,7 +205,7 @@ You will still be able to login using the locally configured `admin` account and
 
 In order to successfully configure AD authentication it is crucial that you provide the correct configuration pertaining to the hierarchy and schema of your AD server.
 
-The https://manpages.ubuntu.com/manpages/kinetic/en/man1/ldapsearch.1.html[`ldapsearch`] tool allows you to query your AD server to learn about the schema used for user and group objects.
+The https://manpages.ubuntu.com/manpages/noble/en/man1/ldapsearch.1.html[`ldapsearch`] tool allows you to query your AD server to learn about the schema used for user and group objects.
 
 For the purpose of the example commands provided below we will assume:
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/configure-oidc-provider.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/configure-oidc-provider.adoc
@@ -1,6 +1,6 @@
 = Configure Rancher as an OIDC provider
 :page-languages: [en, zh]
-:revdate: 2025-08-27
+:revdate: 2025-09-22
 :page-revdate: {revdate}
 
 Rancher can function as a standard OpenID Connect (OIDC) provider, allowing external applications to use Rancher for authentication.
@@ -8,13 +8,13 @@ This can be used for enabling single sign-on (SSO) across Rancher Prime componen
 
 The OIDC provider can be enabled with the `oidc-provider` feature flag. When this flag is on the following endpoints are available:
 
-- `https://{rancher-url}/oidc/authorize`: This endpoint initiates the authentication flow. If a user is already logged into Rancher, it returns an authorization code. Otherwise, it redirects the user to the Rancher login page. Authorization codes and related request information are securely stored in session secrets. Codes are single-use and expire after 10 minutes.
+- `+https://{rancher-url}/oidc/authorize+`: This endpoint initiates the authentication flow. If a user is already logged into Rancher, it returns an authorization code. Otherwise, it redirects the user to the Rancher login page. Authorization codes and related request information are securely stored in session secrets. Codes are single-use and expire after 10 minutes.
 
-- `https://{rancher-url}/oidc/token`: This endpoint exchanges an authorization code for an `id_token`, `access_token`, and `refresh_token`.
+- `+https://{rancher-url}/oidc/token+`: This endpoint exchanges an authorization code for an `id_token`, `access_token`, and `refresh_token`.
 
-- `https://{rancher-url}/oidc/.well-known/openid-configuration`: This endpoint returns a JSON document containing the OIDC provider's configuration, including endpoint URLs, supported scopes, claims, and other relevant details.
+- `+https://{rancher-url}/oidc/.well-known/openid-configuration+`: This endpoint returns a JSON document containing the OIDC provider's configuration, including endpoint URLs, supported scopes, claims, and other relevant details.
 
-- `https://{rancher-url}/oidc/userinfo`: This endpoint provides information about the authenticated user.
+- `+https://{rancher-url}/oidc/userinfo+`: This endpoint provides information about the authenticated user.
 
 The OIDC provider supports the OIDC Authentication Code Flow with PKCE.
 

--- a/versions/v2.12/modules/zh/pages/rancher-admin/users/authn-and-authz/configure-active-directory.adoc
+++ b/versions/v2.12/modules/zh/pages/rancher-admin/users/authn-and-authz/configure-active-directory.adoc
@@ -1,6 +1,6 @@
 = 配置 Active Directory (AD)
 :page-languages: [en, zh]
-:revdate: 2025-08-05
+:revdate: 2025-09-22
 :page-revdate: {revdate}
 
 如果你的组织使用 Microsoft Active Directory 作为中心用户仓库，你可以将 Rancher 配置为与 Active Directory 服务器通信，从而对用户进行身份验证。这使 Rancher 管理员可以对外部用户系统中的用户和组进行集群和项目的访问控制，同时允许最终用户在登录 Rancher UI 时使用 Active Directory 凭证进行身份验证。
@@ -205,7 +205,7 @@ Rancher 使用 LDAP 查询来搜索和检索关于 Active Directory 中的用户
 
 为了成功配置 AD 身份验证，你必须提供 AD 服务器的层次结构和 Schema 的正确配置。
 
-https://manpages.ubuntu.com/manpages/kinetic/en/man1/ldapsearch.1.html[`ldapsearch`] 工具允许你查询你的 AD 服务器，从而了解用于用户和组对象的 Schema。
+https://manpages.ubuntu.com/manpages/noble/en/man1/ldapsearch.1.html[`ldapsearch`] 工具允许你查询你的 AD 服务器，从而了解用于用户和组对象的 Schema。
 
 在下面的示例命令中，我们假设：
 

--- a/versions/v2.12/modules/zh/pages/rancher-admin/users/authn-and-authz/configure-oidc-provider.adoc
+++ b/versions/v2.12/modules/zh/pages/rancher-admin/users/authn-and-authz/configure-oidc-provider.adoc
@@ -1,6 +1,6 @@
 = Configure Rancher as an OIDC provider
 :page-languages: [en, zh]
-:revdate: 2025-08-27
+:revdate: 2025-09-22
 :page-revdate: {revdate}
 
 Rancher can function as a standard OpenID Connect (OIDC) provider, allowing external applications to use Rancher for authentication.
@@ -8,13 +8,13 @@ This can be used for enabling single sign-on (SSO) across Rancher Prime componen
 
 The OIDC provider can be enabled with the `oidc-provider` feature flag. When this flag is on the following endpoints are available:
 
-- `https://{rancher-url}/oidc/authorize`: This endpoint initiates the authentication flow. If a user is already logged into Rancher, it returns an authorization code. Otherwise, it redirects the user to the Rancher login page. Authorization codes and related request information are securely stored in session secrets. Codes are single-use and expire after 10 minutes.
+- `+https://{rancher-url}/oidc/authorize+`: This endpoint initiates the authentication flow. If a user is already logged into Rancher, it returns an authorization code. Otherwise, it redirects the user to the Rancher login page. Authorization codes and related request information are securely stored in session secrets. Codes are single-use and expire after 10 minutes.
 
-- `https://{rancher-url}/oidc/token`: This endpoint exchanges an authorization code for an `id_token`, `access_token`, and `refresh_token`.
+- `+https://{rancher-url}/oidc/token+`: This endpoint exchanges an authorization code for an `id_token`, `access_token`, and `refresh_token`.
 
-- `https://{rancher-url}/oidc/.well-known/openid-configuration`: This endpoint returns a JSON document containing the OIDC provider's configuration, including endpoint URLs, supported scopes, claims, and other relevant details.
+- `+https://{rancher-url}/oidc/.well-known/openid-configuration+`: This endpoint returns a JSON document containing the OIDC provider's configuration, including endpoint URLs, supported scopes, claims, and other relevant details.
 
-- `https://{rancher-url}/oidc/userinfo`: This endpoint provides information about the authenticated user.
+- `+https://{rancher-url}/oidc/userinfo+`: This endpoint provides information about the authenticated user.
 
 The OIDC provider supports the OIDC Authentication Code Flow with PKCE.
 

--- a/versions/v2.9/modules/en/pages/integrations/cluster-api/overview.adoc
+++ b/versions/v2.9/modules/en/pages/integrations/cluster-api/overview.adoc
@@ -1,6 +1,6 @@
 = Overview
 :page-languages: [en, zh]
-:revdate: 2025-07-11
+:revdate: 2025-09-22
 :page-revdate: {revdate}
 :experimental:
 
@@ -116,7 +116,7 @@ There are two ways to install Rancher Turtles with Helm, depending on whether yo
 
 The CAPI Operator is required for installing Rancher Turtles. You can choose whether you want to take care of this dependency yourself or let the Rancher Turtles Helm chart manage it for you. <<_installing_rancher_turtles_with_cluster_api_capi_operator_as_a_helm_dependency,Installing Turtles as a dependency>> is simpler, but your best option depends on your specific configuration.
 
-The CAPI Operator allows for handling the lifecycle of https://documentation.suse.com/cloudnative/cluster-api/{turtles-docs-version}/en/operator/manual.html[CAPI providers] using a declarative approach, extending the capabilities of `clusterctl`. If you want to learn more about it, you can refer to https://cluster-api-operator.sigs.k8s.io/[Cluster API Operator book].
+The CAPI Operator allows for handling the lifecycle of https://documentation.suse.com/cloudnative/cluster-api/{turtles-docs-version}/en/getting-started/install-rancher-turtles/using_helm.html[CAPI providers] using a declarative approach, extending the capabilities of `clusterctl`. If you want to learn more about it, you can refer to https://cluster-api-operator.sigs.k8s.io/[Cluster API Operator book].
 
 [#_installing_rancher_turtles_with_cluster_api_capi_operator_as_a_helm_dependency]
 ==== Installing {turtles-product-name} with `Cluster API (CAPI) Operator` as a Helm dependency
@@ -194,7 +194,7 @@ For detailed information on the values supported by the chart and their usage, r
 [NOTE]
 ====
 
-Remember that if you opt for this installation option, you must manage the CAPI Operator installation yourself. You can follow the link:https://documentation.suse.com/cloudnative/cluster-api/{turtles-docs-version}/en/operator/manual.html[manual installation guide] in the Cluster API documentation for assistance.
+Remember that if you opt for this installation option, you must manage the CAPI Operator installation yourself. You can follow the link:https://documentation.suse.com/cloudnative/cluster-api/{turtles-docs-version}/en/getting-started/install-rancher-turtles/using_helm.html[manual installation guide] in the Cluster API documentation for assistance.
 ====
 
 

--- a/versions/v2.9/modules/en/pages/rancher-admin/users/authn-and-authz/configure-active-directory.adoc
+++ b/versions/v2.9/modules/en/pages/rancher-admin/users/authn-and-authz/configure-active-directory.adoc
@@ -1,6 +1,6 @@
 = Configure Active Directory (AD)
 :page-languages: [en, zh]
-:revdate: 2025-03-17
+:revdate: 2025-09-22
 :page-revdate: {revdate}
 
 If your organization uses Microsoft Active Directory as central user repository, you can configure Rancher to communicate with an Active Directory server to authenticate users. This allows Rancher admins to control access to clusters and projects based on users and groups managed externally in the Active Directory, while allowing end-users to authenticate with their AD credentials when logging in to the Rancher UI.
@@ -205,7 +205,7 @@ You will still be able to login using the locally configured `admin` account and
 
 In order to successfully configure AD authentication it is crucial that you provide the correct configuration pertaining to the hierarchy and schema of your AD server.
 
-The https://manpages.ubuntu.com/manpages/kinetic/en/man1/ldapsearch.1.html[`ldapsearch`] tool allows you to query your AD server to learn about the schema used for user and group objects.
+The https://manpages.ubuntu.com/manpages/noble/en/man1/ldapsearch.1.html[`ldapsearch`] tool allows you to query your AD server to learn about the schema used for user and group objects.
 
 For the purpose of the example commands provided below we will assume:
 

--- a/versions/v2.9/modules/zh/pages/rancher-admin/users/authn-and-authz/configure-active-directory.adoc
+++ b/versions/v2.9/modules/zh/pages/rancher-admin/users/authn-and-authz/configure-active-directory.adoc
@@ -1,6 +1,6 @@
 = 配置 Active Directory (AD)
 :page-languages: [en, zh]
-:revdate: 2025-03-17
+:revdate: 2025-09-22
 :page-revdate: {revdate}
 
 如果你的组织使用 Microsoft Active Directory 作为中心用户仓库，你可以将 Rancher 配置为与 Active Directory 服务器通信，从而对用户进行身份验证。这使 Rancher 管理员可以对外部用户系统中的用户和组进行集群和项目的访问控制，同时允许最终用户在登录 Rancher UI 时使用 Active Directory 凭证进行身份验证。
@@ -205,7 +205,7 @@ Rancher 使用 LDAP 查询来搜索和检索关于 Active Directory 中的用户
 
 为了成功配置 AD 身份验证，你必须提供 AD 服务器的层次结构和 Schema 的正确配置。
 
-https://manpages.ubuntu.com/manpages/kinetic/en/man1/ldapsearch.1.html[`ldapsearch`] 工具允许你查询你的 AD 服务器，从而了解用于用户和组对象的 Schema。
+https://manpages.ubuntu.com/manpages/noble/en/man1/ldapsearch.1.html[`ldapsearch`] 工具允许你查询你的 AD 服务器，从而了解用于用户和组对象的 Schema。
 
 在下面的示例命令中，我们假设：
 


### PR DESCRIPTION
Note, for the Ubuntu URL in v2.8 I linked it to jammy since 22.04 is the highest supported by v2.8 per our support mtarix. 