### PR TITLE
generate-release-notes: Generate RN for all versions found by default

### DIFF
--- a/.github/workflows/generate-release-notes.yml
+++ b/.github/workflows/generate-release-notes.yml
@@ -74,8 +74,8 @@ jobs:
 
             # Re-add title to release notes.
             # A pandoc bug?
-            TITLE_LINE=$(head -n 1 "$INPUT_FILE" | sed 's/^=/#/')
-            sed -i "1i${TITLE_LINE}\n" "$MARKDOWN_FILE"
+            TITLE_TEXT=$(grep -oP '(?<=<title>).*?(?=</title>)' "$XML_FILE" | head -n 1)
+            sed -i "1i# ${TITLE_TEXT}\n" "$MARKDOWN_FILE"
           done
 
       - name: Deploy to release-notes-build branch


### PR DESCRIPTION
* Allow for specifying a version on input.
* Workaround for re-adding title
  Can't source from adoc attributes since not all *.adoc files have
  them implemented.