### PR TITLE
Use shared resource for attributes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "dsc-style-bundle"]
 	path = dsc-style-bundle
 	url = https://github.com/SUSEdoc/dsc-style-bundle
+[submodule "product-docs-common"]
+	path = product-docs-common
+	url = https://github.com/rancher/product-docs-common

--- a/playbook-local.yml
+++ b/playbook-local.yml
@@ -23,3 +23,6 @@ antora:
   extensions:
   - require: '@antora/lunr-extension'
     languages: [en, zh]
+  - require: ./product-docs-common/extensions/dynamic-loading-attributes/load-global-site-attributes.js
+    attributefile: ./product-docs-common/global-attributes.yml
+    enabled: true

--- a/playbook-remote.yml
+++ b/playbook-remote.yml
@@ -23,3 +23,6 @@ antora:
   extensions:
   - require: '@antora/lunr-extension'
     languages: [en, zh]
+  - require: ./product-docs-common/extensions/dynamic-loading-attributes/load-global-site-attributes.js
+    attributefile: ./product-docs-common/global-attributes.yml
+    enabled: true


### PR DESCRIPTION
After merging https://github.com/rancher/rancher-product-docs/pull/491, builds currently fail with the error below due to the `page-project-data` attribute not being defined on all pages. This PR enables access to the attribute globally.

```
FATAL (antora): Cannot read properties of undefined (reading 'find') in UI template partials/breadcrumbs.hbs
    Cause: Error
    d')
```. This PR enables access to the attribute globally.
