### PR TITLE
#707 Address issues with generated release notes

### DIFF
--- a/.github/workflows/generate-release-notes.yml
+++ b/.github/workflows/generate-release-notes.yml
@@ -65,12 +65,23 @@ jobs:
             # Convert AsciiDoc to DocBook
             asciidoctor -v -a build-type=community -b docbook5 -o "$XML_FILE" "$INPUT_FILE"
 
+            # Workaround for admonition boxes with lists and no preceding para
+            # A pandoc bug?
+            sed -i '/^<important>$/{N;s/^<important>\n<itemizedlist>/<important><simpara>\&#8203;<\/simpara>\n<itemizedlist>/}' "$XML_FILE"
+
             # Convert DocBook to GitHub-Flavored Markdown
             pandoc -v
             pandoc --from docbook \
                    --to gfm \
+                   --wrap=none \
                    --output "$MARKDOWN_FILE" \
                    "$XML_FILE"
+
+            # Remove the empty lines added by the workaround above
+            sed -i '/^> \[!IMPORTANT\]$/{N;N;s/\n>.*\n>.*//}' "$MARKDOWN_FILE"
+
+            # Add an extra # to each Markdown header due to a missing title
+            sed -i 's/^#/##/' "$MARKDOWN_FILE"
 
             # Re-add title to release notes.
             # A pandoc bug?

--- a/versions/v2.10/modules/en/pages/release-notes/v2.10.11.adoc
+++ b/versions/v2.10/modules/en/pages/release-notes/v2.10.11.adoc
@@ -187,11 +187,11 @@ Two new agent environment variables have been added for Windows nodes, `CATTLE_E
 Additionally, Windows nodes will now attempt to execute plans multiple times if the initial application fails, up to 5 times. This change, as well as appropriate use of the above two agent environment variables, aims to address plan failures for Windows nodes after a node reboot.
 +
 See https://github.com/rancher/rancher/issues/42458[#42458].
-** A change was made starting with RKE2 versions `v1.28.15`, `v1.29.10`, `v1.30.6` and `v1.31.2` on Windows which allows the user to configure `*_PROXY` environment variables on the `rke2` service after the node has already been provisioned.
+** A change was made starting with RKE2 versions `v1.28.15`, `v1.29.10`, `v1.30.6` and `v1.31.2` on Windows which allows the user to configure `+*_PROXY+` environment variables on the `rke2` service after the node has already been provisioned.
 +
-Previously any attempt to do so would be a no-op. With this change, If the `*_PROXY` environment variables are set on the cluster _after_ a Windows node is provisioned, they can be automatically removed from the `rke2` service. However, if the variables are set _before_ the node is provisioned, they cannot be removed.
+Previously any attempt to do so would be a no-op. With this change, If the `+*_PROXY+` environment variables are set on the cluster _after_ a Windows node is provisioned, they can be automatically removed from the `rke2` service. However, if the variables are set _before_ the node is provisioned, they cannot be removed.
 +
-More information can be found https://github.com/rancher/rancher/issues/47839[here]. A workaround is to remove the environment variables from the `rancher-wins` service and restart the service or node. At which point `*_PROXY` environment variables will no longer be set on either service.
+More information can be found https://github.com/rancher/rancher/issues/47839[here]. A workaround is to remove the environment variables from the `rancher-wins` service and restart the service or node. At which point `+*_PROXY+` environment variables will no longer be set on either service.
 +
 [source,shell]
 ----


### PR DESCRIPTION
Related to #707.

Use --wrap=none.

Add workaround for admonition boxes with lists and no preceding para. A pandoc bug?

Add an extra # to each Markdown header due to a missing title.

Use passthrough for *_PROXY to avoid invalid XML.