### PR TITLE
Update upgrade steps for upgrading from v2.13.1

### DIFF
--- a/versions/v2.13/modules/en/pages/installation-and-upgrade/upgrades.adoc
+++ b/versions/v2.13/modules/en/pages/installation-and-upgrade/upgrades.adoc
@@ -207,6 +207,12 @@ Upgrade Rancher to the latest version with all your settings.
 
 Take all the values from the previous step and append them to the command using `--set key=value`.
 
+----
+helm upgrade rancher rancher-prime/rancher \
+  --namespace cattle-system \
+  --set hostname=rancher.my.org
+----
+
 [NOTE]
 ====
 

--- a/versions/v2.13/modules/en/pages/installation-and-upgrade/upgrades.adoc
+++ b/versions/v2.13/modules/en/pages/installation-and-upgrade/upgrades.adoc
@@ -163,11 +163,11 @@ If you are upgrading cert-manager to the latest version from v1.5 or below, foll
 [IMPORTANT]
 .Upgrading from Rancher v2.13.1
 ====
-In Rancher v2.13.2, the Helm chart name has reverted from `rancher-prime` back to `rancher`. If you are upgrading from v2.13.1, the existing Ingress resource created by the previous chart will conflict with the new one, causing the upgrade to fail with an error similar to:
+In Rancher v2.13.2, the Helm chart name has reverted from `rancher-prime` back to `rancher`. If you are upgrading from v2.13.1, the existing Ingress resource created by the previous chart conflicts with the new one, causing the upgrade to fail with an error similar to:
 
 [,shell]
 ----
-Error: UPGRADE FAILED: failed to create resource: admission webhook "validate.nginx.ingress.kubernetes.io" denied the request: host "<HOSTNAME>" and path "/" is already defined in ingress cattle-system/rancher-rancher-prime
+Error: UPGRADE FAILED: failed to create resource: admission webhook "validate.nginx.ingress.kubernetes.io" denied the request: host "rancher.my.org" and path "/" is already defined in ingress cattle-system/rancher-rancher-prime
 ----
 
 To prevent or resolve this issue, you must manually delete the old Ingress before completing the upgrade:
@@ -194,7 +194,7 @@ helm upgrade rancher rancher-prime/rancher \
   --namespace cattle-system \
   -f rancher-values.yaml \
   --set hostname=rancher.my.org \
-  --version "~2.13.2"
+  --version 2.13.2
 ----
 
 . After the upgrade completes, verify that the new ingress has been successfully created and is pointing to the correct hostname:

--- a/versions/v2.13/modules/en/pages/installation-and-upgrade/upgrades.adoc
+++ b/versions/v2.13/modules/en/pages/installation-and-upgrade/upgrades.adoc
@@ -125,6 +125,23 @@ This section describes how to upgrade normal (Internet-connected) or air-gapped 
 If you are installing Rancher in an air-gapped environment, skip the rest of this page and render the Helm template by following the instructions on {xref-air-gap-upgrade}[this page.]
 ====
 
+[IMPORTANT]
+.Upgrading from Rancher v2.13.1
+====
+In Rancher v2.13.2, the Helm chart name has reverted from `rancher-prime` back to `rancher`. If you are upgrading from v2.13.1, the existing Ingress resource created by the previous chart conflicts with the new one, causing the upgrade to fail with an error similar to:
+
+[,shell]
+----
+Error: UPGRADE FAILED: failed to create resource: admission webhook "validate.nginx.ingress.kubernetes.io" denied the request: host "rancher.my.org" and path "/" is already defined in ingress cattle-system/rancher-rancher-prime
+----
+
+To prevent or resolve this issue, you must manually delete the old Ingress before completing the upgrade:
+
+[,shell]
+----
+kubectl delete ingress rancher-rancher-prime -n cattle-system
+----
+====
 
 Get the values, which were passed with `--set`, from the current Rancher Helm chart that is installed.
 
@@ -183,24 +200,6 @@ helm get values rancher -n cattle-system -o yaml > rancher-values.yaml
 [,shell]
 ----
 kubectl delete ingress rancher-rancher-prime -n cattle-system
-----
-
-. Run the upgrade command using the updated chart reference:
-+
-[,shell]
-----
-helm upgrade rancher rancher-prime/rancher \
-  --namespace cattle-system \
-  -f rancher-values.yaml \
-  --set hostname=rancher.my.org \
-  --version 2.13.2
-----
-
-. After the upgrade completes, verify that the new ingress has been successfully created and is pointing to the correct hostname:
-+
-[,shell]
-----
-kubectl get ingress -n cattle-system rancher
 ----
 ====
 

--- a/versions/v2.13/modules/en/pages/installation-and-upgrade/upgrades.adoc
+++ b/versions/v2.13/modules/en/pages/installation-and-upgrade/upgrades.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2026-04-21
+:revdate: 2026-05-06
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/upgrades.adoc 
 :product-path: installation-and-upgrade/upgrades.adoc
@@ -158,7 +158,6 @@ hostname: rancher.my.org
 If you are upgrading cert-manager to the latest version from v1.5 or below, follow the {xref-upgrade-certmanager}#_option_c_upgrade_cert_manager_from_versions_15_and_below[cert-manager upgrade docs] to learn how to upgrade cert-manager without needing to perform an uninstall or reinstall of Rancher. Otherwise, follow the <<_steps_to_upgrade_rancher,steps to upgrade Rancher>> below.
 
 ==== Steps to Upgrade Rancher
-
 
 [IMPORTANT]
 .Upgrading from Rancher v2.13.1

--- a/versions/v2.13/modules/en/pages/installation-and-upgrade/upgrades.adoc
+++ b/versions/v2.13/modules/en/pages/installation-and-upgrade/upgrades.adoc
@@ -159,17 +159,55 @@ If you are upgrading cert-manager to the latest version from v1.5 or below, foll
 
 ==== Steps to Upgrade Rancher
 
-Upgrade Rancher to the latest version with all your settings.
 
-Take all the values from the previous step and append them to the command using `--set key=value`.
+[IMPORTANT]
+.Upgrading from Rancher v2.13.1
+====
+In Rancher v2.13.2, the Helm chart name has reverted from `rancher-prime` back to `rancher`. If you are upgrading from v2.13.1, the existing Ingress resource created by the previous chart will conflict with the new one, causing the upgrade to fail with an error similar to:
 
-include::shared:ROOT:partial$en/rancher-chart-rename.adoc[]
+[,shell]
+----
+Error: UPGRADE FAILED: failed to create resource: admission webhook "validate.nginx.ingress.kubernetes.io" denied the request: host "<HOSTNAME>" and path "/" is already defined in ingress cattle-system/rancher-rancher-prime
+----
 
+To prevent or resolve this issue, you must manually delete the old Ingress before completing the upgrade:
+
+. Export your current Helm values to ensure all settings (like hostname and private CA data) are preserved:
++
+[,shell]
+----
+helm get values rancher -n cattle-system -o yaml > rancher-values.yaml
+----
+
+. Delete the conflicting Ingress resource:
++
+[,shell]
+----
+kubectl delete ingress rancher-rancher-prime -n cattle-system
+----
+
+. Run the upgrade command using the updated chart reference:
++
+[,shell]
 ----
 helm upgrade rancher rancher-prime/rancher \
   --namespace cattle-system \
-  --set hostname=rancher.my.org
+  -f rancher-values.yaml \
+  --set hostname=rancher.my.org \
+  --version "~2.13.2"
 ----
+
+. After the upgrade completes, verify that the new ingress has been successfully created and is pointing to the correct hostname:
++
+[,shell]
+----
+kubectl get ingress -n cattle-system rancher
+----
+====
+
+Upgrade Rancher to the latest version with all your settings.
+
+Take all the values from the previous step and append them to the command using `--set key=value`.
 
 [NOTE]
 ====

--- a/versions/v2.14/modules/en/pages/installation-and-upgrade/upgrades.adoc
+++ b/versions/v2.14/modules/en/pages/installation-and-upgrade/upgrades.adoc
@@ -188,6 +188,12 @@ Upgrade Rancher to the latest version with all your settings.
 
 Take all the values from the previous step and append them to the command using `--set key=value`.
 
+----
+helm upgrade rancher rancher-prime/rancher \
+  --namespace cattle-system \
+  --set hostname=rancher.my.org
+----
+
 [NOTE]
 ====
 

--- a/versions/v2.14/modules/en/pages/installation-and-upgrade/upgrades.adoc
+++ b/versions/v2.14/modules/en/pages/installation-and-upgrade/upgrades.adoc
@@ -132,6 +132,23 @@ This section describes how to upgrade normal (Internet-connected) or air-gapped 
 If you are installing Rancher in an air-gapped environment, skip the rest of this page and render the Helm template by following the instructions on {xref-air-gap-upgrade}[this page.]
 ====
 
+[IMPORTANT]
+.Upgrading from Rancher v2.13.1
+====
+In Rancher v2.13.2, the Helm chart name has reverted from `rancher-prime` back to `rancher`. If you are upgrading from v2.13.1, the existing Ingress resource created by the previous chart conflicts with the new one, causing the upgrade to fail with an error similar to:
+
+[,shell]
+----
+Error: UPGRADE FAILED: failed to create resource: admission webhook "validate.nginx.ingress.kubernetes.io" denied the request: host "rancher.my.org" and path "/" is already defined in ingress cattle-system/rancher-rancher-prime
+----
+
+To prevent or resolve this issue, you must manually delete the old Ingress before completing the upgrade:
+
+[,shell]
+----
+kubectl delete ingress rancher-rancher-prime -n cattle-system
+----
+====
 
 Get the values, which were passed with `--set`, from the current Rancher Helm chart that is installed.
 
@@ -166,51 +183,6 @@ If you are upgrading cert-manager to the latest version from v1.5 or below, foll
 
 [#_steps_to_upgrade_rancher]
 ==== Steps to Upgrade Rancher
-
-[IMPORTANT]
-.Upgrading from Rancher v2.13.1
-====
-In Rancher v2.13.2, the Helm chart name has reverted from `rancher-prime` back to `rancher`. If you are upgrading from v2.13.1, the existing Ingress resource created by the previous chart conflicts with the new one, causing the upgrade to fail with an error similar to:
-
-[,shell]
-----
-Error: UPGRADE FAILED: failed to create resource: admission webhook "validate.nginx.ingress.kubernetes.io" denied the request: host "rancher.my.org" and path "/" is already defined in ingress cattle-system/rancher-rancher-prime
-----
-
-To prevent or resolve this issue, you must manually delete the old Ingress before completing the upgrade:
-
-. Export your current Helm values to ensure all settings (like hostname and private CA data) are preserved:
-+
-[,shell]
-----
-helm get values rancher -n cattle-system -o yaml > rancher-values.yaml
-----
-
-. Delete the conflicting Ingress resource:
-+
-[,shell]
-----
-kubectl delete ingress rancher-rancher-prime -n cattle-system
-----
-
-. Run the upgrade command using the updated chart reference:
-+
-[,shell]
-----
-helm upgrade rancher rancher-prime/rancher \
-  --namespace cattle-system \
-  -f rancher-values.yaml \
-  --set hostname=rancher.my.org \
-  --version 2.13.2
-----
-
-. After the upgrade completes, verify that the new ingress has been successfully created and is pointing to the correct hostname:
-+
-[,shell]
-----
-kubectl get ingress -n cattle-system rancher
-----
-====
 
 Upgrade Rancher to the latest version with all your settings.
 

--- a/versions/v2.14/modules/en/pages/installation-and-upgrade/upgrades.adoc
+++ b/versions/v2.14/modules/en/pages/installation-and-upgrade/upgrades.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2026-04-21
+:revdate: 2026-05-06
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/upgrades.adoc 
 :product-path: installation-and-upgrade/upgrades.adoc
@@ -167,15 +167,54 @@ If you are upgrading cert-manager to the latest version from v1.5 or below, foll
 [#_steps_to_upgrade_rancher]
 ==== Steps to Upgrade Rancher
 
-Upgrade Rancher to the latest version with all your settings.
+[IMPORTANT]
+.Upgrading from Rancher v2.13.1
+====
+In Rancher v2.13.2, the Helm chart name has reverted from `rancher-prime` back to `rancher`. If you are upgrading from v2.13.1, the existing Ingress resource created by the previous chart conflicts with the new one, causing the upgrade to fail with an error similar to:
 
-Take all the values from the previous step and append them to the command using `--set key=value`.
+[,shell]
+----
+Error: UPGRADE FAILED: failed to create resource: admission webhook "validate.nginx.ingress.kubernetes.io" denied the request: host "rancher.my.org" and path "/" is already defined in ingress cattle-system/rancher-rancher-prime
+----
 
+To prevent or resolve this issue, you must manually delete the old Ingress before completing the upgrade:
+
+. Export your current Helm values to ensure all settings (like hostname and private CA data) are preserved:
++
+[,shell]
+----
+helm get values rancher -n cattle-system -o yaml > rancher-values.yaml
+----
+
+. Delete the conflicting Ingress resource:
++
+[,shell]
+----
+kubectl delete ingress rancher-rancher-prime -n cattle-system
+----
+
+. Run the upgrade command using the updated chart reference:
++
+[,shell]
 ----
 helm upgrade rancher rancher-prime/rancher \
   --namespace cattle-system \
-  --set hostname=rancher.my.org
+  -f rancher-values.yaml \
+  --set hostname=rancher.my.org \
+  --version 2.13.2
 ----
+
+. After the upgrade completes, verify that the new ingress has been successfully created and is pointing to the correct hostname:
++
+[,shell]
+----
+kubectl get ingress -n cattle-system rancher
+----
+====
+
+Upgrade Rancher to the latest version with all your settings.
+
+Take all the values from the previous step and append them to the command using `--set key=value`.
 
 [NOTE]
 ====


### PR DESCRIPTION
- Fixes https://github.com/rancher/rancher-product-docs/issues/742.
- Removing outdated tip pointing to https://github.com/rancher/rancher-docs/blob/main/archived_docs/en/version-2.0-2.4/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/upgrades/namespace-migration.md.

  <img width="750" height="190" alt="Screenshot 2026-02-12 at 10 51 11 AM" src="https://github.com/user-attachments/assets/18c7d414-f21c-40ec-9021-f070045438fd" />

- Will update zh docs once en docs reviewed. 
