### PR TITLE
Add docs for tls-additional

### DIFF
--- a/versions/v2.10/modules/en/pages/installation-and-upgrade/resources/tls-secrets.adoc
+++ b/versions/v2.10/modules/en/pages/installation-and-upgrade/resources/tls-secrets.adoc
@@ -1,6 +1,6 @@
 = Adding TLS Secrets
 :page-languages: [en, zh]
-:revdate: 2024-12-13
+:revdate: 2025-12-01
 :page-revdate: {revdate}
 
 Kubernetes will create all the objects and services for Rancher, but it will not become available until we populate the `tls-rancher-ingress` secret in the `cattle-system` namespace with the certificate and key.

--- a/versions/v2.10/modules/zh/pages/installation-and-upgrade/resources/tls-secrets.adoc
+++ b/versions/v2.10/modules/zh/pages/installation-and-upgrade/resources/tls-secrets.adoc
@@ -1,6 +1,6 @@
 = 添加 TLS 密文
 :page-languages: [en, zh]
-:revdate: 2024-12-13
+:revdate: 2025-12-01
 :page-revdate: {revdate}
 
 我们使用证书和密钥将 `cattle-system` 命名空间中的 `tls-rancher-ingress` 密文配置好后，Kubernetes 会为 Rancher 创建对象和服务。

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/resources/tls-secrets.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/resources/tls-secrets.adoc
@@ -1,6 +1,6 @@
 = Adding TLS Secrets
 :page-languages: [en, zh]
-:revdate: 2025-03-12
+:revdate: 2025-12-01
 :page-revdate: {revdate}
 
 Kubernetes will create all the objects and services for Rancher, but it will not become available until we populate the `tls-rancher-ingress` secret in the `cattle-system` namespace with the certificate and key.

--- a/versions/v2.11/modules/zh/pages/installation-and-upgrade/resources/tls-secrets.adoc
+++ b/versions/v2.11/modules/zh/pages/installation-and-upgrade/resources/tls-secrets.adoc
@@ -1,6 +1,6 @@
 = 添加 TLS 密文
 :page-languages: [en, zh]
-:revdate: 2025-03-12
+:revdate: 2025-12-01
 :page-revdate: {revdate}
 
 我们使用证书和密钥将 `cattle-system` 命名空间中的 `tls-rancher-ingress` 密文配置好后，Kubernetes 会为 Rancher 创建对象和服务。

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/resources/tls-secrets.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/resources/tls-secrets.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-05
+:revdate: 2025-12-01
 :page-revdate: {revdate}
 
 Kubernetes will create all the objects and services for Rancher, but it will not become available until we populate the `tls-rancher-ingress` secret in the `cattle-system` namespace with the certificate and key.

--- a/versions/v2.12/modules/zh/pages/installation-and-upgrade/resources/tls-secrets.adoc
+++ b/versions/v2.12/modules/zh/pages/installation-and-upgrade/resources/tls-secrets.adoc
@@ -1,6 +1,6 @@
 = 添加 TLS 密文
 :page-languages: [en, zh]
-:revdate: 2025-08-05
+:revdate: 2025-12-01
 :page-revdate: {revdate}
 
 我们使用证书和密钥将 `cattle-system` 命名空间中的 `tls-rancher-ingress` 密文配置好后，Kubernetes 会为 Rancher 创建对象和服务。

--- a/versions/v2.13/modules/en/pages/installation-and-upgrade/resources/tls-secrets.adoc
+++ b/versions/v2.13/modules/en/pages/installation-and-upgrade/resources/tls-secrets.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-05
+:revdate: 2025-12-01
 :page-revdate: {revdate}
 
 Kubernetes will create all the objects and services for Rancher, but it will not become available until we populate the `tls-rancher-ingress` secret in the `cattle-system` namespace with the certificate and key.

--- a/versions/v2.13/modules/zh/pages/installation-and-upgrade/resources/tls-secrets.adoc
+++ b/versions/v2.13/modules/zh/pages/installation-and-upgrade/resources/tls-secrets.adoc
@@ -1,6 +1,6 @@
 = 添加 TLS 密文
 :page-languages: [en, zh]
-:revdate: 2025-08-05
+:revdate: 2025-12-01
 :page-revdate: {revdate}
 
 我们使用证书和密钥将 `cattle-system` 命名空间中的 `tls-rancher-ingress` 密文配置好后，Kubernetes 会为 Rancher 创建对象和服务。

--- a/versions/v2.9/modules/en/pages/installation-and-upgrade/resources/tls-secrets.adoc
+++ b/versions/v2.9/modules/en/pages/installation-and-upgrade/resources/tls-secrets.adoc
@@ -1,6 +1,6 @@
 = Adding TLS Secrets
 :page-languages: [en, zh]
-:revdate: 2024-11-25
+:revdate: 2025-12-01
 :page-revdate: {revdate}
 
 Kubernetes will create all the objects and services for Rancher, but it will not become available until we populate the `tls-rancher-ingress` secret in the `cattle-system` namespace with the certificate and key.

--- a/versions/v2.9/modules/zh/pages/installation-and-upgrade/resources/tls-secrets.adoc
+++ b/versions/v2.9/modules/zh/pages/installation-and-upgrade/resources/tls-secrets.adoc
@@ -1,6 +1,6 @@
 = 添加 TLS 密文
 :page-languages: [en, zh]
-:revdate: 2024-11-25
+:revdate: 2025-12-01
 :page-revdate: {revdate}
 
 我们使用证书和密钥将 `cattle-system` 命名空间中的 `tls-rancher-ingress` 密文配置好后，Kubernetes 会为 Rancher 创建对象和服务。


### PR DESCRIPTION
Ports https://github.com/rancher/rancher-docs/pull/1981 which documents the `tls-additional` secret for node drivers that make API requests using a CA different from the one configured for Rancher.


This was made with the help of Copilot, context is: https://github.com/moio/rancher-product-docs/pull/1 as part of experiments for [my HackWeek project trying out Copilot agents](https://hackweek.opensuse.org/25/projects/the-agentic-rancher-experiment-do-androids-dream-of-electric-cattle).


I reviewed this and it looks OK - fundamentally the translation from Markdown to Asciidoc looks fine to me.


What surprised me is the inclusion of the Chinese translation - for which I have absolutely no competence. Should I remove it?