### PR TITLE
Sync Community PRs #2128 ([docs] Update etcd tuning with incorrect RKE1 references) & #2130 ([docs] etcd tuning fix typo etcd-args)

### DIFF
--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/best-practices/tuning-etcd-for-large-installs.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/best-practices/tuning-etcd-for-large-installs.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-09-29
+:revdate: 2026-01-06
 :page-revdate: {revdate}
 
 When Rancher is used to manage xref:installation-and-upgrade/requirements/requirements.adoc[a large infrastructure] it is recommended to increase the default keyspace for etcd from the default 2 GB. The maximum setting is 8 GB and the host should have enough RAM to keep the entire dataset in memory. When increasing this value you should also increase the size of the host. The keyspace size can also be adjusted in smaller installations if you anticipate a high rate of change of pods during the garbage collection interval.
@@ -12,13 +12,10 @@ The etcd data set is automatically cleaned up on a five-minute interval by Kuber
 == Example: This Snippet of the RKE2/K3s config.yaml file Increases the Keyspace Size to 5GB
 
 [,yaml]
+.RKE2/K3s config.yaml
 ----
-# RKE2/K3s config.yaml
----
-services:
-  etcd:
-    extra_args:
-      quota-backend-bytes: 5368709120
+etcd-arg:
+  - "quota-backend-bytes=5368709120"
 ----
 
 == Scaling etcd Disk Performance
@@ -30,15 +27,9 @@ Additionally, to reduce IO contention on the disks for etcd, you can use a dedic
 To implement this solution in an RKE2/K3s cluster, the `/var/lib/etcd/data` and `/var/lib/etcd/wal` directories will need to have disks mounted and formatted on the underlying host. In the `extra_args` directive of the `etcd` service, you must include the `wal_dir` directory. Without specifying the `wal_dir`, etcd process will try to manipulate the underlying `wal` mount with insufficient permissions.
 
 [,yaml]
+.RKE2/K3s config.yaml
 ----
-# RKE2/K3s config.yaml
----
-services:
-  etcd:
-    extra_args:
-      data-dir: '/var/lib/rancher/etcd/data/'
-      wal-dir: '/var/lib/rancher/etcd/wal/wal_dir'
-    extra_binds:
-      - '/var/lib/etcd/data:/var/lib/rancher/etcd/data'
-      - '/var/lib/etcd/wal:/var/lib/rancher/etcd/wal'
+etcd-arg:
+  - "data-dir=/var/lib/etcd/data"
+  - "wal-dir=/var/lib/etcd/wal"
 ----

--- a/versions/v2.12/modules/zh/pages/installation-and-upgrade/best-practices/tuning-etcd-for-large-installs.adoc
+++ b/versions/v2.12/modules/zh/pages/installation-and-upgrade/best-practices/tuning-etcd-for-large-installs.adoc
@@ -1,6 +1,6 @@
 = 为大型安装进行 etcd 调优
 :page-languages: [en, zh]
-:revdate: 2025-09-29
+:revdate: 2026-01-06
 :page-revdate: {revdate}
 
 当你运行具有 15 个或更多集群的大型 Rancher 安装时，我们建议你扩大 etcd 的默认 keyspace（默认为 2GB）。你最大可以将它设置为 8GB。此外，请确保主机有足够的 RAM 来保存整个数据集。如果需要增加这个值，你还需要同步增加主机的大小。如果你预计在垃圾回收间隔期间 Pod 的变化率很高，你也可以在较小的安装中调整 Keyspace 大小。
@@ -10,13 +10,10 @@ Kubernetes 每隔五分钟会自动清理 etcd 数据集。在某些情况下（
 == 示例：此 RKE2/K3s config.yaml 文件的代码片段将 Keyspace 的大小增加到 5GB
 
 [,yaml]
+.RKE2/K3s config.yaml
 ----
-# RKE2/K3s config.yaml
----
-services:
-  etcd:
-    extra_args:
-      quota-backend-bytes: 5368709120
+etcd-arg:
+  - "quota-backend-bytes=5368709120"
 ----
 
 == 扩展 etcd 磁盘性能
@@ -28,15 +25,9 @@ services:
 要在 RKE2/K3s 集群中实现此解决方案，你需要在底层主机上为 `/var/lib/etcd/data` 和 `/var/lib/etcd/wal` 目录挂载并格式化磁盘。`etcd` 服务的 `extra_args` 指令中必须包含 `wal_dir` 目录。如果不指定 `wal_dir`，etcd 进程会尝试在权限不足的情况下操作底层的 `wal` 挂载。
 
 [,yaml]
+.RKE2/K3s config.yaml
 ----
-# RKE2/K3s config.yaml
----
-services:
-  etcd:
-    extra_args:
-      data-dir: '/var/lib/rancher/etcd/data/'
-      wal-dir: '/var/lib/rancher/etcd/wal/wal_dir'
-    extra_binds:
-      - '/var/lib/etcd/data:/var/lib/rancher/etcd/data'
-      - '/var/lib/etcd/wal:/var/lib/rancher/etcd/wal'
+etcd-arg:
+  - "data-dir=/var/lib/etcd/data"
+  - "wal-dir=/var/lib/etcd/wal"
 ----

--- a/versions/v2.13/modules/en/pages/installation-and-upgrade/best-practices/tuning-etcd-for-large-installs.adoc
+++ b/versions/v2.13/modules/en/pages/installation-and-upgrade/best-practices/tuning-etcd-for-large-installs.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-09-29
+:revdate: 2026-01-06
 :page-revdate: {revdate}
 
 When Rancher is used to manage xref:installation-and-upgrade/requirements/requirements.adoc[a large infrastructure] it is recommended to increase the default keyspace for etcd from the default 2 GB. The maximum setting is 8 GB and the host should have enough RAM to keep the entire dataset in memory. When increasing this value you should also increase the size of the host. The keyspace size can also be adjusted in smaller installations if you anticipate a high rate of change of pods during the garbage collection interval.
@@ -12,13 +12,10 @@ The etcd data set is automatically cleaned up on a five-minute interval by Kuber
 == Example: This Snippet of the RKE2/K3s config.yaml file Increases the Keyspace Size to 5GB
 
 [,yaml]
+.RKE2/K3s config.yaml
 ----
-# RKE2/K3s config.yaml
----
-services:
-  etcd:
-    extra_args:
-      quota-backend-bytes: 5368709120
+etcd-arg:
+  - "quota-backend-bytes=5368709120"
 ----
 
 == Scaling etcd Disk Performance
@@ -30,15 +27,9 @@ Additionally, to reduce IO contention on the disks for etcd, you can use a dedic
 To implement this solution in an RKE2/K3s cluster, the `/var/lib/etcd/data` and `/var/lib/etcd/wal` directories will need to have disks mounted and formatted on the underlying host. In the `extra_args` directive of the `etcd` service, you must include the `wal_dir` directory. Without specifying the `wal_dir`, etcd process will try to manipulate the underlying `wal` mount with insufficient permissions.
 
 [,yaml]
+.RKE2/K3s config.yaml
 ----
-# RKE2/K3s config.yaml
----
-services:
-  etcd:
-    extra_args:
-      data-dir: '/var/lib/rancher/etcd/data/'
-      wal-dir: '/var/lib/rancher/etcd/wal/wal_dir'
-    extra_binds:
-      - '/var/lib/etcd/data:/var/lib/rancher/etcd/data'
-      - '/var/lib/etcd/wal:/var/lib/rancher/etcd/wal'
+etcd-arg:
+  - "data-dir=/var/lib/etcd/data"
+  - "wal-dir=/var/lib/etcd/wal"
 ----

--- a/versions/v2.13/modules/zh/pages/installation-and-upgrade/best-practices/tuning-etcd-for-large-installs.adoc
+++ b/versions/v2.13/modules/zh/pages/installation-and-upgrade/best-practices/tuning-etcd-for-large-installs.adoc
@@ -1,6 +1,6 @@
 = 为大型安装进行 etcd 调优
 :page-languages: [en, zh]
-:revdate: 2025-09-29
+:revdate: 2026-01-06
 :page-revdate: {revdate}
 
 当你运行具有 15 个或更多集群的大型 Rancher 安装时，我们建议你扩大 etcd 的默认 keyspace（默认为 2GB）。你最大可以将它设置为 8GB。此外，请确保主机有足够的 RAM 来保存整个数据集。如果需要增加这个值，你还需要同步增加主机的大小。如果你预计在垃圾回收间隔期间 Pod 的变化率很高，你也可以在较小的安装中调整 Keyspace 大小。
@@ -10,13 +10,10 @@ Kubernetes 每隔五分钟会自动清理 etcd 数据集。在某些情况下（
 == 示例：此 RKE2/K3s config.yaml 文件的代码片段将 Keyspace 的大小增加到 5GB
 
 [,yaml]
+.RKE2/K3s config.yaml
 ----
-# RKE2/K3s config.yaml
----
-services:
-  etcd:
-    extra_args:
-      quota-backend-bytes: 5368709120
+etcd-arg:
+  - "quota-backend-bytes=5368709120"
 ----
 
 == 扩展 etcd 磁盘性能
@@ -28,15 +25,9 @@ services:
 要在 RKE2/K3s 集群中实现此解决方案，你需要在底层主机上为 `/var/lib/etcd/data` 和 `/var/lib/etcd/wal` 目录挂载并格式化磁盘。`etcd` 服务的 `extra_args` 指令中必须包含 `wal_dir` 目录。如果不指定 `wal_dir`，etcd 进程会尝试在权限不足的情况下操作底层的 `wal` 挂载。
 
 [,yaml]
+.RKE2/K3s config.yaml
 ----
-# RKE2/K3s config.yaml
----
-services:
-  etcd:
-    extra_args:
-      data-dir: '/var/lib/rancher/etcd/data/'
-      wal-dir: '/var/lib/rancher/etcd/wal/wal_dir'
-    extra_binds:
-      - '/var/lib/etcd/data:/var/lib/rancher/etcd/data'
-      - '/var/lib/etcd/wal:/var/lib/rancher/etcd/wal'
+etcd-arg:
+  - "data-dir=/var/lib/etcd/data"
+  - "wal-dir=/var/lib/etcd/wal"
 ----


### PR DESCRIPTION
Related to https://github.com/rancher/rancher-product-docs/issues/649 and https://github.com/rancher/rancher-product-docs/issues/648