### PR TITLE
Add symlinked 'versions/srfa' to support building SRFA remotely

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -43,14 +43,14 @@ jobs:
             ${{ runner.os }}-node-
       - name: Install Antora with the Antora Lunr Extension
         run: make environment
-      - name: Generate Rancher Manager Site
-        run: make local
       - name: Generate SRFA Site
         run: make srfa-local
+      - name: Generate Rancher Manager Site
+        run: make local
       - name: Upload Artifacts
         uses: actions/upload-pages-artifact@v3
         with:
-          path: build/
+          path: build/site/
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,6 @@ remote:
 
 srfa-local:
 	mkdir -p tmp
-	ln -sf antora-yml/antora-srfa.yml ./versions/v2.12/antora.yml
 	npx antora --version
 	trap 'echo "Cleaning up .adoc files..."; git restore ./versions/v2.12/modules/en/pages' EXIT; \
 	\
@@ -26,12 +25,9 @@ srfa-local:
 	npx antora --stacktrace --log-format=pretty --log-level=info \
 		playbook-srfa-local.yml \
 		2>&1 | tee tmp/srfa-local-build.log 2>&1
-	rm -rf build/site-srfa/rancher-srfa/v2.12/zh/
-	ln -sf antora-yml/antora-product.yml ./versions/v2.12/antora.yml
 
 srfa-remote:
 	mkdir -p tmp
-	ln -sf antora-yml/antora-srfa.yml ./versions/v2.12/antora.yml
 	npm ci
 	npx antora --version
 	trap 'echo "Cleaning up .adoc files..."; git restore ./versions/v2.12/modules/en/pages' EXIT; \
@@ -43,8 +39,6 @@ srfa-remote:
 	npx antora --stacktrace --log-format=pretty --log-level=info \
 		playbook-srfa-remote.yml \
 		2>&1 | tee tmp/srfa-remote-build.log 2>&1
-	rm -rf build/site-srfa/rancher-srfa/v2.12/zh/
-	ln -sf antora-yml/antora-product.yml ./versions/v2.12/antora.yml
 
 clean:
 	rm -rf build
@@ -54,6 +48,3 @@ environment:
 
 preview:
 	npx http-server build/site -c-1
-
-preview-srfa:
-	npx http-server build/site-srfa -c-1

--- a/playbook-local.yml
+++ b/playbook-local.yml
@@ -1,7 +1,7 @@
 site:
   title: SUSE® Rancher Manager
   url: /
-  start_page: latest@rancher-manager:en:about-rancher/what-is-rancher.adoc
+  start_page: v2.12@rancher-manager:en:about-rancher/what-is-rancher.adoc
   robots: disallow
 content:
   sources: 

--- a/playbook-remote.yml
+++ b/playbook-remote.yml
@@ -1,7 +1,7 @@
 site:
   title: SUSE® Rancher Manager
   url: /
-  start_page: latest@rancher-manager:en:about-rancher/what-is-rancher.adoc
+  start_page: v2.12@rancher-manager:en:about-rancher/what-is-rancher.adoc
   robots: disallow
 content:
   sources: 

--- a/playbook-srfa-local.yml
+++ b/playbook-srfa-local.yml
@@ -1,13 +1,13 @@
 site:
   title: SUSE® Rancher for AWS
   url: /
-  start_page: v2.12@rancher-srfa:en:about-rancher/what-is-rancher.adoc
+  start_page: latest@rancher-srfa:en:about-rancher/what-is-rancher.adoc
   robots: disallow
 content:
   sources: 
   - url: .
     branches: HEAD
-    start_paths: [shared, versions/v2.12]
+    start_paths: [shared, versions/srfa]
 ui:
   bundle:
     url: https://github.com/SUSEdoc/dsc-style-bundle/blob/main/default-ui/ui-bundle.zip?raw=true
@@ -32,5 +32,6 @@ antora:
     attributefile: ./product-docs-common/global-attributes.yml
     enabled: true
   - require: ./product-docs-common/extensions/unpublish-unlisted-pages/unpublish-unlisted-pages.js
+    component: 'rancher-srfa'
 output:
-  dir: ./build/site-srfa
+  dir: ./build/site

--- a/playbook-srfa-remote.yml
+++ b/playbook-srfa-remote.yml
@@ -1,13 +1,13 @@
 site:
   title: SUSE® Rancher for AWS
   url: /
-  start_page: v2.12@rancher-srfa:en:about-rancher/what-is-rancher.adoc
+  start_page: latest@rancher-srfa:en:about-rancher/what-is-rancher.adoc
   robots: disallow
 content:
   sources: 
   - url: https://github.com/rancher/rancher-product-docs
     branches: [main]
-    start_paths: [shared, versions/v2.12]
+    start_paths: [shared, versions/srfa]
 ui:
   bundle:
     url: https://github.com/SUSEdoc/dsc-style-bundle/blob/main/default-ui/ui-bundle.zip?raw=true
@@ -32,5 +32,6 @@ antora:
     attributefile: ./product-docs-common/global-attributes.yml
     enabled: true
   - require: ./product-docs-common/extensions/unpublish-unlisted-pages/unpublish-unlisted-pages.js
+    component: 'rancher-srfa'
 output:
-  dir: ./build/site-srfa
+  dir: ./build/site

--- a/versions/srfa/antora.yml
+++ b/versions/srfa/antora.yml
@@ -1,0 +1,1 @@
+../v2.12/antora-yml/antora-srfa.yml

--- a/versions/srfa/modules/en/attachments
+++ b/versions/srfa/modules/en/attachments
@@ -1,0 +1,1 @@
+../../../v2.12/modules/en/attachments

--- a/versions/srfa/modules/en/images
+++ b/versions/srfa/modules/en/images
@@ -1,0 +1,1 @@
+../../../v2.12/modules/en/images

--- a/versions/srfa/modules/en/nav.adoc
+++ b/versions/srfa/modules/en/nav.adoc
@@ -1,0 +1,1 @@
+../../../v2.12/modules/en/nav.adoc

--- a/versions/srfa/modules/en/pages
+++ b/versions/srfa/modules/en/pages
@@ -1,0 +1,1 @@
+../../../v2.12/modules/en/pages

--- a/versions/v2.12/antora-yml/antora-srfa.yml
+++ b/versions/v2.12/antora-yml/antora-srfa.yml
@@ -1,12 +1,18 @@
 name: rancher-srfa
 title: SUSE® Rancher for AWS
-version: v2.12
+version: latest
+display_version: Latest
 prerelease: (Unreleased)
 start_page: en:about-rancher/what-is-rancher.adoc
 nav: 
 - modules/en/nav.adoc
 asciidoc:
   attributes:
+    build-type: 'srfa'
+    rancher-prime: Cloud Native
+    rancher-product-name: "SUSE Rancher for AWS"
+    rancher-product-name-tm: "SUSE® Rancher for AWS"
+    rancher-short-name: "Rancher"
     # docs links
     harvester-docs-version: v1.5
     longhorn-docs-version: 1.8


### PR DESCRIPTION
* This ensures there is 'antora.yml' available from remote.
* Use 'latest' since we support one version at a time.
* Build srfa-local first to ensure index.html does not default to SRFA.
* Define attributes in antora-srfa.yml to support overriding soft set global attrs.