### PR TITLE
Update Links - Release Notes

### DIFF
--- a/versions/v2.11/modules/en/pages/release-notes/v2.11.9.adoc
+++ b/versions/v2.11/modules/en/pages/release-notes/v2.11.9.adoc
@@ -18,7 +18,7 @@ For more information on new features in the general minor release see the https:
 
 == Changes Since v2.11.8
 
-See the full list of https://github.com/rancher/rancher/compare/v2.11.8...v2.11.9[changes].
+See the full list of https://github.com/rancher/rancher/compare/v2.11.8%E2%80%A6v2.11.9[changes].
 
 == Install/Upgrade Notes
 

--- a/versions/v2.11/modules/en/pages/release-notes/v2.11.9.adoc
+++ b/versions/v2.11/modules/en/pages/release-notes/v2.11.9.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-12-16
+:revdate: 2026-01-14
 :page-revdate: {revdate}
 
 [IMPORTANT]

--- a/versions/v2.11/modules/zh/pages/release-notes/v2.11.9.adoc
+++ b/versions/v2.11/modules/zh/pages/release-notes/v2.11.9.adoc
@@ -18,7 +18,7 @@ For more information on new features in the general minor release see the https:
 
 == Changes Since v2.11.8
 
-See the full list of https://github.com/rancher/rancher/compare/v2.11.8...v2.11.9[changes].
+See the full list of https://github.com/rancher/rancher/compare/v2.11.8%E2%80%A6v2.11.9[changes].
 
 == Install/Upgrade Notes
 

--- a/versions/v2.11/modules/zh/pages/release-notes/v2.11.9.adoc
+++ b/versions/v2.11/modules/zh/pages/release-notes/v2.11.9.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-12-16
+:revdate: 2026-01-14
 :page-revdate: {revdate}
 
 [IMPORTANT]

--- a/versions/v2.12/modules/en/pages/release-notes/v2.12.5.adoc
+++ b/versions/v2.12/modules/en/pages/release-notes/v2.12.5.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-12-16
+:revdate: 2026-01-14
 :page-revdate: {revdate}
 
 [IMPORTANT]

--- a/versions/v2.12/modules/en/pages/release-notes/v2.12.5.adoc
+++ b/versions/v2.12/modules/en/pages/release-notes/v2.12.5.adoc
@@ -29,7 +29,7 @@ For more information on new features in the general minor release see the https:
 
 == Changes Since v2.12.4
 
-See the full list of https://github.com/rancher/rancher/compare/v2.12.4...v2.12.5[changes].
+See the full list of https://github.com/rancher/rancher/compare/v2.12.4%E2%80%A6v2.12.5[changes].
 
 == Install/Upgrade Notes
 

--- a/versions/v2.12/modules/zh/pages/release-notes/v2.12.5.adoc
+++ b/versions/v2.12/modules/zh/pages/release-notes/v2.12.5.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-12-16
+:revdate: 2026-01-14
 :page-revdate: {revdate}
 
 [IMPORTANT]

--- a/versions/v2.12/modules/zh/pages/release-notes/v2.12.5.adoc
+++ b/versions/v2.12/modules/zh/pages/release-notes/v2.12.5.adoc
@@ -29,7 +29,7 @@ For more information on new features in the general minor release see the https:
 
 == Changes Since v2.12.4
 
-See the full list of https://github.com/rancher/rancher/compare/v2.12.4...v2.12.5[changes].
+See the full list of https://github.com/rancher/rancher/compare/v2.12.4%E2%80%A6v2.12.5[changes].
 
 == Install/Upgrade Notes
 


### PR DESCRIPTION
Updating 'full list of changes' link in release notes to use UTF-8 hexadecimal encoding for the ellipsis character. Currently shows users a blank list of changes.