### PR TITLE
Sync Community PR #2179: Documents node draining behavior during Rancher upgrades

### DIFF
--- a/playbook-product-local.yml
+++ b/playbook-product-local.yml
@@ -7,7 +7,7 @@ content:
   sources: 
   - url: .
     branches: HEAD
-    start_paths: [shared, versions/v2.13]
+    start_paths: [shared, versions/v2.13, versions/v2.12, versions/v2.11, versions/v2.10, versions/v2.9, versions/v2.8]
 ui:
   bundle:
     url: https://github.com/SUSEdoc/dsc-style-bundle/blob/main/default-ui/ui-bundle.zip?raw=true

--- a/versions/v2.10/modules/en/pages/cluster-admin/backups-and-restore/backups-and-restore.adoc
+++ b/versions/v2.10/modules/en/pages/cluster-admin/backups-and-restore/backups-and-restore.adoc
@@ -1,6 +1,6 @@
 = Upgrading and Rolling Back Kubernetes
 :page-languages: [en, zh]
-:revdate: 2025-03-17
+:revdate: 2026-02-11
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/upgrade-and-roll-back-kubernetes 
 :product-path: cluster-admin/backups-and-restore/backups-and-restore
@@ -95,8 +95,8 @@ To enable draining each node during a cluster upgrade,
 
 [NOTE]
 ====
-
-There is a https://github.com/rancher/rancher/issues/25478[known issue] in which the Rancher UI doesn't show the state of etcd and controlplane as drained, even though they are being drained.
+* There is a https://github.com/rancher/rancher/issues/25478[known issue] in which the Rancher UI doesn't show the state of etcd and controlplane as drained, even though they are being drained.
+* During an upgrade, nodes may be drained even when no user-visible YAML changes are present. This can occur if non-dynamic configuration files are updated or if a new `system-agent-installer` image is introduced. In such cases, Rancher generates a new upgrade plan, resulting in a new plan hash. When `Upgrade Strategy` is set to `Drain nodes`, this plan change can trigger node draining.
 ====
 
 

--- a/versions/v2.11/modules/en/pages/cluster-admin/backups-and-restore/backups-and-restore.adoc
+++ b/versions/v2.11/modules/en/pages/cluster-admin/backups-and-restore/backups-and-restore.adoc
@@ -1,6 +1,6 @@
 = Upgrading and Rolling Back Kubernetes
 :page-languages: [en, zh]
-:revdate: 2025-03-17
+:revdate: 2026-02-11
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/upgrade-and-roll-back-kubernetes 
 :product-path: cluster-admin/backups-and-restore/backups-and-restore
@@ -95,8 +95,8 @@ To enable draining each node during a cluster upgrade,
 
 [NOTE]
 ====
-
-There is a https://github.com/rancher/rancher/issues/25478[known issue] in which the Rancher UI doesn't show the state of etcd and controlplane as drained, even though they are being drained.
+* There is a https://github.com/rancher/rancher/issues/25478[known issue] in which the Rancher UI doesn't show the state of etcd and controlplane as drained, even though they are being drained.
+* During an upgrade, nodes may be drained even when no user-visible YAML changes are present. This can occur if non-dynamic configuration files are updated or if a new `system-agent-installer` image is introduced. In such cases, Rancher generates a new upgrade plan, resulting in a new plan hash. When `Upgrade Strategy` is set to `Drain nodes`, this plan change can trigger node draining.
 ====
 
 

--- a/versions/v2.12/modules/en/pages/cluster-admin/backups-and-restore/backups-and-restore.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-admin/backups-and-restore/backups-and-restore.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-05
+:revdate: 2026-02-11
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/upgrade-and-roll-back-kubernetes 
 :product-path: cluster-admin/backups-and-restore/backups-and-restore
@@ -97,8 +97,8 @@ To enable draining each node during a cluster upgrade,
 
 [NOTE]
 ====
-
-There is a https://github.com/rancher/rancher/issues/25478[known issue] in which the Rancher UI doesn't show the state of etcd and controlplane as drained, even though they are being drained.
+* There is a https://github.com/rancher/rancher/issues/25478[known issue] in which the Rancher UI doesn't show the state of etcd and controlplane as drained, even though they are being drained.
+* During an upgrade, nodes may be drained even when no user-visible YAML changes are present. This can occur if non-dynamic configuration files are updated or if a new `system-agent-installer` image is introduced. In such cases, Rancher generates a new upgrade plan, resulting in a new plan hash. When `Upgrade Strategy` is set to `Drain nodes`, this plan change can trigger node draining.
 ====
 
 

--- a/versions/v2.13/modules/en/pages/cluster-admin/backups-and-restore/backups-and-restore.adoc
+++ b/versions/v2.13/modules/en/pages/cluster-admin/backups-and-restore/backups-and-restore.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-05
+:revdate: 2026-02-11
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/upgrade-and-roll-back-kubernetes 
 :product-path: cluster-admin/backups-and-restore/backups-and-restore
@@ -97,8 +97,8 @@ To enable draining each node during a cluster upgrade,
 
 [NOTE]
 ====
-
-There is a https://github.com/rancher/rancher/issues/25478[known issue] in which the Rancher UI doesn't show the state of etcd and controlplane as drained, even though they are being drained.
+* There is a https://github.com/rancher/rancher/issues/25478[known issue] in which the Rancher UI doesn't show the state of etcd and controlplane as drained, even though they are being drained.
+* During an upgrade, nodes may be drained even when no user-visible YAML changes are present. This can occur if non-dynamic configuration files are updated or if a new `system-agent-installer` image is introduced. In such cases, Rancher generates a new upgrade plan, resulting in a new plan hash. When `Upgrade Strategy` is set to `Drain nodes`, this plan change can trigger node draining.
 ====
 
 

--- a/versions/v2.9/modules/en/pages/cluster-admin/backups-and-restore/backups-and-restore.adoc
+++ b/versions/v2.9/modules/en/pages/cluster-admin/backups-and-restore/backups-and-restore.adoc
@@ -1,6 +1,6 @@
 = Upgrading and Rolling Back Kubernetes
 :page-languages: [en, zh]
-:revdate: 2025-03-17
+:revdate: 2026-02-11
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/upgrade-and-roll-back-kubernetes 
 :product-path: cluster-admin/backups-and-restore/backups-and-restore
@@ -95,8 +95,8 @@ To enable draining each node during a cluster upgrade,
 
 [NOTE]
 ====
-
-There is a https://github.com/rancher/rancher/issues/25478[known issue] in which the Rancher UI doesn't show the state of etcd and controlplane as drained, even though they are being drained.
+* There is a https://github.com/rancher/rancher/issues/25478[known issue] in which the Rancher UI doesn't show the state of etcd and controlplane as drained, even though they are being drained.
+* During an upgrade, nodes may be drained even when no user-visible YAML changes are present. This can occur if non-dynamic configuration files are updated or if a new `system-agent-installer` image is introduced. In such cases, Rancher generates a new upgrade plan, resulting in a new plan hash. When `Upgrade Strategy` is set to `Drain nodes`, this plan change can trigger node draining.
 ====
 
 


### PR DESCRIPTION
Fixes #735 

Also adds back version sources into playbook-product-local.yml removed during single source testing.