### PR TITLE
Remove references to psp

### DIFF
--- a/shared/modules/ROOT/partials/en/cluster-capabilities-updated-table.adoc
+++ b/shared/modules/ROOT/partials/en/cluster-capabilities-updated-table.adoc
@@ -72,12 +72,6 @@
 |
 |
 |
-
-| xref:security/psp/add.adoc[Configuring Pod Security Policies]
-| ✓
-| ✓
-|
-|
 |===
 
 . Registered EKS, GKE and AKS clusters have the same options available as EKS, GKE and AKS clusters created from the Rancher UI. The  difference is that when a registered cluster is deleted from the Rancher UI, it is not destroyed.

--- a/shared/modules/ROOT/partials/zh/cluster-capabilities-updated-table.adoc
+++ b/shared/modules/ROOT/partials/zh/cluster-capabilities-updated-table.adoc
@@ -72,12 +72,6 @@
 |
 |
 |
-
-| xref:security/psp/add.adoc[Configuring Pod Security Policies]
-| ✓
-| ✓
-|
-|
 |===
 
 . Registered EKS, GKE and AKS clusters have the same options available as EKS, GKE and AKS clusters created from the Rancher UI. The  difference is that when a registered cluster is deleted from the Rancher UI, it is not destroyed.


### PR DESCRIPTION
Some PSP references have snuck back in and cause broken links.