### PR TITLE
Use conditionals for page-languages instead of preprocessing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,12 +16,6 @@ remote:
 srfa-local:
 	mkdir -p tmp
 	npx antora --version
-	trap 'echo "Cleaning up .adoc files..."; git restore ./versions/v2.12/modules/en/pages' EXIT; \
-	\
-	echo "Preprocessing .adoc files to remove :page-languages:..." ; \
-	find ./versions/v2.12/modules/en/pages -name "*.adoc" -exec sed -i '/^:page-languages: \[en, zh\]/d' {} + ; \
-	\
-	echo "Running Antora build..." ; \
 	npx antora --stacktrace --log-format=pretty --log-level=info \
 		playbook-srfa-local.yml \
 		2>&1 | tee tmp/srfa-local-build.log 2>&1
@@ -30,12 +24,6 @@ srfa-remote:
 	mkdir -p tmp
 	npm ci
 	npx antora --version
-	trap 'echo "Cleaning up .adoc files..."; git restore ./versions/v2.12/modules/en/pages' EXIT; \
-	\
-	echo "Preprocessing .adoc files to remove :page-languages:..." ; \
-	find ./versions/v2.12/modules/en/pages -name "*.adoc" -exec sed -i '/^:page-languages: \[en, zh\]/d' {} + ; \
-	\
-	echo "Running Antora build..." ; \
 	npx antora --stacktrace --log-format=pretty --log-level=info \
 		playbook-srfa-remote.yml \
 		2>&1 | tee tmp/srfa-remote-build.log 2>&1

--- a/versions/v2.12/modules/en/pages/about-rancher/architecture/architecture.adoc
+++ b/versions/v2.12/modules/en/pages/about-rancher/architecture/architecture.adoc
@@ -1,5 +1,7 @@
 = {rancher-product-name} Architecture
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/about-rancher/architecture/communicating-with-downstream-clusters.adoc
+++ b/versions/v2.12/modules/en/pages/about-rancher/architecture/communicating-with-downstream-clusters.adoc
@@ -1,5 +1,7 @@
 = Communicating with Downstream User Clusters
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-10-03
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/about-rancher/architecture/rancher-server-and-components.adoc
+++ b/versions/v2.12/modules/en/pages/about-rancher/architecture/rancher-server-and-components.adoc
@@ -1,5 +1,7 @@
 = {rancher-product-name} Server and Components
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-10-01
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/about-rancher/architecture/recommendations.adoc
+++ b/versions/v2.12/modules/en/pages/about-rancher/architecture/recommendations.adoc
@@ -1,5 +1,7 @@
 = Architecture Recommendations
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-22
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/about-rancher/concepts.adoc
+++ b/versions/v2.12/modules/en/pages/about-rancher/concepts.adoc
@@ -1,5 +1,7 @@
 = Kubernetes Concepts
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-27
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/about-rancher/glossary.adoc
+++ b/versions/v2.12/modules/en/pages/about-rancher/glossary.adoc
@@ -1,5 +1,7 @@
 = Glossary
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/about-rancher/overview.adoc
+++ b/versions/v2.12/modules/en/pages/about-rancher/overview.adoc
@@ -1,5 +1,7 @@
 = Overview
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-18
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/about-rancher/prime.adoc
+++ b/versions/v2.12/modules/en/pages/about-rancher/prime.adoc
@@ -1,5 +1,7 @@
 = {rancher-prime}
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/about-rancher/what-is-rancher.adoc
+++ b/versions/v2.12/modules/en/pages/about-rancher/what-is-rancher.adoc
@@ -1,5 +1,7 @@
 = What is {rancher-product-name}?
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :description: Rancher adds significant value on top of Kubernetes: managing hundreds of clusters from one interface, centralizing RBAC, enabling monitoring and alerting. Read more.

--- a/versions/v2.12/modules/en/pages/api/api-tokens.adoc
+++ b/versions/v2.12/modules/en/pages/api/api-tokens.adoc
@@ -1,5 +1,7 @@
 = Using API Tokens
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/api/extension-apiserver.adoc
+++ b/versions/v2.12/modules/en/pages/api/extension-apiserver.adoc
@@ -1,5 +1,7 @@
 = Extension API Server
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-20
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/api/quickstart.adoc
+++ b/versions/v2.12/modules/en/pages/api/quickstart.adoc
@@ -1,5 +1,7 @@
 = RK-API Quick Start Guide
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/api/reference.adoc
+++ b/versions/v2.12/modules/en/pages/api/reference.adoc
@@ -1,5 +1,7 @@
 = API Reference
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :page-role: -toc

--- a/versions/v2.12/modules/en/pages/api/v3-rancher-api-guide.adoc
+++ b/versions/v2.12/modules/en/pages/api/v3-rancher-api-guide.adoc
@@ -1,5 +1,7 @@
 = Previous v3 {rancher-product-name} API Guide
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-18
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/api/workflows/kubeconfigs.adoc
+++ b/versions/v2.12/modules/en/pages/api/workflows/kubeconfigs.adoc
@@ -1,5 +1,7 @@
 = Kubeconfigs
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-22
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/api/workflows/projects.adoc
+++ b/versions/v2.12/modules/en/pages/api/workflows/projects.adoc
@@ -1,5 +1,7 @@
 = Projects
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/api/workflows/tokens.adoc
+++ b/versions/v2.12/modules/en/pages/api/workflows/tokens.adoc
@@ -1,5 +1,7 @@
 = Tokens
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-22
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-admin/backups-and-restore/backups-and-restore.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/backups-and-restore/backups-and-restore.adoc
@@ -1,5 +1,7 @@
 = Upgrading and Rolling Back Kubernetes
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-admin/backups-and-restore/backups-without-uprading-rancher.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/backups-and-restore/backups-without-uprading-rancher.adoc
@@ -1,5 +1,7 @@
 = Upgrading Kubernetes without Upgrading {rancher-product-name}
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-admin/backups-and-restore/backups.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/backups-and-restore/backups.adoc
@@ -1,5 +1,7 @@
 = Backing up a Cluster
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-admin/backups-and-restore/restore.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/backups-and-restore/restore.adoc
@@ -1,5 +1,7 @@
 = Restoring a Cluster from Backup
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-10-01
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-admin/best-practices/disconnected-clusters.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/best-practices/disconnected-clusters.adoc
@@ -1,5 +1,7 @@
 = Best Practices for Disconnected Clusters
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-22
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-admin/helm-charts-in-rancher/create-apps.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/helm-charts-in-rancher/create-apps.adoc
@@ -1,5 +1,7 @@
 = Creating Apps
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-admin/helm-charts-in-rancher/helm-charts-in-rancher.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/helm-charts-in-rancher/helm-charts-in-rancher.adoc
@@ -1,5 +1,7 @@
 = Helm Charts and Apps
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/cluster-admin/helm-charts-in-rancher/oci-repositories.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/helm-charts-in-rancher/oci-repositories.adoc
@@ -1,5 +1,7 @@
 = Using OCI-Based Helm Chart Repositories
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-admin/kubernetes-resources/configmaps.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/kubernetes-resources/configmaps.adoc
@@ -1,5 +1,7 @@
 = ConfigMaps
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/cluster-admin/kubernetes-resources/create-services.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/kubernetes-resources/create-services.adoc
@@ -1,5 +1,7 @@
 = Services
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/cluster-admin/kubernetes-resources/horizontal-pod-autoscaler/about-hpas.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/kubernetes-resources/horizontal-pod-autoscaler/about-hpas.adoc
@@ -1,5 +1,7 @@
 = Background Information on HPAs
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-admin/kubernetes-resources/horizontal-pod-autoscaler/horizontal-pod-autoscaler.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/kubernetes-resources/horizontal-pod-autoscaler/horizontal-pod-autoscaler.adoc
@@ -1,5 +1,7 @@
 = Horizontal Pod Autoscaler
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :description: Learn about the horizontal pod autoscaler (HPA). How to manage HPAs and how to test them with a service deployment

--- a/versions/v2.12/modules/en/pages/cluster-admin/kubernetes-resources/horizontal-pod-autoscaler/manage-hpas-with-kubectl.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/kubernetes-resources/horizontal-pod-autoscaler/manage-hpas-with-kubectl.adoc
@@ -1,5 +1,7 @@
 = Managing HPAs with kubectl
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-admin/kubernetes-resources/horizontal-pod-autoscaler/manage-hpas-with-ui.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/kubernetes-resources/horizontal-pod-autoscaler/manage-hpas-with-ui.adoc
@@ -1,5 +1,7 @@
 = Managing HPAs with the {rancher-product-name} UI
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/cluster-admin/kubernetes-resources/horizontal-pod-autoscaler/test-hpas-with-kubectl.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/kubernetes-resources/horizontal-pod-autoscaler/test-hpas-with-kubectl.adoc
@@ -1,5 +1,7 @@
 = Testing HPAs with kubectl
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-admin/kubernetes-resources/kubernetes-and-docker-registries.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/kubernetes-resources/kubernetes-and-docker-registries.adoc
@@ -1,5 +1,7 @@
 = Kubernetes Registry and Container Image Registry
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :description: Learn about the container image registry and Kubernetes registry, their use cases, and how to use a private registry with the Rancher UI

--- a/versions/v2.12/modules/en/pages/cluster-admin/kubernetes-resources/kubernetes-resources-setup.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/kubernetes-resources/kubernetes-resources-setup.adoc
@@ -1,5 +1,7 @@
 = Kubernetes Resources Setup
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-admin/kubernetes-resources/load-balancer-and-ingress-controller/add-ingresses.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/kubernetes-resources/load-balancer-and-ingress-controller/add-ingresses.adoc
@@ -1,5 +1,7 @@
 = Adding Ingresses
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :description: Ingresses can be added for workloads to provide load balancing, SSL termination and host/path-based routing. Learn how to add Rancher ingress

--- a/versions/v2.12/modules/en/pages/cluster-admin/kubernetes-resources/load-balancer-and-ingress-controller/ingress-configuration.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/kubernetes-resources/load-balancer-and-ingress-controller/ingress-configuration.adoc
@@ -1,5 +1,7 @@
 = Configuring an Ingress
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :description: Configuring an Ingress

--- a/versions/v2.12/modules/en/pages/cluster-admin/kubernetes-resources/load-balancer-and-ingress-controller/layer-4-and-layer-7-load-balancing.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/kubernetes-resources/load-balancer-and-ingress-controller/layer-4-and-layer-7-load-balancing.adoc
@@ -1,5 +1,7 @@
 = Layer 4 and Layer 7 Load Balancing
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :description: Kubernetes supports load balancing in two ways: Layer-4 Load Balancing and Layer-7 Load Balancing. Learn about the support for each way in different deployments

--- a/versions/v2.12/modules/en/pages/cluster-admin/kubernetes-resources/load-balancer-and-ingress-controller/load-balancer-and-ingress-controller.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/kubernetes-resources/load-balancer-and-ingress-controller/load-balancer-and-ingress-controller.adoc
@@ -1,5 +1,7 @@
 = Load Balancer and Ingress Controller Setup within {rancher-product-name}
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :description: Learn how you can set up load balancers and ingress controllers to redirect service requests within Rancher, and learn about the limitations of load balancers

--- a/versions/v2.12/modules/en/pages/cluster-admin/kubernetes-resources/workloads-and-pods/add-a-sidecar.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/kubernetes-resources/workloads-and-pods/add-a-sidecar.adoc
@@ -1,5 +1,7 @@
 = Adding a Sidecar
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-admin/kubernetes-resources/workloads-and-pods/deploy-workloads.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/kubernetes-resources/workloads-and-pods/deploy-workloads.adoc
@@ -1,5 +1,7 @@
 = Deploying Workloads
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :description: Read this step by step guide for deploying workloads. Deploy a workload to run an application in one or more containers.

--- a/versions/v2.12/modules/en/pages/cluster-admin/kubernetes-resources/workloads-and-pods/roll-back-workloads.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/kubernetes-resources/workloads-and-pods/roll-back-workloads.adoc
@@ -1,5 +1,7 @@
 = Rolling Back Workloads
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-admin/kubernetes-resources/workloads-and-pods/upgrade-workloads.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/kubernetes-resources/workloads-and-pods/upgrade-workloads.adoc
@@ -1,5 +1,7 @@
 = Upgrading Workloads
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-admin/kubernetes-resources/workloads-and-pods/workloads-and-pods.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/kubernetes-resources/workloads-and-pods/workloads-and-pods.adoc
@@ -1,5 +1,7 @@
 = Kubernetes Workloads and Pods
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :description: Learn about the two constructs with which you can build any complex containerized application in Kubernetes: Kubernetes workloads and pods

--- a/versions/v2.12/modules/en/pages/cluster-admin/manage-clusters/access-clusters/access-clusters.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/manage-clusters/access-clusters/access-clusters.adoc
@@ -1,5 +1,7 @@
 = Access Clusters
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-admin/manage-clusters/access-clusters/add-users-to-clusters.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/manage-clusters/access-clusters/add-users-to-clusters.adoc
@@ -1,5 +1,7 @@
 = Adding Users to Clusters
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-admin/manage-clusters/access-clusters/authorized-cluster-endpoint.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/manage-clusters/access-clusters/authorized-cluster-endpoint.adoc
@@ -1,5 +1,7 @@
 = How the Authorized Cluster Endpoint Works
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-admin/manage-clusters/access-clusters/use-kubectl-and-kubeconfig.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/manage-clusters/access-clusters/use-kubectl-and-kubeconfig.adoc
@@ -1,5 +1,7 @@
 = Access a Cluster with Kubectl and kubeconfig
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-25
 :page-revdate: {revdate}
 :description: Learn how you can access and manage your Kubernetes clusters using kubectl with kubectl Shell or with kubectl CLI and kubeconfig file. A kubeconfig file is used to configure access to Kubernetes. When you create a cluster with Rancher, it automatically creates a kubeconfig for your cluster.

--- a/versions/v2.12/modules/en/pages/cluster-admin/manage-clusters/clean-cluster-nodes.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/manage-clusters/clean-cluster-nodes.adoc
@@ -1,5 +1,7 @@
 = Removing Kubernetes Components from Nodes
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-11-05
 :page-revdate: {revdate}
 :description: Learn about cluster cleanup when removing nodes from your Rancher-launched Kubernetes cluster. What is removed, how to do it manually

--- a/versions/v2.12/modules/en/pages/cluster-admin/manage-clusters/cluster-templates.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/manage-clusters/cluster-templates.adoc
@@ -1,5 +1,7 @@
 = Cluster Templates
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-11-04
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/cluster-admin/manage-clusters/install-cluster-autoscaler/install-cluster-autoscaler.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/manage-clusters/install-cluster-autoscaler/install-cluster-autoscaler.adoc
@@ -1,5 +1,7 @@
 = Cluster Autoscaler
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-admin/manage-clusters/install-cluster-autoscaler/use-aws-ec2-auto-scaling-groups.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/manage-clusters/install-cluster-autoscaler/use-aws-ec2-auto-scaling-groups.adoc
@@ -1,5 +1,7 @@
 = Cluster Autoscaler with AWS EC2 Auto Scaling Groups
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-10-01
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-admin/manage-clusters/manage-clusters.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/manage-clusters/manage-clusters.adoc
@@ -1,5 +1,7 @@
 = Cluster Administration
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-admin/manage-clusters/nodes-and-node-pools.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/manage-clusters/nodes-and-node-pools.adoc
@@ -1,5 +1,7 @@
 = Nodes and Node Pools
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-admin/manage-clusters/persistent-storage/about-glusterfs-volumes.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/manage-clusters/persistent-storage/about-glusterfs-volumes.adoc
@@ -1,5 +1,7 @@
 = GlusterFS Volumes
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-admin/manage-clusters/persistent-storage/about-persistent-storage.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/manage-clusters/persistent-storage/about-persistent-storage.adoc
@@ -1,5 +1,7 @@
 = How Persistent Storage Works
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/cluster-admin/manage-clusters/persistent-storage/dynamically-provision-new-storage.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/manage-clusters/persistent-storage/dynamically-provision-new-storage.adoc
@@ -1,5 +1,7 @@
 = Dynamically Provisioning New Storage in {rancher-product-name}
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-09-12
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/cluster-admin/manage-clusters/persistent-storage/examples/examples.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/manage-clusters/persistent-storage/examples/examples.adoc
@@ -1,5 +1,7 @@
 = Provisioning Storage Examples
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-admin/manage-clusters/persistent-storage/examples/nfs-storage.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/manage-clusters/persistent-storage/examples/nfs-storage.adoc
@@ -1,5 +1,7 @@
 = NFS Storage
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-admin/manage-clusters/persistent-storage/examples/persistent-storage-in-amazon-ebs.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/manage-clusters/persistent-storage/examples/persistent-storage-in-amazon-ebs.adoc
@@ -1,5 +1,7 @@
 = Creating Persistent Storage in Amazon's EBS
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-admin/manage-clusters/persistent-storage/examples/vsphere-storage.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/manage-clusters/persistent-storage/examples/vsphere-storage.adoc
@@ -1,5 +1,7 @@
 = VMware vSphere Storage
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/cluster-admin/manage-clusters/persistent-storage/install-iscsi-volumes.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/manage-clusters/persistent-storage/install-iscsi-volumes.adoc
@@ -1,5 +1,7 @@
 = iSCSI Volumes
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-admin/manage-clusters/persistent-storage/manage-persistent-storage.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/manage-clusters/persistent-storage/manage-persistent-storage.adoc
@@ -1,5 +1,7 @@
 = Create Kubernetes Persistent Volumes and Storage Classes
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :description: Learn about the two ways with which you can create persistent storage in Kubernetes: persistent volumes and storage classes

--- a/versions/v2.12/modules/en/pages/cluster-admin/manage-clusters/persistent-storage/set-up-existing-storage.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/manage-clusters/persistent-storage/set-up-existing-storage.adoc
@@ -1,5 +1,7 @@
 = Setting up Existing Storage
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/cluster-admin/manage-clusters/persistent-storage/use-external-ceph-driver.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/manage-clusters/persistent-storage/use-external-ceph-driver.adoc
@@ -1,5 +1,7 @@
 = Using an External Ceph Driver
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/cluster-admin/manage-clusters/projects-and-namespaces.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/manage-clusters/projects-and-namespaces.adoc
@@ -1,5 +1,7 @@
 = Projects and Kubernetes Namespaces with {rancher-product-name}
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-10-01
 :page-revdate: {revdate}
 :description: Rancher Projects ease the administrative burden of your cluster and support multi-tenancy. Learn to create projects and divide projects into Kubernetes namespaces

--- a/versions/v2.12/modules/en/pages/cluster-admin/manage-clusters/rotate-certificates.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/manage-clusters/rotate-certificates.adoc
@@ -1,5 +1,7 @@
 = Certificate Rotation
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-22
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-admin/manage-clusters/rotate-encryption-key.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/manage-clusters/rotate-encryption-key.adoc
@@ -1,5 +1,7 @@
 = Encryption Key Rotation
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-22
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/cluster-admin/namespaces.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/namespaces.adoc
@@ -1,5 +1,7 @@
 = Namespaces
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-admin/project-admin/add-users-to-projects.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/project-admin/add-users-to-projects.adoc
@@ -1,5 +1,7 @@
 = Adding Users to Projects
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/cluster-admin/project-admin/project-admin.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/project-admin/project-admin.adoc
@@ -1,5 +1,7 @@
 = Project Administration
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-18
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-admin/project-admin/project-resource-quotas/override-default-limit-in-namespaces.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/project-admin/project-resource-quotas/override-default-limit-in-namespaces.adoc
@@ -1,5 +1,7 @@
 = Overriding the Default Limit for a Namespace
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/cluster-admin/project-admin/project-resource-quotas/project-resource-quotas.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/project-admin/project-resource-quotas/project-resource-quotas.adoc
@@ -1,5 +1,7 @@
 = Project Resource Quotas
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/cluster-admin/project-admin/project-resource-quotas/resource-quota-types.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/project-admin/project-resource-quotas/resource-quota-types.adoc
@@ -1,5 +1,7 @@
 = Resource Quota Type Reference
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-admin/project-admin/project-resource-quotas/resource-quotas-in-projects.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/project-admin/project-resource-quotas/resource-quotas-in-projects.adoc
@@ -1,5 +1,7 @@
 = How Resource Quotas Work in {rancher-product-name} Projects
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-admin/project-admin/project-resource-quotas/set-container-default-resource-limits.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/project-admin/project-resource-quotas/set-container-default-resource-limits.adoc
@@ -1,5 +1,7 @@
 = Setting Container Default Resource Limits
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/cluster-deployment/about-rancher-agents.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/about-rancher-agents.adoc
@@ -1,5 +1,7 @@
 = {rancher-product-name} Agents
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/cluster-deployment.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/cluster-deployment.adoc
@@ -1,5 +1,7 @@
 = Kubernetes Clusters in {rancher-product-name} Setup
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :description: Provisioning Kubernetes Clusters

--- a/versions/v2.12/modules/en/pages/cluster-deployment/configuration/k3s.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/configuration/k3s.adoc
@@ -1,5 +1,7 @@
 = {k3s-product-name} Cluster Configuration Reference
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/configuration/rke1.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/configuration/rke1.adoc
@@ -1,5 +1,7 @@
 = RKE Cluster Configuration Reference
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-18
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/configuration/rke2.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/configuration/rke2.adoc
@@ -1,5 +1,7 @@
 = {rke2-product-name} Cluster Configuration Reference
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-18
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/custom-clusters/custom-clusters.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/custom-clusters/custom-clusters.adoc
@@ -1,5 +1,7 @@
 = Launching Kubernetes on Existing Custom Nodes
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-10-01
 :page-revdate: {revdate}
 :description: To create a cluster with custom nodes, you’ll need to access servers in your cluster and provision them according to Rancher requirements

--- a/versions/v2.12/modules/en/pages/cluster-deployment/custom-clusters/rancher-agent-options.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/custom-clusters/rancher-agent-options.adoc
@@ -1,5 +1,7 @@
 = {rancher-product-name} Agent Options
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/custom-clusters/windows/azure-storageclass-configuration.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/custom-clusters/windows/azure-storageclass-configuration.adoc
@@ -1,5 +1,7 @@
 = Configuring Storage Classes in Azure
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/custom-clusters/windows/network-requirements-for-host-gateway.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/custom-clusters/windows/network-requirements-for-host-gateway.adoc
@@ -1,5 +1,7 @@
 = Networking Requirements for Host Gateway (L2bridge)
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/custom-clusters/windows/use-windows-clusters.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/custom-clusters/windows/use-windows-clusters.adoc
@@ -1,5 +1,7 @@
 = Launching Kubernetes on Windows Clusters
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/custom-clusters/windows/windows-linux-cluster-feature-parity.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/custom-clusters/windows/windows-linux-cluster-feature-parity.adoc
@@ -1,5 +1,7 @@
 = Windows and Linux Cluster Feature Parity
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/custom-clusters/windows/workload-migration-guidance.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/custom-clusters/windows/workload-migration-guidance.adoc
@@ -1,5 +1,7 @@
 = RKE1 to {rke2-product-name} Windows Migration Guidance
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/enable-cluster-agent-scheduling-customization.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/enable-cluster-agent-scheduling-customization.adoc
@@ -1,5 +1,7 @@
 = Enabling Cluster Agent Scheduling Customization
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/hosted-kubernetes/aks/aks.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/hosted-kubernetes/aks/aks.adoc
@@ -1,5 +1,7 @@
 = Creating an AKS Cluster
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/cluster-deployment/hosted-kubernetes/aks/configuration.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/hosted-kubernetes/aks/configuration.adoc
@@ -1,5 +1,7 @@
 = AKS Cluster Configuration Reference
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/hosted-kubernetes/eks/configuration.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/hosted-kubernetes/eks/configuration.adoc
@@ -1,5 +1,7 @@
 = EKS Cluster Configuration Reference
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/hosted-kubernetes/eks/eks.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/hosted-kubernetes/eks/eks.adoc
@@ -1,5 +1,7 @@
 = Creating an EKS Cluster
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/hosted-kubernetes/gke/configuration.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/hosted-kubernetes/gke/configuration.adoc
@@ -1,5 +1,7 @@
 = GKE Cluster Configuration Reference
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/hosted-kubernetes/gke/gke.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/hosted-kubernetes/gke/gke.adoc
@@ -1,5 +1,7 @@
 = Creating a GKE Cluster
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/hosted-kubernetes/gke/private-clusters.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/hosted-kubernetes/gke/private-clusters.adoc
@@ -1,5 +1,7 @@
 = Private Clusters
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/hosted-kubernetes/hosted-kubernetes.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/hosted-kubernetes/hosted-kubernetes.adoc
@@ -1,5 +1,7 @@
 = Setting up Clusters from Hosted Kubernetes Providers
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/hosted-kubernetes/sync-clusters.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/hosted-kubernetes/sync-clusters.adoc
@@ -1,5 +1,7 @@
 = Syncing Hosted Clusters
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-10-21
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/aws/aws.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/aws/aws.adoc
@@ -1,5 +1,7 @@
 = Creating an Amazon EC2 Cluster
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-25
 :page-revdate: {revdate}
 :description: Learn the prerequisites and steps required in order for you to create an Amazon EC2 cluster using Rancher

--- a/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/aws/machine-configuration.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/aws/machine-configuration.adoc
@@ -1,5 +1,7 @@
 = EC2 Machine Configuration Reference
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/aws/node-template-configuration.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/aws/node-template-configuration.adoc
@@ -1,5 +1,7 @@
 = EC2 Node Template Configuration
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/azure/azure.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/azure/azure.adoc
@@ -1,5 +1,7 @@
 = Creating an Azure Cluster
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-25
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/azure/machine-configuration.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/azure/machine-configuration.adoc
@@ -1,5 +1,7 @@
 = Azure Machine Configuration
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/azure/node-template-configuration.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/azure/node-template-configuration.adoc
@@ -1,5 +1,7 @@
 = Azure Node Template Configuration
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/digitalocean/digitalocean.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/digitalocean/digitalocean.adoc
@@ -1,5 +1,7 @@
 = Creating a DigitalOcean Cluster
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-25
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/digitalocean/machine-configuration.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/digitalocean/machine-configuration.adoc
@@ -1,5 +1,7 @@
 = DigitalOcean Machine Configuration
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/digitalocean/node-template-configuration.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/digitalocean/node-template-configuration.adoc
@@ -1,5 +1,7 @@
 = DigitalOcean Node Template Configuration
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/gce/gce.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/gce/gce.adoc
@@ -1,5 +1,7 @@
 = Creating a Google Compute Engine cluster
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-27
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/gce/machine-configuration.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/gce/machine-configuration.adoc
@@ -1,5 +1,7 @@
 = GCE Machine Configuration
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-26
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/infra-providers.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/infra-providers.adoc
@@ -1,5 +1,7 @@
 = Launching Kubernetes on New Nodes in an Infrastructure Provider
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/nutanix/node-template-configuration.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/nutanix/node-template-configuration.adoc
@@ -1,5 +1,7 @@
 = Nutanix Node Template Configuration
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/nutanix/nutanix.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/nutanix/nutanix.adoc
@@ -1,5 +1,7 @@
 = Creating a Nutanix AOS Cluster
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-25
 :page-revdate: {revdate}
 :description: Use Rancher to create a Nutanix AOS (AHV) cluster. It may consist of groups of VMs with distinct properties which allow for fine-grained control over the sizing of nodes.

--- a/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/nutanix/provision-kubernetes-clusters-in-aos.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/nutanix/provision-kubernetes-clusters-in-aos.adoc
@@ -1,5 +1,7 @@
 = Provisioning Kubernetes Clusters in Nutanix AOS
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/vsphere/best-practices.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/vsphere/best-practices.adoc
@@ -1,5 +1,7 @@
 = Best Practices for {rancher-product-name} Managed VMware vSphere Clusters
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/vsphere/create-a-vm-template.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/vsphere/create-a-vm-template.adoc
@@ -1,5 +1,7 @@
 = Creating a VMware vSphere Virtual Machine Template
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-25
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/vsphere/create-credentials.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/vsphere/create-credentials.adoc
@@ -1,5 +1,7 @@
 = Creating Credentials in the VMware vSphere Console
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-25
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/vsphere/node-template-configuration.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/vsphere/node-template-configuration.adoc
@@ -1,5 +1,7 @@
 = VMware vSphere Node Template Configuration
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/vsphere/provision-kubernetes-clusters-in-vsphere.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/vsphere/provision-kubernetes-clusters-in-vsphere.adoc
@@ -1,5 +1,7 @@
 = Provisioning Kubernetes Clusters in VMware vSphere
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-25
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/vsphere/shutdown-vm.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/vsphere/shutdown-vm.adoc
@@ -1,5 +1,7 @@
 = Graceful Shutdown for VMware vSphere Virtual Machines
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-25
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/vsphere/vsphere.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/vsphere/vsphere.adoc
@@ -1,5 +1,7 @@
 = Creating a VMware vSphere Cluster
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-25
 :page-revdate: {revdate}
 :description: Use Rancher to create a VMware vSphere cluster. It may consist of groups of VMs with distinct properties which allow for fine-grained control over the sizing of nodes.

--- a/versions/v2.12/modules/en/pages/cluster-deployment/launch-kubernetes-with-rancher.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/launch-kubernetes-with-rancher.adoc
@@ -1,5 +1,7 @@
 = Launching Kubernetes with {rancher-product-name}
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-25
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/migrate-to-an-out-of-tree-cloud-provider/amazon.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/migrate-to-an-out-of-tree-cloud-provider/amazon.adoc
@@ -1,5 +1,7 @@
 = Migrating Amazon In-tree to Out-of-tree
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/migrate-to-an-out-of-tree-cloud-provider/azure.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/migrate-to-an-out-of-tree-cloud-provider/azure.adoc
@@ -1,5 +1,7 @@
 = Migrating Azure In-tree to Out-of-tree
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/migrate-to-an-out-of-tree-cloud-provider/vsphere.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/migrate-to-an-out-of-tree-cloud-provider/vsphere.adoc
@@ -1,5 +1,7 @@
 = Migrating VMware vSphere In-tree to Out-of-tree
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/cluster-deployment/node-requirements.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/node-requirements.adoc
@@ -1,5 +1,7 @@
 = Node Requirements for {rancher-product-name} Managed Clusters
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/production-checklist/production-checklist.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/production-checklist/production-checklist.adoc
@@ -1,5 +1,7 @@
 = Checklist for Production-Ready Clusters
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/production-checklist/recommended-cluster-architecture.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/production-checklist/recommended-cluster-architecture.adoc
@@ -1,5 +1,7 @@
 = Recommended Cluster Architecture
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/production-checklist/roles-for-nodes-in-kubernetes.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/production-checklist/roles-for-nodes-in-kubernetes.adoc
@@ -1,5 +1,7 @@
 = Roles for Nodes in Kubernetes
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/production-checklist/tips-to-set-up-containers.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/production-checklist/tips-to-set-up-containers.adoc
@@ -1,5 +1,7 @@
 = Tips for Setting Up Containers
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/register-existing-clusters-troubleshooting.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/register-existing-clusters-troubleshooting.adoc
@@ -1,5 +1,7 @@
 = Registered Clusters
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/register-existing-clusters.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/register-existing-clusters.adoc
@@ -1,5 +1,7 @@
 = Registering Existing Clusters
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-25
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/set-up-cloud-providers/amazon.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/set-up-cloud-providers/amazon.adoc
@@ -1,5 +1,7 @@
 = Setting up the Amazon Cloud Provider
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :weight: 1

--- a/versions/v2.12/modules/en/pages/cluster-deployment/set-up-cloud-providers/azure.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/set-up-cloud-providers/azure.adoc
@@ -1,5 +1,7 @@
 = Setting up the Azure Cloud Provider
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/set-up-cloud-providers/configure-in-tree-vsphere.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/set-up-cloud-providers/configure-in-tree-vsphere.adoc
@@ -1,5 +1,7 @@
 = Setting Up an In-tree VMware vSphere Cloud Provider
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/set-up-cloud-providers/configure-out-of-tree-vsphere.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/set-up-cloud-providers/configure-out-of-tree-vsphere.adoc
@@ -1,5 +1,7 @@
 = Setting Up an Out-of-tree VMware vSphere Cloud Provider
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/cluster-deployment/set-up-cloud-providers/google-compute-engine.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/set-up-cloud-providers/google-compute-engine.adoc
@@ -1,5 +1,7 @@
 = Setting up the Google Compute Engine Cloud Provider
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/set-up-cloud-providers/set-up-cloud-providers.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/set-up-cloud-providers/set-up-cloud-providers.adoc
@@ -1,5 +1,7 @@
 = Setting up Cloud Providers
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/contribute-to-rancher.adoc
+++ b/versions/v2.12/modules/en/pages/contribute-to-rancher.adoc
@@ -1,5 +1,7 @@
 = Contributing to {rancher-product-name}
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-14
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/faq/container-network-interface-providers.adoc
+++ b/versions/v2.12/modules/en/pages/faq/container-network-interface-providers.adoc
@@ -1,5 +1,7 @@
 = Container Network Interface (CNI) Providers
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-18
 :page-revdate: {revdate}
 :description: Learn about Container Network Interface (CNI), the CNI providers Rancher provides, the features they offer, and how to choose a provider for you

--- a/versions/v2.12/modules/en/pages/faq/deprecated-features.adoc
+++ b/versions/v2.12/modules/en/pages/faq/deprecated-features.adoc
@@ -1,5 +1,7 @@
 = Deprecated Features in {rancher-product-name}
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-10-21
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/faq/general-faq.adoc
+++ b/versions/v2.12/modules/en/pages/faq/general-faq.adoc
@@ -1,5 +1,7 @@
 = General FAQ
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/faq/install-and-configure-kubectl.adoc
+++ b/versions/v2.12/modules/en/pages/faq/install-and-configure-kubectl.adoc
@@ -1,5 +1,7 @@
 = Installing and Configuring kubectl
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-18
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/faq/rancher-is-no-longer-needed.adoc
+++ b/versions/v2.12/modules/en/pages/faq/rancher-is-no-longer-needed.adoc
@@ -1,5 +1,7 @@
 = {rancher-product-name} is No Longer Needed
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-18
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/faq/security.adoc
+++ b/versions/v2.12/modules/en/pages/faq/security.adoc
@@ -1,5 +1,7 @@
 = Security FAQ
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/faq/technical-items.adoc
+++ b/versions/v2.12/modules/en/pages/faq/technical-items.adoc
@@ -1,5 +1,7 @@
 = Technical FAQ
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-18
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/best-practices/best-practices.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/best-practices/best-practices.adoc
@@ -1,5 +1,7 @@
 = Best Practices for the {rancher-product-name} Server
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/best-practices/deployment-strategy.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/best-practices/deployment-strategy.adoc
@@ -1,5 +1,7 @@
 = {rancher-product-name} Deployment Strategy
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/best-practices/high-availability-installs.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/best-practices/high-availability-installs.adoc
@@ -1,5 +1,7 @@
 = About High-availability Installations
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/best-practices/rancher-on-vsphere.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/best-practices/rancher-on-vsphere.adoc
@@ -1,5 +1,7 @@
 = Installing {rancher-product-name} in a VMware vSphere Environment
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/best-practices/resources.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/best-practices/resources.adoc
@@ -1,5 +1,7 @@
 = Other Resources
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/best-practices/tips-for-running-rancher.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/best-practices/tips-for-running-rancher.adoc
@@ -1,5 +1,7 @@
 = Tips for Running {rancher-product-name}
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-22
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/best-practices/tuning-etcd-for-large-installs.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/best-practices/tuning-etcd-for-large-installs.adoc
@@ -1,5 +1,7 @@
 = Tuning etcd for Large Installations
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-09-29
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/best-practices/tuning-rancher-at-scale.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/best-practices/tuning-rancher-at-scale.adoc
@@ -1,5 +1,7 @@
 = Tuning and Best Practices for {rancher-product-name} at Scale
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-22
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/hosted-kubernetes/cloud-marketplace/aws/adapter-requirements.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/hosted-kubernetes/cloud-marketplace/aws/adapter-requirements.adoc
@@ -1,5 +1,7 @@
 = Prerequisites
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/hosted-kubernetes/cloud-marketplace/aws/aws.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/hosted-kubernetes/cloud-marketplace/aws/aws.adoc
@@ -1,5 +1,7 @@
 = AWS Marketplace Integration
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/hosted-kubernetes/cloud-marketplace/aws/common-issues.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/hosted-kubernetes/cloud-marketplace/aws/common-issues.adoc
@@ -1,5 +1,7 @@
 = Common Issues
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/hosted-kubernetes/cloud-marketplace/aws/install-adapter.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/hosted-kubernetes/cloud-marketplace/aws/install-adapter.adoc
@@ -1,5 +1,7 @@
 = Installing the Adapter
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-10-21
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/hosted-kubernetes/cloud-marketplace/aws/uninstall-adapter.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/hosted-kubernetes/cloud-marketplace/aws/uninstall-adapter.adoc
@@ -1,5 +1,7 @@
 = Uninstalling The Adapter
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/hosted-kubernetes/cloud-marketplace/cloud-marketplace.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/hosted-kubernetes/cloud-marketplace/cloud-marketplace.adoc
@@ -1,5 +1,7 @@
 = Cloud Marketplace Integration
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/hosted-kubernetes/cloud-marketplace/supportconfig.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/hosted-kubernetes/cloud-marketplace/supportconfig.adoc
@@ -1,5 +1,7 @@
 = Supportconfig Bundle
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/hosted-kubernetes/rancher-on-aks.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/hosted-kubernetes/rancher-on-aks.adoc
@@ -1,5 +1,7 @@
 = Installing {rancher-product-name} on Azure Kubernetes Service
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/hosted-kubernetes/rancher-on-amazon-eks.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/hosted-kubernetes/rancher-on-amazon-eks.adoc
@@ -1,5 +1,7 @@
 = Installing {rancher-product-name} on Amazon EKS
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/hosted-kubernetes/rancher-on-gke.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/hosted-kubernetes/rancher-on-gke.adoc
@@ -1,5 +1,7 @@
 = Installing {rancher-product-name} on a Google Kubernetes Engine Cluster
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/infrastructure-setup/amazon-elb-load-balancer.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/infrastructure-setup/amazon-elb-load-balancer.adoc
@@ -1,5 +1,7 @@
 = Setting up Amazon ELB Network Load Balancer
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/infrastructure-setup/configure-layer-7-nginx-load-balancer.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/infrastructure-setup/configure-layer-7-nginx-load-balancer.adoc
@@ -1,5 +1,7 @@
 = Docker Install with TLS Termination at Layer-7 NGINX Load Balancer
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-27
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/infrastructure-setup/ha-k3s-kubernetes-cluster.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/infrastructure-setup/ha-k3s-kubernetes-cluster.adoc
@@ -1,5 +1,7 @@
 = Setting up Infrastructure for a High Availability {k3s-product-name} Kubernetes Cluster
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/infrastructure-setup/ha-rke1-kubernetes-cluster.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/infrastructure-setup/ha-rke1-kubernetes-cluster.adoc
@@ -1,5 +1,7 @@
 = Setting up Infrastructure for a High Availability RKE Kubernetes Cluster
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/infrastructure-setup/ha-rke2-kubernetes-cluster.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/infrastructure-setup/ha-rke2-kubernetes-cluster.adoc
@@ -1,5 +1,7 @@
 = Setting up Infrastructure for a High Availability {rke2-product-name} Kubernetes Cluster
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/infrastructure-setup/infrastructure-setup.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/infrastructure-setup/infrastructure-setup.adoc
@@ -1,5 +1,7 @@
 = Infrastructure Setup
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/infrastructure-setup/mysql-database-in-amazon-rds.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/infrastructure-setup/mysql-database-in-amazon-rds.adoc
@@ -1,5 +1,7 @@
 = Setting up a MySQL Database in Amazon RDS
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/infrastructure-setup/nginx-load-balancer.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/infrastructure-setup/nginx-load-balancer.adoc
@@ -1,5 +1,7 @@
 = Setting up an NGINX Load Balancer
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/infrastructure-setup/nodes-in-amazon-ec2.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/infrastructure-setup/nodes-in-amazon-ec2.adoc
@@ -1,5 +1,7 @@
 = Setting up Nodes in Amazon EC2
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/install-kubernetes/install-kubernetes.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/install-kubernetes/install-kubernetes.adoc
@@ -1,5 +1,7 @@
 = Setting up a Kubernetes Cluster for {rancher-product-name} Server
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/install-kubernetes/k3s-for-rancher.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/install-kubernetes/k3s-for-rancher.adoc
@@ -1,5 +1,7 @@
 = Setting up a High-availability {k3s-product-name} Kubernetes Cluster for {rancher-product-name}
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/install-kubernetes/rke1-for-rancher.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/install-kubernetes/rke1-for-rancher.adoc
@@ -1,5 +1,7 @@
 = Setting up a High-availability RKE Kubernetes Cluster
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/install-kubernetes/rke2-for-rancher.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/install-kubernetes/rke2-for-rancher.adoc
@@ -1,5 +1,7 @@
 = Setting up a High-availability {rke2-product-name} Kubernetes Cluster for {rancher-product-name}
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/install-rancher.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/install-rancher.adoc
@@ -1,5 +1,7 @@
 = Install/Upgrade {rancher-product-name} on a Kubernetes Cluster
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-25
 :page-revdate: {revdate}
 :description: Learn how to install Rancher in development and production environments. Read about single node and high availability installation

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/installation-and-upgrade.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/installation-and-upgrade.adoc
@@ -1,5 +1,7 @@
 = Installing {rancher-product-name}
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :description: Learn how to install Rancher in development and production environments. Read about single node and high availability installation

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/air-gapped.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/air-gapped.adoc
@@ -1,5 +1,7 @@
 = Air-Gapped Helm CLI Install
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/infrastructure-private-registry.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/infrastructure-private-registry.adoc
@@ -1,5 +1,7 @@
 = 1. Set up Infrastructure and Private Registry
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-kubernetes.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-kubernetes.adoc
@@ -1,5 +1,7 @@
 = 3. Install Kubernetes (Skip for Docker Installs)
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -1,5 +1,7 @@
 = 4. Install {rancher-product-name}
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-18
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/local-system-charts.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/local-system-charts.adoc
@@ -1,5 +1,7 @@
 = Setting up Local System Charts for Air Gapped Installations
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/publish-images.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/publish-images.adoc
@@ -1,5 +1,7 @@
 = 2. Collect and Publish Images to your Private Registry
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/upgrades.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/upgrades.adoc
@@ -1,5 +1,7 @@
 = Upgrading in an Air-Gapped Environment
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/http-proxy.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/http-proxy.adoc
@@ -1,5 +1,7 @@
 = Installing {rancher-product-name} behind an HTTP Proxy
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-kubernetes.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-kubernetes.adoc
@@ -1,5 +1,7 @@
 = 2. Install Kubernetes
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-25
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
@@ -1,5 +1,7 @@
 = 3. Install {rancher-product-name}
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/set-up-infrastructure.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/set-up-infrastructure.adoc
@@ -1,5 +1,7 @@
 = 1. Set up Infrastructure
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/other-installation-methods/other-installation-methods.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/other-installation-methods/other-installation-methods.adoc
@@ -1,5 +1,7 @@
 = Other Installation Methods
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/aws-marketplace.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/aws-marketplace.adoc
@@ -1,5 +1,7 @@
 = {rancher-prime} AWS Marketplace Quick Start
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :description: Deploy SUSE Rancher from the AWS Marketplace listing.

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/deploy-rancher.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/deploy-rancher.adoc
@@ -1,5 +1,7 @@
 = Deploying {rancher-product-name} Server
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
@@ -1,5 +1,7 @@
 = {rancher-product-name} Equinix Metal Quick Start
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/helm-cli.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/helm-cli.adoc
@@ -1,5 +1,7 @@
 = Helm CLI Quick Start
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-18
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/quick-start/deploy-workloads/deploy-workloads.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/quick-start/deploy-workloads/deploy-workloads.adoc
@@ -1,5 +1,7 @@
 = Deploying Workloads
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/quick-start/deploy-workloads/nodeports.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/quick-start/deploy-workloads/nodeports.adoc
@@ -1,5 +1,7 @@
 = Workload with NodePort Quick Start
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/quick-start/deploy-workloads/workload-ingress.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/quick-start/deploy-workloads/workload-ingress.adoc
@@ -1,5 +1,7 @@
 = Workload with Ingress Quick Start
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/quick-start/quick-start.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/quick-start/quick-start.adoc
@@ -1,5 +1,7 @@
 = {rancher-product-name} Deployment Quick Start Guides
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/references/feature-flags.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/references/feature-flags.adoc
@@ -1,5 +1,7 @@
 = Feature Flags
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-26
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/references/helm-chart-options.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/references/helm-chart-options.adoc
@@ -1,5 +1,7 @@
 = {rancher-product-name} Helm Chart Options
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-27
 :page-revdate: {revdate}
 :keywords: ["rancher helm chart", "rancher helm options", "rancher helm chart options", "helm chart rancher", "helm options rancher", "helm chart options rancher"]

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/references/references.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/references/references.adoc
@@ -1,5 +1,7 @@
 = Installation References
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/references/tls-settings.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/references/tls-settings.adoc
@@ -1,5 +1,7 @@
 = TLS Settings
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-25
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/requirements/dockershim.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/requirements/dockershim.adoc
@@ -1,5 +1,7 @@
 = Dockershim
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/requirements/helm-version-requirements.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/requirements/helm-version-requirements.adoc
@@ -1,5 +1,7 @@
 = Helm Version Requirements
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/requirements/install-docker.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/requirements/install-docker.adoc
@@ -1,5 +1,7 @@
 = Installing Docker
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/requirements/port-requirements.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/requirements/port-requirements.adoc
@@ -1,5 +1,7 @@
 = Port Requirements
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :description: Read about port requirements needed in order for Rancher to operate properly, both for Rancher nodes and downstream Kubernetes cluster nodes

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/requirements/requirements.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/requirements/requirements.adoc
@@ -1,5 +1,7 @@
 = Installation Requirements
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-20
 :page-revdate: {revdate}
 :description: Learn the node requirements for each node running Rancher server when you’re configuring  Rancher to run either in a Docker or Kubernetes setup

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/resources/bootstrap-password.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/resources/bootstrap-password.adoc
@@ -1,5 +1,7 @@
 = Setting up the Bootstrap Password
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/resources/custom-ca-root-certificates.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/resources/custom-ca-root-certificates.adoc
@@ -1,5 +1,7 @@
 = About Custom CA Root Certificates
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/resources/resources.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/resources/resources.adoc
@@ -1,5 +1,7 @@
 = Resources
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/resources/tls-secrets.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/resources/tls-secrets.adoc
@@ -1,5 +1,7 @@
 = Adding TLS Secrets
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/resources/update-rancher-certificate.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/resources/update-rancher-certificate.adoc
@@ -1,5 +1,7 @@
 = Updating the {rancher-product-name} Certificate
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
@@ -1,5 +1,7 @@
 = Upgrading Cert-Manager
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/rollbacks.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/rollbacks.adoc
@@ -1,5 +1,7 @@
 = Rollbacks
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-26
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/troubleshooting/certificate-troubleshooting.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/troubleshooting/certificate-troubleshooting.adoc
@@ -1,5 +1,7 @@
 = Troubleshooting Certificates
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/troubleshooting/rancher-ha.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/troubleshooting/rancher-ha.adoc
@@ -1,5 +1,7 @@
 = {rancher-product-name} HA
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/troubleshooting/troubleshooting.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/troubleshooting/troubleshooting.adoc
@@ -1,5 +1,7 @@
 = Troubleshooting the {rancher-product-name} Server Kubernetes Cluster
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-25
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/upgrades.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/upgrades.adoc
@@ -1,5 +1,7 @@
 = Upgrades
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-25
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/integrations/cluster-api/cluster-api.adoc
+++ b/versions/v2.12/modules/en/pages/integrations/cluster-api/cluster-api.adoc
@@ -1,5 +1,7 @@
 = {turtles-product-name}
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/integrations/cluster-api/overview.adoc
+++ b/versions/v2.12/modules/en/pages/integrations/cluster-api/overview.adoc
@@ -1,5 +1,7 @@
 = Overview
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/integrations/elemental.adoc
+++ b/versions/v2.12/modules/en/pages/integrations/elemental.adoc
@@ -1,5 +1,7 @@
 = {elemental-product-name}
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/integrations/fleet/architecture.adoc
+++ b/versions/v2.12/modules/en/pages/integrations/fleet/architecture.adoc
@@ -1,5 +1,7 @@
 = {fleet-product-name} Architecture
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/integrations/fleet/fleet.adoc
+++ b/versions/v2.12/modules/en/pages/integrations/fleet/fleet.adoc
@@ -1,5 +1,7 @@
 = {fleet-product-name}
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/integrations/fleet/overview.adoc
+++ b/versions/v2.12/modules/en/pages/integrations/fleet/overview.adoc
@@ -1,5 +1,7 @@
 = Overview
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-11-04
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/integrations/fleet/use-fleet-behind-a-proxy.adoc
+++ b/versions/v2.12/modules/en/pages/integrations/fleet/use-fleet-behind-a-proxy.adoc
@@ -1,5 +1,7 @@
 = Using {fleet-product-name} Behind a Proxy
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-25
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/integrations/fleet/windows-support.adoc
+++ b/versions/v2.12/modules/en/pages/integrations/fleet/windows-support.adoc
@@ -1,5 +1,7 @@
 = Windows Support
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/integrations/harvester/harvester.adoc
+++ b/versions/v2.12/modules/en/pages/integrations/harvester/harvester.adoc
@@ -1,5 +1,7 @@
 = {harvester-product-name}
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/integrations/harvester/overview.adoc
+++ b/versions/v2.12/modules/en/pages/integrations/harvester/overview.adoc
@@ -1,5 +1,7 @@
 = Overview
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-25
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/integrations/integrations.adoc
+++ b/versions/v2.12/modules/en/pages/integrations/integrations.adoc
@@ -1,5 +1,7 @@
 = Integrations in {rancher-product-name}
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/integrations/kubernetes-distributions.adoc
+++ b/versions/v2.12/modules/en/pages/integrations/kubernetes-distributions.adoc
@@ -1,5 +1,7 @@
 = Kubernetes Distributions
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/integrations/kubewarden.adoc
+++ b/versions/v2.12/modules/en/pages/integrations/kubewarden.adoc
@@ -1,5 +1,7 @@
 = {kubewarden-product-name}
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/integrations/longhorn/longhorn.adoc
+++ b/versions/v2.12/modules/en/pages/integrations/longhorn/longhorn.adoc
@@ -1,5 +1,7 @@
 = {longhorn-product-name}
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/integrations/longhorn/overview.adoc
+++ b/versions/v2.12/modules/en/pages/integrations/longhorn/overview.adoc
@@ -1,5 +1,7 @@
 = Overview
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/integrations/neuvector/neuvector.adoc
+++ b/versions/v2.12/modules/en/pages/integrations/neuvector/neuvector.adoc
@@ -1,5 +1,7 @@
 = {neuvector-product-name}
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/integrations/neuvector/overview.adoc
+++ b/versions/v2.12/modules/en/pages/integrations/neuvector/overview.adoc
@@ -1,5 +1,7 @@
 = Overview
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-15
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/integrations/rancher-desktop.adoc
+++ b/versions/v2.12/modules/en/pages/integrations/rancher-desktop.adoc
@@ -1,5 +1,7 @@
 = Kubernetes on the Desktop with Rancher Desktop
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/integrations/rancher-extensions.adoc
+++ b/versions/v2.12/modules/en/pages/integrations/rancher-extensions.adoc
@@ -1,5 +1,7 @@
 = Extensions
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/integrations/suse-observability.adoc
+++ b/versions/v2.12/modules/en/pages/integrations/suse-observability.adoc
@@ -1,5 +1,7 @@
 = {stackstate-product-name}
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/observability/istio/configuration/configuration.adoc
+++ b/versions/v2.12/modules/en/pages/observability/istio/configuration/configuration.adoc
@@ -1,5 +1,7 @@
 = Configuration Options
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-10-01
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/observability/istio/configuration/install-istio-on-rke2-cluster.adoc
+++ b/versions/v2.12/modules/en/pages/observability/istio/configuration/install-istio-on-rke2-cluster.adoc
@@ -1,5 +1,7 @@
 = Additional Steps for Installing Istio on {rke2-product-name} and {k3s-product-name} Clusters
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-10-01
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/observability/istio/configuration/project-network-isolation.adoc
+++ b/versions/v2.12/modules/en/pages/observability/istio/configuration/project-network-isolation.adoc
@@ -1,5 +1,7 @@
 = Additional Steps for Project Network Isolation
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-10-01
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/observability/istio/configuration/selectors-and-scrape-configurations.adoc
+++ b/versions/v2.12/modules/en/pages/observability/istio/configuration/selectors-and-scrape-configurations.adoc
@@ -1,5 +1,7 @@
 = Selectors and Scrape Configs
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-10-01
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/observability/istio/cpu-and-memory-allocations.adoc
+++ b/versions/v2.12/modules/en/pages/observability/istio/cpu-and-memory-allocations.adoc
@@ -1,5 +1,7 @@
 = CPU and Memory Allocations
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-10-01
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/observability/istio/disable-istio.adoc
+++ b/versions/v2.12/modules/en/pages/observability/istio/disable-istio.adoc
@@ -1,5 +1,7 @@
 = Disabling Istio
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-10-01
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/observability/istio/guides/enable-istio-in-cluster.adoc
+++ b/versions/v2.12/modules/en/pages/observability/istio/guides/enable-istio-in-cluster.adoc
@@ -1,5 +1,7 @@
 = Enable Istio in the Cluster
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-10-01
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/observability/istio/guides/enable-istio-in-namespace.adoc
+++ b/versions/v2.12/modules/en/pages/observability/istio/guides/enable-istio-in-namespace.adoc
@@ -1,5 +1,7 @@
 = Enable Istio in a Namespace
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-10-01
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/observability/istio/guides/generate-and-view-traffic.adoc
+++ b/versions/v2.12/modules/en/pages/observability/istio/guides/generate-and-view-traffic.adoc
@@ -1,5 +1,7 @@
 = Generate and View Traffic from Istio
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-10-01
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/observability/istio/guides/guides.adoc
+++ b/versions/v2.12/modules/en/pages/observability/istio/guides/guides.adoc
@@ -1,5 +1,7 @@
 = Istio Setup Guides
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-10-01
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/observability/istio/guides/set-up-istio-gateway.adoc
+++ b/versions/v2.12/modules/en/pages/observability/istio/guides/set-up-istio-gateway.adoc
@@ -1,5 +1,7 @@
 = Set up the Istio Gateway
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-10-01
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/observability/istio/guides/set-up-traffic-management.adoc
+++ b/versions/v2.12/modules/en/pages/observability/istio/guides/set-up-traffic-management.adoc
@@ -1,5 +1,7 @@
 = Set up Istio's Components for Traffic Management
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-10-01
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/observability/istio/guides/use-istio-sidecar.adoc
+++ b/versions/v2.12/modules/en/pages/observability/istio/guides/use-istio-sidecar.adoc
@@ -1,5 +1,7 @@
 = Add Deployments and Services with the Istio Sidecar
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-10-01
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/observability/istio/istio.adoc
+++ b/versions/v2.12/modules/en/pages/observability/istio/istio.adoc
@@ -1,5 +1,7 @@
 = Istio
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-10-01
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/observability/istio/rbac.adoc
+++ b/versions/v2.12/modules/en/pages/observability/istio/rbac.adoc
@@ -1,5 +1,7 @@
 = Role-based Access Control
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-10-01
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/observability/logging/best-practices.adoc
+++ b/versions/v2.12/modules/en/pages/observability/logging/best-practices.adoc
@@ -1,5 +1,7 @@
 = Logging Best Practices
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-22
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/observability/logging/custom-resource-configuration/flows-and-clusterflows.adoc
+++ b/versions/v2.12/modules/en/pages/observability/logging/custom-resource-configuration/flows-and-clusterflows.adoc
@@ -1,5 +1,7 @@
 = Flows and ClusterFlows
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/observability/logging/custom-resource-configuration/outputs-and-clusteroutputs.adoc
+++ b/versions/v2.12/modules/en/pages/observability/logging/custom-resource-configuration/outputs-and-clusteroutputs.adoc
@@ -1,5 +1,7 @@
 = Outputs and ClusterOutputs
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/observability/logging/enable-api-audit-log-in-downstream-clusters.adoc
+++ b/versions/v2.12/modules/en/pages/observability/logging/enable-api-audit-log-in-downstream-clusters.adoc
@@ -1,5 +1,7 @@
 = Enabling the API Audit Log in Downstream Clusters
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-09-29
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/observability/logging/enable-api-audit-log.adoc
+++ b/versions/v2.12/modules/en/pages/observability/logging/enable-api-audit-log.adoc
@@ -1,5 +1,7 @@
 = Enabling the API Audit Log to Record System Events
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-27
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/observability/logging/logging-architecture.adoc
+++ b/versions/v2.12/modules/en/pages/observability/logging/logging-architecture.adoc
@@ -1,5 +1,7 @@
 = Logging Architecture
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/observability/logging/logging-helm-chart-options.adoc
+++ b/versions/v2.12/modules/en/pages/observability/logging/logging-helm-chart-options.adoc
@@ -1,5 +1,7 @@
 = rancher-logging Helm Chart Options
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-15
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/observability/logging/logging.adoc
+++ b/versions/v2.12/modules/en/pages/observability/logging/logging.adoc
@@ -1,5 +1,7 @@
 = {rancher-product-name} Integration with Logging Services
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :description: Rancher integrates with popular logging services. Learn the requirements and benefits of integrating with logging services, and enable logging on your cluster.

--- a/versions/v2.12/modules/en/pages/observability/logging/rbac-for-logging.adoc
+++ b/versions/v2.12/modules/en/pages/observability/logging/rbac-for-logging.adoc
@@ -1,5 +1,7 @@
 = Role-based Access Control for Logging
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/observability/logging/taints-and-tolerations.adoc
+++ b/versions/v2.12/modules/en/pages/observability/logging/taints-and-tolerations.adoc
@@ -1,5 +1,7 @@
 = Working with Taints and Tolerations
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/observability/logging/troubleshooting.adoc
+++ b/versions/v2.12/modules/en/pages/observability/logging/troubleshooting.adoc
@@ -1,5 +1,7 @@
 = Troubleshooting
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/best-practices.adoc
+++ b/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/best-practices.adoc
@@ -1,5 +1,7 @@
 = Monitoring Best Practices
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-18
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/built-in-dashboards.adoc
+++ b/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/built-in-dashboards.adoc
@@ -1,5 +1,7 @@
 = Built-in Dashboards
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/configuration/advanced/advanced.adoc
+++ b/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/configuration/advanced/advanced.adoc
@@ -1,5 +1,7 @@
 = Advanced Configuration
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/configuration/advanced/alertmanager.adoc
+++ b/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/configuration/advanced/alertmanager.adoc
@@ -1,5 +1,7 @@
 = Alertmanager Configuration
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/configuration/advanced/prometheus.adoc
+++ b/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/configuration/advanced/prometheus.adoc
@@ -1,5 +1,7 @@
 = Prometheus Configuration
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/configuration/advanced/prometheusrules.adoc
+++ b/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/configuration/advanced/prometheusrules.adoc
@@ -1,5 +1,7 @@
 = Configuring PrometheusRules
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/configuration/configuration.adoc
+++ b/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/configuration/configuration.adoc
@@ -1,5 +1,7 @@
 = Monitoring Configuration Guides
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/configuration/debug-high-memory-usage.adoc
+++ b/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/configuration/debug-high-memory-usage.adoc
@@ -1,5 +1,7 @@
 = Debugging High Memory Usage
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/configuration/examples.adoc
+++ b/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/configuration/examples.adoc
@@ -1,5 +1,7 @@
 = Monitoring Configuration Examples
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/configuration/helm-chart-options.adoc
+++ b/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/configuration/helm-chart-options.adoc
@@ -1,5 +1,7 @@
 = Helm Chart Options
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/configuration/receivers.adoc
+++ b/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/configuration/receivers.adoc
@@ -1,5 +1,7 @@
 = Receiver Configuration
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-18
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/configuration/routes.adoc
+++ b/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/configuration/routes.adoc
@@ -1,5 +1,7 @@
 = Route Configuration
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/configuration/servicemonitors-and-podmonitors.adoc
+++ b/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/configuration/servicemonitors-and-podmonitors.adoc
@@ -1,5 +1,7 @@
 = ServiceMonitor and PodMonitor Configuration
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/customizing-dashboard/create-persistent-grafana-dashboard.adoc
+++ b/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/customizing-dashboard/create-persistent-grafana-dashboard.adoc
@@ -1,5 +1,7 @@
 = Persistent Grafana Dashboards
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/customizing-dashboard/customize-grafana-dashboard.adoc
+++ b/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/customizing-dashboard/customize-grafana-dashboard.adoc
@@ -1,5 +1,7 @@
 = Customizing Grafana Dashboards
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/enable-monitoring.adoc
+++ b/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/enable-monitoring.adoc
@@ -1,5 +1,7 @@
 = Enable Monitoring
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-09-29
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/how-monitoring-works.adoc
+++ b/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/how-monitoring-works.adoc
@@ -1,5 +1,7 @@
 = How Monitoring Works
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-15
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/monitoring-and-dashboards.adoc
+++ b/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/monitoring-and-dashboards.adoc
@@ -1,5 +1,7 @@
 = Monitoring and Dashboards
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-25
 :page-revdate: {revdate}
 :description: Prometheus lets you view metrics from your different Rancher and Kubernetes objects. Learn about the scope of monitoring and how to enable cluster monitoring

--- a/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/prometheus-federator/customize-grafana-dashboards.adoc
+++ b/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/prometheus-federator/customize-grafana-dashboards.adoc
@@ -1,5 +1,7 @@
 = Customizing Grafana Dashboards
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/prometheus-federator/enable-prometheus-federator.adoc
+++ b/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/prometheus-federator/enable-prometheus-federator.adoc
@@ -1,5 +1,7 @@
 = Enable Prometheus Federator
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/prometheus-federator/install-project-monitors.adoc
+++ b/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/prometheus-federator/install-project-monitors.adoc
@@ -1,5 +1,7 @@
 = Installing Project Monitors
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/prometheus-federator/prometheus-federator.adoc
+++ b/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/prometheus-federator/prometheus-federator.adoc
@@ -1,5 +1,7 @@
 = Prometheus Federator
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/prometheus-federator/rbac.adoc
+++ b/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/prometheus-federator/rbac.adoc
@@ -1,5 +1,7 @@
 = Role-Based Access Control
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/prometheus-federator/set-up-workloads.adoc
+++ b/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/prometheus-federator/set-up-workloads.adoc
@@ -1,5 +1,7 @@
 = Setting up Prometheus Federator for a Workload
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/prometheus-federator/uninstall-prometheus-federator.adoc
+++ b/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/prometheus-federator/uninstall-prometheus-federator.adoc
@@ -1,5 +1,7 @@
 = Uninstall Prometheus Federator
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/promql-expressions.adoc
+++ b/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/promql-expressions.adoc
@@ -1,5 +1,7 @@
 = PromQL Expression Reference
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/rbac-for-monitoring.adoc
+++ b/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/rbac-for-monitoring.adoc
@@ -1,5 +1,7 @@
 = Role-based Access Control
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/set-up-monitoring-for-workloads.adoc
+++ b/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/set-up-monitoring-for-workloads.adoc
@@ -1,5 +1,7 @@
 = Setting up Monitoring for a Workload
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/uninstall-monitoring.adoc
+++ b/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/uninstall-monitoring.adoc
@@ -1,5 +1,7 @@
 = Uninstall Monitoring
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/windows-support.adoc
+++ b/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/windows-support.adoc
@@ -1,5 +1,7 @@
 = Windows Cluster Support for Monitoring V2
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-25
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/observability/rancher-cluster-tools.adoc
+++ b/versions/v2.12/modules/en/pages/observability/rancher-cluster-tools.adoc
@@ -1,5 +1,7 @@
 = Cluster Tools for Logging, Monitoring, and Visibility
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/observability/rancher-project-tools.adoc
+++ b/versions/v2.12/modules/en/pages/observability/rancher-project-tools.adoc
@@ -1,5 +1,7 @@
 = Project Tools for Logging, Monitoring, and Visibility
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/back-up-restore-and-disaster-recovery/back-up-restore-and-disaster-recovery.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/back-up-restore-and-disaster-recovery/back-up-restore-and-disaster-recovery.adoc
@@ -1,5 +1,7 @@
 = Backup, Restore, and Disaster Recovery
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-13
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/rancher-admin/back-up-restore-and-disaster-recovery/back-up.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/back-up-restore-and-disaster-recovery/back-up.adoc
@@ -1,5 +1,7 @@
 = Backing up {rancher-product-name}
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-13
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/rancher-admin/back-up-restore-and-disaster-recovery/configuration/backup.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/back-up-restore-and-disaster-recovery/configuration/backup.adoc
@@ -1,5 +1,7 @@
 = Backup Configuration
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-13
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/back-up-restore-and-disaster-recovery/configuration/examples.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/back-up-restore-and-disaster-recovery/configuration/examples.adoc
@@ -1,5 +1,7 @@
 = Backup and Restore Examples
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-09-25
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/back-up-restore-and-disaster-recovery/configuration/restore.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/back-up-restore-and-disaster-recovery/configuration/restore.adoc
@@ -1,5 +1,7 @@
 = Restore Configuration
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/back-up-restore-and-disaster-recovery/configuration/storage.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/back-up-restore-and-disaster-recovery/configuration/storage.adoc
@@ -1,5 +1,7 @@
 = Backup Storage Location Configuration
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/back-up-restore-and-disaster-recovery/migrate-to-a-new-cluster.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/back-up-restore-and-disaster-recovery/migrate-to-a-new-cluster.adoc
@@ -1,5 +1,7 @@
 = Migrating {rancher-product-name} to a New Cluster
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-18
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/back-up-restore-and-disaster-recovery/restore.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/back-up-restore-and-disaster-recovery/restore.adoc
@@ -1,5 +1,7 @@
 = Restoring {rancher-product-name}
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-11-04
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/rancher-admin/back-up-restore-and-disaster-recovery/usage-guide.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/back-up-restore-and-disaster-recovery/usage-guide.adoc
@@ -1,5 +1,7 @@
 = Backup Restore Usage Guide
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-26
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/cli/kubectl.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/cli/kubectl.adoc
@@ -1,5 +1,7 @@
 = kubectl Utility
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/cli/rancher-cli.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/cli/rancher-cli.adoc
@@ -1,5 +1,7 @@
 = {rancher-product-name} CLI
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-10-10
 :page-revdate: {revdate}
 :description: Interact with Rancher using command line interface (CLI) tools from your workstation.

--- a/versions/v2.12/modules/en/pages/rancher-admin/experimental-features/cluster-role-aggregation.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/experimental-features/cluster-role-aggregation.adoc
@@ -1,5 +1,7 @@
 = ClusterRole Aggregation
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/experimental-features/continuous-delivery.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/experimental-features/continuous-delivery.adoc
@@ -1,5 +1,7 @@
 = Continuous Delivery
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/experimental-features/experimental-features.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/experimental-features/experimental-features.adoc
@@ -1,5 +1,7 @@
 = Enabling Experimental Features
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-18
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/experimental-features/istio-traffic-management-features.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/experimental-features/istio-traffic-management-features.adoc
@@ -1,5 +1,7 @@
 = UI for Istio Virtual Services and Destination Rules
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/experimental-features/rancher-on-arm64.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/experimental-features/rancher-on-arm64.adoc
@@ -1,5 +1,7 @@
 = Running on ARM64 Mixed Architecture (Experimental)
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-10-07
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/experimental-features/unsupported-storage-drivers.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/experimental-features/unsupported-storage-drivers.adoc
@@ -1,5 +1,7 @@
 = Allowing Unsupported Storage Drivers
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-09-12
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/global-configuration/custom-branding.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/global-configuration/custom-branding.adoc
@@ -1,5 +1,7 @@
 = Custom Branding
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/global-configuration/global-default-private-registry.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/global-configuration/global-default-private-registry.adoc
@@ -1,5 +1,7 @@
 = Configuring a Global Default Private Registry
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/global-configuration/notification-center.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/global-configuration/notification-center.adoc
@@ -1,5 +1,7 @@
 = Notification Center
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-27
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/global-configuration/provisioning-drivers/manage-cluster-drivers.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/global-configuration/provisioning-drivers/manage-cluster-drivers.adoc
@@ -1,5 +1,7 @@
 = Cluster Drivers
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/global-configuration/provisioning-drivers/manage-node-drivers.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/global-configuration/provisioning-drivers/manage-node-drivers.adoc
@@ -1,5 +1,7 @@
 = Node Drivers
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/global-configuration/provisioning-drivers/provisioning-drivers.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/global-configuration/provisioning-drivers/provisioning-drivers.adoc
@@ -1,5 +1,7 @@
 = About Provisioning Drivers
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-26
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/global-configuration/rke1-templates/access-or-share-templates.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/global-configuration/rke1-templates/access-or-share-templates.adoc
@@ -1,5 +1,7 @@
 = Access and Sharing
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/rancher-admin/global-configuration/rke1-templates/apply-templates.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/global-configuration/rke1-templates/apply-templates.adoc
@@ -1,5 +1,7 @@
 = Applying Templates
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/global-configuration/rke1-templates/creator-permissions.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/global-configuration/rke1-templates/creator-permissions.adoc
@@ -1,5 +1,7 @@
 = Template Creator Permissions
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/global-configuration/rke1-templates/enforce-templates.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/global-configuration/rke1-templates/enforce-templates.adoc
@@ -1,5 +1,7 @@
 = Enforcing Templates
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/global-configuration/rke1-templates/example-use-cases.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/global-configuration/rke1-templates/example-use-cases.adoc
@@ -1,5 +1,7 @@
 = Example Scenarios
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/global-configuration/rke1-templates/infrastructure.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/global-configuration/rke1-templates/infrastructure.adoc
@@ -1,5 +1,7 @@
 = RKE Templates and Infrastructure
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/global-configuration/rke1-templates/manage-templates.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/global-configuration/rke1-templates/manage-templates.adoc
@@ -1,5 +1,7 @@
 = Creating and Revising RKE Templates
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/rancher-admin/global-configuration/rke1-templates/override-template-settings.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/global-configuration/rke1-templates/override-template-settings.adoc
@@ -1,5 +1,7 @@
 = Overriding Template Settings
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/global-configuration/rke1-templates/rke1-templates.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/global-configuration/rke1-templates/rke1-templates.adoc
@@ -1,5 +1,7 @@
 = About RKE1 Templates
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/global-configuration/rke1-templates/template-example-yaml.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/global-configuration/rke1-templates/template-example-yaml.adoc
@@ -1,5 +1,7 @@
 = RKE1 Example YAML
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/global-configuration/ui-server-side-pagination.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/global-configuration/ui-server-side-pagination.adoc
@@ -1,5 +1,7 @@
 = UI Server-Side Pagination
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-26
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/rancher-admin.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/rancher-admin.adoc
@@ -1,5 +1,7 @@
 = Authentication, Permissions and Global Settings
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-18
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/scc-registration.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/scc-registration.adoc
@@ -1,5 +1,7 @@
 = SUSE Customer Center Registration
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-27
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/authn-and-authz.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/authn-and-authz.adoc
@@ -1,5 +1,7 @@
 = Configuring Authentication
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-09-18
 :page-revdate: {revdate}
 :weight: 10

--- a/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/configure-active-directory.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/configure-active-directory.adoc
@@ -1,5 +1,7 @@
 = Configure Active Directory (AD)
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-09-22
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/configure-amazon-cognito.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/configure-amazon-cognito.adoc
@@ -1,5 +1,7 @@
 = Configure Amazon Cognito
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-13
 :page-revdate: {revdate}
 :description: Create an Amazon Cognito user pool and configure Rancher to work with Amazon Cognito. Your users can then sign into Rancher using their login from Amazon Cognito.

--- a/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/configure-azure-ad.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/configure-azure-ad.adoc
@@ -1,5 +1,7 @@
 = Configure Azure AD
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/configure-freeipa.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/configure-freeipa.adoc
@@ -1,5 +1,7 @@
 = Configure FreeIPA
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/configure-generic-oidc.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/configure-generic-oidc.adoc
@@ -1,5 +1,7 @@
 = Configure Generic OIDC
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :description: Create an OpenID Connect (OIDC) client and configure Rancher to work with your authentication provider. Your users can then sign into Rancher using their login from the authentication provider.

--- a/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/configure-github.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/configure-github.adoc
@@ -1,5 +1,7 @@
 = Configure GitHub
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/configure-google-oauth.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/configure-google-oauth.adoc
@@ -1,5 +1,7 @@
 = Configure Google OAuth
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/configure-keycloak-oidc.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/configure-keycloak-oidc.adoc
@@ -1,5 +1,7 @@
 = Configure Keycloak (OIDC)
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :description: Create a Keycloak OpenID Connect (OIDC) client and configure Rancher to work with Keycloak. By the end your users will be able to sign into Rancher using their Keycloak logins

--- a/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/configure-keycloak-saml.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/configure-keycloak-saml.adoc
@@ -1,5 +1,7 @@
 = Configure Keycloak (SAML)
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-09-18
 :page-revdate: {revdate}
 :description: Create a Keycloak SAML client and configure Rancher to work with Keycloak. By the end your users will be able to sign into Rancher using their Keycloak logins

--- a/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/configure-oidc-provider.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/configure-oidc-provider.adoc
@@ -1,5 +1,7 @@
 = Configure Rancher as an OIDC provider
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-09-22
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/configure-okta-saml.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/configure-okta-saml.adoc
@@ -1,5 +1,7 @@
 = Configure Okta (SAML)
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-09-18
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/configure-pingidentity.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/configure-pingidentity.adoc
@@ -1,5 +1,7 @@
 = Configure PingIdentity (SAML)
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-09-18
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/create-local-users.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/create-local-users.adoc
@@ -1,5 +1,7 @@
 = Local Authentication
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/enable-user-retention.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/enable-user-retention.adoc
@@ -1,5 +1,7 @@
 = Enabling User Retention
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/jwt-authentication.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/jwt-authentication.adoc
@@ -1,5 +1,7 @@
 = JSON Web Token (JWT) Authentication
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/cluster-and-project-roles.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/cluster-and-project-roles.adoc
@@ -1,5 +1,7 @@
 = Cluster and Project Roles
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/custom-roles.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/custom-roles.adoc
@@ -1,5 +1,7 @@
 = Custom Roles
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/global-permissions.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/global-permissions.adoc
@@ -1,5 +1,7 @@
 = Global Permissions
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-09-23
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/locked-roles.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/locked-roles.adoc
@@ -1,5 +1,7 @@
 = Locked Roles
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/manage-role-based-access-control-rbac.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/manage-role-based-access-control-rbac.adoc
@@ -1,5 +1,7 @@
 = Managing Role-Based Access Control (RBAC)
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/manage-users-and-groups.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/manage-users-and-groups.adoc
@@ -1,5 +1,7 @@
 = Users and Groups
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-09-18
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/microsoft-ad-federation-service-saml/microsoft-ad-federation-service-saml.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/microsoft-ad-federation-service-saml/microsoft-ad-federation-service-saml.adoc
@@ -1,5 +1,7 @@
 = Configuring Microsoft Active Directory Federation Service (SAML)
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-09-18
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/microsoft-ad-federation-service-saml/ms-adfs-for-rancher.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/microsoft-ad-federation-service-saml/ms-adfs-for-rancher.adoc
@@ -1,5 +1,7 @@
 = 1. Configuring Microsoft AD FS for {rancher-product-name}
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/microsoft-ad-federation-service-saml/rancher-for-ms-adfs.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/microsoft-ad-federation-service-saml/rancher-for-ms-adfs.adoc
@@ -1,5 +1,7 @@
 = 2. Configuring {rancher-product-name} for Microsoft AD FS
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/openldap/openldap.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/openldap/openldap.adoc
@@ -1,5 +1,7 @@
 = Configuring OpenLDAP
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/openldap/reference.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/openldap/reference.adoc
@@ -1,5 +1,7 @@
 = OpenLDAP Configuration Reference
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/shibboleth-saml/group-permissions.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/shibboleth-saml/group-permissions.adoc
@@ -1,5 +1,7 @@
 = Group Permissions with Shibboleth and OpenLDAP
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/shibboleth-saml/shibboleth-saml.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/users/authn-and-authz/shibboleth-saml/shibboleth-saml.adoc
@@ -1,5 +1,7 @@
 = Configuring Shibboleth (SAML)
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-09-18
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/users/settings/api-keys.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/users/settings/api-keys.adoc
@@ -1,5 +1,7 @@
 = API Keys
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/rancher-admin/users/settings/manage-cloud-credentials.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/users/settings/manage-cloud-credentials.adoc
@@ -1,5 +1,7 @@
 = Managing Cloud Credentials
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/users/settings/manage-node-templates.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/users/settings/manage-node-templates.adoc
@@ -1,5 +1,7 @@
 = Managing Node Templates
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/rancher-admin/users/settings/settings.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/users/settings/settings.adoc
@@ -1,5 +1,7 @@
 = User Settings
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/users/settings/user-preferences.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/users/settings/user-preferences.adoc
@@ -1,5 +1,7 @@
 = User Preferences
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/release-notes.adoc
+++ b/versions/v2.12/modules/en/pages/release-notes.adoc
@@ -1,5 +1,7 @@
 = Release Notes
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-10-21
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/security/compliance-scans/compliance-scans.adoc
+++ b/versions/v2.12/modules/en/pages/security/compliance-scans/compliance-scans.adoc
@@ -1,5 +1,7 @@
 = Compliance Scans
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-10-01
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/security/compliance-scans/configuration-reference.adoc
+++ b/versions/v2.12/modules/en/pages/security/compliance-scans/configuration-reference.adoc
@@ -1,5 +1,7 @@
 = Configuration
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-10-01
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/security/compliance-scans/configure-alerts-for-periodic-scan-on-a-schedule.adoc
+++ b/versions/v2.12/modules/en/pages/security/compliance-scans/configure-alerts-for-periodic-scan-on-a-schedule.adoc
@@ -1,5 +1,7 @@
 = Configure Alerts for Periodic Scan on a Schedule
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-26
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/security/compliance-scans/create-a-custom-compliance-version-to-run.adoc
+++ b/versions/v2.12/modules/en/pages/security/compliance-scans/create-a-custom-compliance-version-to-run.adoc
@@ -1,5 +1,7 @@
 = Create a Custom Compliance Version for Running a Cluster Scan
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-26
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/security/compliance-scans/custom-benchmark.adoc
+++ b/versions/v2.12/modules/en/pages/security/compliance-scans/custom-benchmark.adoc
@@ -1,5 +1,7 @@
 = Creating a Custom Benchmark Version for Running a Cluster Scan
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-26
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/security/compliance-scans/enable-alerting-for-rancher-compliance.adoc
+++ b/versions/v2.12/modules/en/pages/security/compliance-scans/enable-alerting-for-rancher-compliance.adoc
@@ -1,5 +1,7 @@
 = Enable Alerting for {rancher-product-name} Compliance
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-26
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/security/compliance-scans/how-to.adoc
+++ b/versions/v2.12/modules/en/pages/security/compliance-scans/how-to.adoc
@@ -1,5 +1,7 @@
 = Compliance Scan Guides
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-26
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/security/compliance-scans/install-rancher-compliance.adoc
+++ b/versions/v2.12/modules/en/pages/security/compliance-scans/install-rancher-compliance.adoc
@@ -1,5 +1,7 @@
 = Install {rancher-product-name} Compliance
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-26
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/security/compliance-scans/rbac-for-compliance-scans.adoc
+++ b/versions/v2.12/modules/en/pages/security/compliance-scans/rbac-for-compliance-scans.adoc
@@ -1,5 +1,7 @@
 = Roles-based Access Control
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-26
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/security/compliance-scans/run-a-scan-periodically-on-a-schedule.adoc
+++ b/versions/v2.12/modules/en/pages/security/compliance-scans/run-a-scan-periodically-on-a-schedule.adoc
@@ -1,5 +1,7 @@
 = Run a Scan Periodically on a Schedule
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-26
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/security/compliance-scans/run-a-scan.adoc
+++ b/versions/v2.12/modules/en/pages/security/compliance-scans/run-a-scan.adoc
@@ -1,5 +1,7 @@
 = Run a Scan
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-26
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/security/compliance-scans/uninstall-rancher-compliance.adoc
+++ b/versions/v2.12/modules/en/pages/security/compliance-scans/uninstall-rancher-compliance.adoc
@@ -1,5 +1,7 @@
 = Uninstall {rancher-product-name} Compliance
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-26
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/security/compliance-scans/view-reports.adoc
+++ b/versions/v2.12/modules/en/pages/security/compliance-scans/view-reports.adoc
@@ -1,5 +1,7 @@
 = View Reports
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-26
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/security/cves.adoc
+++ b/versions/v2.12/modules/en/pages/security/cves.adoc
@@ -1,5 +1,7 @@
 = Security Advisories and CVEs
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-10-22
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/security/encrypting-http.adoc
+++ b/versions/v2.12/modules/en/pages/security/encrypting-http.adoc
@@ -1,5 +1,7 @@
 = Encrypting HTTP Communication
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 :description: Learn how to add an SSL (Secure Sockets Layer) certificate or TLS (Transport Layer Security) certificate

--- a/versions/v2.12/modules/en/pages/security/kubernetes-security-best-practices.adoc
+++ b/versions/v2.12/modules/en/pages/security/kubernetes-security-best-practices.adoc
@@ -1,5 +1,7 @@
 = Kubernetes Security Best Practices
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/security/open-ports-with-firewalld.adoc
+++ b/versions/v2.12/modules/en/pages/security/open-ports-with-firewalld.adoc
@@ -1,5 +1,7 @@
 = Opening Ports with firewalld
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/security/psa-pss.adoc
+++ b/versions/v2.12/modules/en/pages/security/psa-pss.adoc
@@ -1,5 +1,7 @@
 = Pod Security Standards (PSS) & Pod Security Admission (PSA)
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-18
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/security/psact.adoc
+++ b/versions/v2.12/modules/en/pages/security/psact.adoc
@@ -1,5 +1,7 @@
 = Pod Security Admission (PSA) Configuration Templates
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/security/rancher-security-best-practices.adoc
+++ b/versions/v2.12/modules/en/pages/security/rancher-security-best-practices.adoc
@@ -1,5 +1,7 @@
 = {rancher-product-name} Security Best Practices
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-22
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/security/rancher-webhook/expired-webhook-certificate-rotation.adoc
+++ b/versions/v2.12/modules/en/pages/security/rancher-webhook/expired-webhook-certificate-rotation.adoc
@@ -1,5 +1,7 @@
 = Rotation of Expired Webhook Certificates
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/security/rancher-webhook/hardening.adoc
+++ b/versions/v2.12/modules/en/pages/security/rancher-webhook/hardening.adoc
@@ -1,5 +1,7 @@
 = Hardening the {rancher-product-name} Webhook
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/security/rancher-webhook/rancher-webhook.adoc
+++ b/versions/v2.12/modules/en/pages/security/rancher-webhook/rancher-webhook.adoc
@@ -1,5 +1,7 @@
 = {rancher-product-name} Webhook
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-10-21
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/security/sample-psact.adoc
+++ b/versions/v2.12/modules/en/pages/security/sample-psact.adoc
@@ -1,5 +1,7 @@
 = Sample PodSecurityConfiguration
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/security/secrets-hub.adoc
+++ b/versions/v2.12/modules/en/pages/security/secrets-hub.adoc
@@ -1,5 +1,7 @@
 = Secrets
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-13
 :page-revdate: {revdate}
 :experimental:

--- a/versions/v2.12/modules/en/pages/security/security-overview.adoc
+++ b/versions/v2.12/modules/en/pages/security/security-overview.adoc
@@ -1,5 +1,7 @@
 = {rancher-product-name} Security Guides
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-22
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/security/selinux-rpm/about-rancher-selinux.adoc
+++ b/versions/v2.12/modules/en/pages/security/selinux-rpm/about-rancher-selinux.adoc
@@ -1,5 +1,7 @@
 = About rancher-selinux
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/security/selinux-rpm/about-rke2-selinux.adoc
+++ b/versions/v2.12/modules/en/pages/security/selinux-rpm/about-rke2-selinux.adoc
@@ -1,5 +1,7 @@
 = About rke2-selinux
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/security/selinux-rpm/selinux-rpm.adoc
+++ b/versions/v2.12/modules/en/pages/security/selinux-rpm/selinux-rpm.adoc
@@ -1,5 +1,7 @@
 = SELinux RPM
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/troubleshooting/general-troubleshooting.adoc
+++ b/versions/v2.12/modules/en/pages/troubleshooting/general-troubleshooting.adoc
@@ -1,5 +1,7 @@
 = General Troubleshooting
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/troubleshooting/kubernetes-components/kubernetes-components.adoc
+++ b/versions/v2.12/modules/en/pages/troubleshooting/kubernetes-components/kubernetes-components.adoc
@@ -1,5 +1,7 @@
 = Kubernetes Components
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/troubleshooting/kubernetes-components/troubleshooting-controlplane-nodes.adoc
+++ b/versions/v2.12/modules/en/pages/troubleshooting/kubernetes-components/troubleshooting-controlplane-nodes.adoc
@@ -1,5 +1,7 @@
 = Troubleshooting Controlplane Nodes
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/troubleshooting/kubernetes-components/troubleshooting-etcd-nodes.adoc
+++ b/versions/v2.12/modules/en/pages/troubleshooting/kubernetes-components/troubleshooting-etcd-nodes.adoc
@@ -1,5 +1,7 @@
 = Troubleshooting etcd Nodes
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/troubleshooting/kubernetes-components/troubleshooting-nginx-proxy.adoc
+++ b/versions/v2.12/modules/en/pages/troubleshooting/kubernetes-components/troubleshooting-nginx-proxy.adoc
@@ -1,5 +1,7 @@
 = Troubleshooting nginx-proxy
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/troubleshooting/kubernetes-components/troubleshooting-worker-nodes-and-generic-components.adoc
+++ b/versions/v2.12/modules/en/pages/troubleshooting/kubernetes-components/troubleshooting-worker-nodes-and-generic-components.adoc
@@ -1,5 +1,7 @@
 = Troubleshooting Worker Nodes and Generic Components
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/troubleshooting/other-troubleshooting-tips/dns.adoc
+++ b/versions/v2.12/modules/en/pages/troubleshooting/other-troubleshooting-tips/dns.adoc
@@ -1,5 +1,7 @@
 = DNS
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/troubleshooting/other-troubleshooting-tips/kubernetes-resources.adoc
+++ b/versions/v2.12/modules/en/pages/troubleshooting/other-troubleshooting-tips/kubernetes-resources.adoc
@@ -1,5 +1,7 @@
 = Kubernetes Resources
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/troubleshooting/other-troubleshooting-tips/networking.adoc
+++ b/versions/v2.12/modules/en/pages/troubleshooting/other-troubleshooting-tips/networking.adoc
@@ -1,5 +1,7 @@
 = Networking
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-05
 :page-revdate: {revdate}
 

--- a/versions/v2.12/modules/en/pages/troubleshooting/other-troubleshooting-tips/user-id-tracking-in-audit-logs.adoc
+++ b/versions/v2.12/modules/en/pages/troubleshooting/other-troubleshooting-tips/user-id-tracking-in-audit-logs.adoc
@@ -1,5 +1,7 @@
 = User ID Tracking in Audit Logs
+ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
+endif::[]
 :revdate: 2025-08-27
 :page-revdate: {revdate}
 


### PR DESCRIPTION
Turns out preprocessing can't be easily done when building from remote repos. It would require either manipulating the cache or writing a special Antora extension to do replacements, which is an overkill.