### PR TITLE
v2.11.10 - Rancher Manager Release Maintenance PT2

### DIFF
--- a/versions/v2.11/modules/en/pages/release-notes.adoc
+++ b/versions/v2.11/modules/en/pages/release-notes.adoc
@@ -13,7 +13,7 @@
 | xref:release-notes/v2.11.10.adoc[View] / https://github.com/rancher/rancher/releases/tag/v2.11.10[GitHub Release]
 | N/A
 | &#10003;
-| &#10003;
+| N/A
 // DO NOT EDIT THIS LINE, REQUIRED BY RELEASE SCRIPT. CURRENT VERSION END.
 
 |===

--- a/versions/v2.11/modules/en/pages/security/rancher-webhook/rancher-webhook.adoc
+++ b/versions/v2.11/modules/en/pages/security/rancher-webhook/rancher-webhook.adoc
@@ -20,7 +20,7 @@ NOTE: Rancher manages deployment and upgrade of the webhook. Under most circumst
 | v2.11.10
 | v0.7.8
 | &#10003;
-| &#10003;
+| &cross;
 
 | v2.11.9
 | v0.7.8

--- a/versions/v2.11/modules/zh/pages/release-notes.adoc
+++ b/versions/v2.11/modules/zh/pages/release-notes.adoc
@@ -13,7 +13,7 @@
 | xref:release-notes/v2.11.10.adoc[View] / https://github.com/rancher/rancher/releases/tag/v2.11.10[GitHub Release]
 | N/A
 | &#10003;
-| &#10003;
+| N/A
 // DO NOT EDIT THIS LINE, REQUIRED BY RELEASE SCRIPT. CURRENT VERSION END.
 
 |===

--- a/versions/v2.11/modules/zh/pages/security/rancher-webhook/rancher-webhook.adoc
+++ b/versions/v2.11/modules/zh/pages/security/rancher-webhook/rancher-webhook.adoc
@@ -20,7 +20,7 @@ Rancher 将 Rancher-Webhook 作为单独的 deployment 和服务部署在 local 
 | v2.11.10
 | v0.7.8
 | &#10003;
-| &#10003;
+| &cross;
 
 | v2.11.9
 | v0.7.8


### PR DESCRIPTION
- Fixes release maintenance table entries labeling v2.11.10 release as a community release.
- Related to https://github.com/rancher/rancher-product-docs/issues/659 and https://github.com/rancher/rancher-product-docs/pull/691.