### PR TITLE
Update Community CSS

### DIFF
--- a/community-supplemental-files/css/site-extra.css
+++ b/community-supplemental-files/css/site-extra.css
@@ -403,6 +403,12 @@ img.langIcon.korea {
   border-bottom: 1px solid #c0c2c4;
 }
 
+.sidebar .toc-menu a.is-active {
+  color: #326ce5;
+  border-left-color: #326ce5;
+  font-weight: 600;
+}
+
 .sidebar .toc-menu li:hover {
   color: #ffffff;
   background-color: #326ce5;

--- a/community-supplemental-files/css/site-extra.css
+++ b/community-supplemental-files/css/site-extra.css
@@ -72,7 +72,7 @@ i.fa[title='Tip:'] {
 }
 
 .nav-container {
-  width: calc(270 / 18 * 1rem);
+  width: calc(270 / 16 * 1rem);
 }
 
 @media screen and (min-width: 1024px) {
@@ -214,6 +214,28 @@ a.navbar-logo {
 
 .nav-panel-explore .context .title {
   flex: auto;
+}
+
+.nav-panel-explore .components .component .title {
+  font-weight: 500;
+  background: #efefef;
+  padding-left: .1em;
+}
+
+.nav-panel-explore .components .component .title a {
+  color: #326ce5;
+  font-weight: 800;
+}
+
+.nav-panel-explore .components .component .title a:hover {
+  color: #326ce5;
+  text-decoration: underline;
+  font-weight: 800;
+}
+
+.nav-panel-explore .component+.component {
+  margin-top: .5rem;
+  border-top-style: ridge;
 }
 
 /* Left Nav Link styles  */

--- a/community-supplemental-files/js/vendor/toc-active.js
+++ b/community-supplemental-files/js/vendor/toc-active.js
@@ -1,0 +1,22 @@
+window.addEventListener('DOMContentLoaded', () => {
+  const observer = new IntersectionObserver(entries => {
+    entries.forEach(entry => {
+      const id = entry.target.getAttribute('id');
+      if (id) {
+        // Find the link in the right-hand TOC pointing to this ID
+        const tocLink = document.querySelector(`.toc-menu a[href="#${id}"]`);
+        
+        if (entry.intersectionRatio > 0) {
+          // Remove active class from all and add to the current one
+          document.querySelectorAll('.toc-menu a').forEach(nav => nav.classList.remove('is-active'));
+          tocLink?.classList.add('is-active');
+        }
+      }
+    });
+  }, { rootMargin: '-10% 0px -80% 0px' }); // Adjust margins to trigger highlight earlier/later
+
+  // Track all headings that Antora generates with IDs
+  document.querySelectorAll('h2[id], h3[id], h4[id]').forEach((section) => {
+    observer.observe(section);
+  });
+});

--- a/community-supplemental-files/js/vendor/toc-active.js
+++ b/community-supplemental-files/js/vendor/toc-active.js
@@ -1,3 +1,4 @@
+// This is a helper script that adds scroll-sync with the right-side TOC menu headers relative to your location in the body content.
 window.addEventListener('DOMContentLoaded', () => {
   const observer = new IntersectionObserver(entries => {
     entries.forEach(entry => {

--- a/community-supplemental-files/partials/footer-scripts.hbs
+++ b/community-supplemental-files/partials/footer-scripts.hbs
@@ -5,5 +5,4 @@
 {{/if}}
 <script src="{{uiRootPath}}/js/vendor/langSelection.js"></script>
 <script async src="{{{uiRootPath}}}/js/vendor/tabs.js"></script>
-
-
+<script src="{{{uiRootPath}}}/js/vendor/toc-active.js"></script>


### PR DESCRIPTION
Updating the Community Supplemental CSS with a scroll-sync with the right-side TOC headers relative to your location in the body content. There is a file added `toc-active.js` which is a script to track generated Antora headings that matches the HREFS in the TOC. This is injected into the HTML files via `footer-scripts.hbs`, and can be adjusted to display the active heading earlier/later.

Additionally, updating the bottom version nav component section to sync with DSC style.