### PR TITLE
Enhance air-gapped migration instructions for Rancher backup and restore

### DIFF
--- a/versions/v2.10/modules/en/pages/rancher-admin/back-up-restore-and-disaster-recovery/migrate-to-a-new-cluster.adoc
+++ b/versions/v2.10/modules/en/pages/rancher-admin/back-up-restore-and-disaster-recovery/migrate-to-a-new-cluster.adoc
@@ -1,6 +1,6 @@
 = Migrating {rancher-product-name} to a New Cluster
 :page-languages: [en, zh]
-:revdate: 2026-01-15
+:revdate: 2026-02-11
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster
 :product-path: rancher-admin/back-up-restore-and-disaster-recovery/migrate-to-a-new-cluster

--- a/versions/v2.11/modules/en/pages/rancher-admin/back-up-restore-and-disaster-recovery/migrate-to-a-new-cluster.adoc
+++ b/versions/v2.11/modules/en/pages/rancher-admin/back-up-restore-and-disaster-recovery/migrate-to-a-new-cluster.adoc
@@ -1,6 +1,6 @@
 = Migrating {rancher-product-name} to a New Cluster
 :page-languages: [en, zh]
-:revdate: 2026-01-15
+:revdate: 2026-02-11
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster
 :product-path: rancher-admin/back-up-restore-and-disaster-recovery/migrate-to-a-new-cluster

--- a/versions/v2.12/modules/en/pages/rancher-admin/back-up-restore-and-disaster-recovery/migrate-to-a-new-cluster.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/back-up-restore-and-disaster-recovery/migrate-to-a-new-cluster.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2026-01-15
+:revdate: 2026-02-11
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster
 :product-path: rancher-admin/back-up-restore-and-disaster-recovery/migrate-to-a-new-cluster

--- a/versions/v2.13/modules/en/pages/rancher-admin/back-up-restore-and-disaster-recovery/migrate-to-a-new-cluster.adoc
+++ b/versions/v2.13/modules/en/pages/rancher-admin/back-up-restore-and-disaster-recovery/migrate-to-a-new-cluster.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2026-01-26
+:revdate: 2026-02-11
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster
 :product-path: rancher-admin/back-up-restore-and-disaster-recovery/migrate-to-a-new-cluster

--- a/versions/v2.8/modules/en/pages/rancher-admin/back-up-restore-and-disaster-recovery/migrate-to-a-new-cluster.adoc
+++ b/versions/v2.8/modules/en/pages/rancher-admin/back-up-restore-and-disaster-recovery/migrate-to-a-new-cluster.adoc
@@ -1,6 +1,6 @@
 = Migrating {rancher-product-name} to a New Cluster
 :page-languages: [en, zh]
-:revdate: 2025-05-14
+:revdate: 2026-02-11
 :page-revdate: {revdate}
 
 If you are migrating Rancher to a new Kubernetes cluster, you don't need to install Rancher on the new cluster first. If Rancher is restored to a new cluster with Rancher already installed, it can cause problems.

--- a/versions/v2.9/modules/en/pages/rancher-admin/back-up-restore-and-disaster-recovery/migrate-to-a-new-cluster.adoc
+++ b/versions/v2.9/modules/en/pages/rancher-admin/back-up-restore-and-disaster-recovery/migrate-to-a-new-cluster.adoc
@@ -1,6 +1,6 @@
 = Migrating {rancher-product-name} to a New Cluster
 :page-languages: [en, zh]
-:revdate: 2025-12-09
+:revdate: 2026-02-11
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster
 :product-path: rancher-admin/back-up-restore-and-disaster-recovery/migrate-to-a-new-cluster


### PR DESCRIPTION
The purpose of this PR is to improve the Rancher migration documentation (using the rancher-backup operator), to cover use-cases where the environment is fully air-gapped, and the user runs helm commands from a host without internet access. In this instance the user needs to first fetch the charts from a non-air-gapped host, and then copy them to the host with access to the cluster, from which they run the helm commands.

Same changes as merged to community in https://github.com/rancher/rancher-docs/pull/2180