### PR TITLE
[Community v2.11] Index pages should be named index

### DIFF
--- a/community-docs/v2.11/modules/ROOT/pages/getting-started/installation-and-upgrade/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/getting-started/installation-and-upgrade/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../versions/v2.11/modules/en/pages/installation-and-upgrade/installation-and-upgrade.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.11/modules/en/pages/installation-and-upgrade/install-rancher.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/getting-started/installation-and-upgrade/installation-references/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/getting-started/installation-and-upgrade/installation-references/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.11/modules/en/pages/installation-and-upgrade/references/references.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/getting-started/installation-and-upgrade/installation-requirements/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/getting-started/installation-and-upgrade/installation-requirements/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.11/modules/en/pages/installation-and-upgrade/requirements/requirements.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.11/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/air-gapped.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/getting-started/installation-and-upgrade/other-installation-methods/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/getting-started/installation-and-upgrade/other-installation-methods/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.11/modules/en/pages/installation-and-upgrade/other-installation-methods/other-installation-methods.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.11/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/http-proxy.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/getting-started/installation-and-upgrade/resources/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/getting-started/installation-and-upgrade/resources/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.11/modules/en/pages/installation-and-upgrade/resources/resources.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/getting-started/quick-start-guides/deploy-rancher-manager/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/getting-started/quick-start-guides/deploy-rancher-manager/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.11/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/deploy-rancher.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/getting-started/quick-start-guides/deploy-workloads/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/getting-started/quick-start-guides/deploy-workloads/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.11/modules/en/pages/installation-and-upgrade/quick-start/deploy-workloads/deploy-workloads.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/getting-started/quick-start-guides/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/getting-started/quick-start-guides/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../versions/v2.11/modules/en/pages/installation-and-upgrade/quick-start/quick-start.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/how-to-guides/advanced-user-guides/cis-scan-guides/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/how-to-guides/advanced-user-guides/cis-scan-guides/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.11/modules/en/pages/security/cis-scans/how-to.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/how-to-guides/advanced-user-guides/enable-experimental-features/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/how-to-guides/advanced-user-guides/enable-experimental-features/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.11/modules/en/pages/rancher-admin/experimental-features/experimental-features.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/how-to-guides/advanced-user-guides/istio-setup-guide/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/how-to-guides/advanced-user-guides/istio-setup-guide/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.11/modules/en/pages/observability/istio/guides/guides.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/how-to-guides/advanced-user-guides/manage-projects/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/how-to-guides/advanced-user-guides/manage-projects/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.11/modules/en/pages/cluster-admin/project-admin/project-admin.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/how-to-guides/advanced-user-guides/manage-projects/manage-project-resource-quotas/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/how-to-guides/advanced-user-guides/manage-projects/manage-project-resource-quotas/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.11/modules/en/pages/cluster-admin/project-admin/project-resource-quotas/project-resource-quotas.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/advanced-configuration/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/advanced-configuration/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.11/modules/en/pages/observability/monitoring-and-dashboards/configuration/advanced/advanced.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.11/modules/en/pages/observability/monitoring-and-dashboards/configuration/configuration.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.11/modules/en/pages/rancher-admin/global-configuration/provisioning-drivers/provisioning-drivers.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-rke1-templates/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-rke1-templates/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.11/modules/en/pages/rancher-admin/global-configuration/rke1-templates/rke1-templates.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.11/modules/en/pages/rancher-admin/users/authn-and-authz/authn-and-authz.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-microsoft-ad-federation-service-saml/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-microsoft-ad-federation-service-saml/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.11/modules/en/pages/rancher-admin/users/authn-and-authz/microsoft-ad-federation-service-saml/microsoft-ad-federation-service-saml.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-openldap/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-openldap/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.11/modules/en/pages/rancher-admin/users/authn-and-authz/openldap/openldap.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-shibboleth-saml/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-shibboleth-saml/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.11/modules/en/pages/rancher-admin/users/authn-and-authz/shibboleth-saml/shibboleth-saml.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.11/modules/en/pages/rancher-admin/rancher-admin.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.11/modules/en/pages/rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/manage-role-based-access-control-rbac.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.11/modules/en/pages/rancher-admin/back-up-restore-and-disaster-recovery/back-up-restore-and-disaster-recovery.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/helm-charts-in-rancher/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/helm-charts-in-rancher/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.11/modules/en/pages/cluster-admin/helm-charts-in-rancher/helm-charts-in-rancher.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/infrastructure-setup/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/infrastructure-setup/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.11/modules/en/pages/installation-and-upgrade/infrastructure-setup/infrastructure-setup.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/kubernetes-cluster-setup/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/kubernetes-cluster-setup/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.11/modules/en/pages/installation-and-upgrade/install-kubernetes/install-kubernetes.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/checklist-for-production-ready-clusters/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/checklist-for-production-ready-clusters/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.11/modules/en/pages/cluster-deployment/production-checklist/production-checklist.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.11/modules/en/pages/cluster-deployment/cluster-deployment.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.11/modules/en/pages/cluster-deployment/set-up-cloud-providers/set-up-cloud-providers.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.11/modules/en/pages/cluster-deployment/hosted-kubernetes/hosted-kubernetes.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/use-windows-clusters/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/use-windows-clusters/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.11/modules/en/pages/cluster-deployment/custom-clusters/windows/use-windows-clusters.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/kubernetes-resources-setup/horizontal-pod-autoscaler/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/kubernetes-resources-setup/horizontal-pod-autoscaler/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.11/modules/en/pages/cluster-admin/kubernetes-resources/horizontal-pod-autoscaler/horizontal-pod-autoscaler.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/kubernetes-resources-setup/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/kubernetes-resources-setup/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.11/modules/en/pages/cluster-admin/kubernetes-resources/kubernetes-resources-setup.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/kubernetes-resources-setup/load-balancer-and-ingress-controller/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/kubernetes-resources-setup/load-balancer-and-ingress-controller/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.11/modules/en/pages/cluster-admin/kubernetes-resources/load-balancer-and-ingress-controller/load-balancer-and-ingress-controller.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/kubernetes-resources-setup/workloads-and-pods/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/kubernetes-resources-setup/workloads-and-pods/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.11/modules/en/pages/cluster-admin/kubernetes-resources/workloads-and-pods/workloads-and-pods.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.11/modules/en/pages/cluster-deployment/launch-kubernetes-with-rancher.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.11/modules/en/pages/cluster-deployment/infra-providers/infra-providers.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/nutanix/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/nutanix/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../../versions/v2.11/modules/en/pages/cluster-deployment/infra-providers/nutanix/nutanix.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../../versions/v2.11/modules/en/pages/cluster-deployment/infra-providers/vsphere/vsphere.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/manage-clusters/access-clusters/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/manage-clusters/access-clusters/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.11/modules/en/pages/cluster-admin/manage-clusters/access-clusters/access-clusters.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/manage-clusters/create-kubernetes-persistent-storage/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/manage-clusters/create-kubernetes-persistent-storage/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.11/modules/en/pages/cluster-admin/manage-clusters/persistent-storage/manage-persistent-storage.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/manage-clusters/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/manage-clusters/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.11/modules/en/pages/cluster-admin/manage-clusters/manage-clusters.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/manage-clusters/install-cluster-autoscaler/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/manage-clusters/install-cluster-autoscaler/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.11/modules/en/pages/cluster-admin/manage-clusters/install-cluster-autoscaler/install-cluster-autoscaler.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/manage-clusters/provisioning-storage-examples/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/how-to-guides/new-user-guides/manage-clusters/provisioning-storage-examples/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.11/modules/en/pages/cluster-admin/manage-clusters/persistent-storage/examples/examples.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/integrations-in-rancher/cis-scans/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/integrations-in-rancher/cis-scans/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../versions/v2.11/modules/en/pages/security/cis-scans/cis-scans.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/integrations-in-rancher/cloud-marketplace/aws-cloud-marketplace/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/integrations-in-rancher/cloud-marketplace/aws-cloud-marketplace/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.11/modules/en/pages/installation-and-upgrade/hosted-kubernetes/cloud-marketplace/aws/aws.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/integrations-in-rancher/cloud-marketplace/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/integrations-in-rancher/cloud-marketplace/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../versions/v2.11/modules/en/pages/installation-and-upgrade/hosted-kubernetes/cloud-marketplace/cloud-marketplace.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/integrations-in-rancher/cluster-api/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/integrations-in-rancher/cluster-api/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../versions/v2.11/modules/en/pages/integrations/cluster-api/cluster-api.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/integrations-in-rancher/elemental/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/integrations-in-rancher/elemental/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../versions/v2.11/modules/en/pages/integrations/elemental.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/integrations-in-rancher/fleet/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/integrations-in-rancher/fleet/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../versions/v2.11/modules/en/pages/integrations/fleet/fleet.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/integrations-in-rancher/harvester/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/integrations-in-rancher/harvester/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../versions/v2.11/modules/en/pages/integrations/harvester/harvester.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/integrations-in-rancher/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/integrations-in-rancher/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../versions/v2.11/modules/en/pages/integrations/integrations.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/integrations-in-rancher/istio/configuration-options/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/integrations-in-rancher/istio/configuration-options/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.11/modules/en/pages/observability/istio/configuration/configuration.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/integrations-in-rancher/istio/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/integrations-in-rancher/istio/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../versions/v2.11/modules/en/pages/observability/istio/istio.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/integrations-in-rancher/kubernetes-distributions/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/integrations-in-rancher/kubernetes-distributions/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../versions/v2.11/modules/en/pages/integrations/kubernetes-distributions.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/integrations-in-rancher/kubewarden/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/integrations-in-rancher/kubewarden/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../versions/v2.11/modules/en/pages/integrations/kubewarden.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/integrations-in-rancher/logging/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/integrations-in-rancher/logging/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../versions/v2.11/modules/en/pages/observability/logging/logging.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/integrations-in-rancher/longhorn/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/integrations-in-rancher/longhorn/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../versions/v2.11/modules/en/pages/integrations/longhorn/longhorn.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/integrations-in-rancher/monitoring-and-alerting/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/integrations-in-rancher/monitoring-and-alerting/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../versions/v2.11/modules/en/pages/observability/monitoring-and-dashboards/monitoring-and-dashboards.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/integrations-in-rancher/neuvector/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/integrations-in-rancher/neuvector/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../versions/v2.11/modules/en/pages/integrations/neuvector/neuvector.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/integrations-in-rancher/suse-observability/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/integrations-in-rancher/suse-observability/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../versions/v2.11/modules/en/pages/integrations/suse-observability.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/reference-guides/best-practices/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/reference-guides/best-practices/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../versions/v2.11/modules/en/pages/installation-and-upgrade/best-practices/resources.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/reference-guides/best-practices/rancher-server/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/reference-guides/best-practices/rancher-server/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.11/modules/en/pages/installation-and-upgrade/best-practices/best-practices.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.11/modules/en/pages/cluster-deployment/hosted-kubernetes/gke/configuration.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/reference-guides/cluster-configuration/rancher-server-configuration/use-existing-nodes/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/reference-guides/cluster-configuration/rancher-server-configuration/use-existing-nodes/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.11/modules/en/pages/cluster-deployment/custom-clusters/custom-clusters.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/reference-guides/prometheus-federator/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/reference-guides/prometheus-federator/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../versions/v2.11/modules/en/pages/observability/monitoring-and-dashboards/prometheus-federator/prometheus-federator.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/reference-guides/rancher-manager-architecture/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/reference-guides/rancher-manager-architecture/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../versions/v2.11/modules/en/pages/about-rancher/architecture/architecture.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/reference-guides/rancher-security/hardening-guides/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/reference-guides/rancher-security/hardening-guides/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.11/modules/en/pages/security/hardening-guides/hardening-guides.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/reference-guides/rancher-security/hardening-guides/k3s-hardening-guide/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/reference-guides/rancher-security/hardening-guides/k3s-hardening-guide/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.11/modules/en/pages/security/hardening-guides/k3s/k3s.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/reference-guides/rancher-security/hardening-guides/rke1-hardening-guide/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/reference-guides/rancher-security/hardening-guides/rke1-hardening-guide/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.11/modules/en/pages/security/hardening-guides/rke1/rke1.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/reference-guides/rancher-security/hardening-guides/rke2-hardening-guide/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/reference-guides/rancher-security/hardening-guides/rke2-hardening-guide/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.11/modules/en/pages/security/hardening-guides/rke2/rke2.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/reference-guides/rancher-security/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/reference-guides/rancher-security/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../versions/v2.11/modules/en/pages/security/security-overview.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/reference-guides/rancher-security/selinux-rpm/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/reference-guides/rancher-security/selinux-rpm/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.11/modules/en/pages/security/selinux-rpm/selinux-rpm.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/reference-guides/user-settings/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/reference-guides/user-settings/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../versions/v2.11/modules/en/pages/rancher-admin/users/settings/settings.adoc

--- a/community-docs/v2.11/modules/ROOT/pages/troubleshooting/kubernetes-components/index.adoc
+++ b/community-docs/v2.11/modules/ROOT/pages/troubleshooting/kubernetes-components/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../versions/v2.11/modules/en/pages/troubleshooting/kubernetes-components/kubernetes-components.adoc

--- a/versions/v2.11/modules/en/pages/about-rancher/architecture/architecture.adoc
+++ b/versions/v2.11/modules/en/pages/about-rancher/architecture/architecture.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-12
 :page-revdate: {revdate}
-:community-path: reference-guides/rancher-manager-architecture/rancher-manager-architecture 
+:community-path: reference-guides/rancher-manager-architecture/index 
 :product-path: about-rancher/architecture/architecture
 
 This section focuses on the xref:about-rancher/architecture/rancher-server-and-components.adoc[Rancher server and its components] and how xref:about-rancher/architecture/communicating-with-downstream-clusters.adoc[Rancher communicates with downstream Kubernetes clusters].

--- a/versions/v2.11/modules/en/pages/cluster-admin/helm-charts-in-rancher/helm-charts-in-rancher.adoc
+++ b/versions/v2.11/modules/en/pages/cluster-admin/helm-charts-in-rancher/helm-charts-in-rancher.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-07-24
 :page-revdate: {revdate}
-:community-path: how-to-guides/new-user-guides/helm-charts-in-rancher/helm-charts-in-rancher 
+:community-path: how-to-guides/new-user-guides/helm-charts-in-rancher/index 
 :product-path: cluster-admin/helm-charts-in-rancher/helm-charts-in-rancher
 :experimental:
 

--- a/versions/v2.11/modules/en/pages/cluster-admin/kubernetes-resources/horizontal-pod-autoscaler/horizontal-pod-autoscaler.adoc
+++ b/versions/v2.11/modules/en/pages/cluster-admin/kubernetes-resources/horizontal-pod-autoscaler/horizontal-pod-autoscaler.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-17
 :page-revdate: {revdate}
-:community-path: how-to-guides/new-user-guides/kubernetes-resources-setup/horizontal-pod-autoscaler/horizontal-pod-autoscaler 
+:community-path: how-to-guides/new-user-guides/kubernetes-resources-setup/horizontal-pod-autoscaler/index 
 :product-path: cluster-admin/kubernetes-resources/horizontal-pod-autoscaler/horizontal-pod-autoscaler
 :description: Learn about the horizontal pod autoscaler (HPA). How to manage HPAs and how to test them with a service deployment
 :experimental:

--- a/versions/v2.11/modules/en/pages/cluster-admin/kubernetes-resources/kubernetes-resources-setup.adoc
+++ b/versions/v2.11/modules/en/pages/cluster-admin/kubernetes-resources/kubernetes-resources-setup.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-17
 :page-revdate: {revdate}
-:community-path: how-to-guides/new-user-guides/kubernetes-resources-setup/kubernetes-resources-setup 
+:community-path: how-to-guides/new-user-guides/kubernetes-resources-setup/index 
 :product-path: cluster-admin/kubernetes-resources/kubernetes-resources-setup
 
 You can view and manipulate all of the custom resources and CRDs in a Kubernetes cluster from the Rancher UI.

--- a/versions/v2.11/modules/en/pages/cluster-admin/kubernetes-resources/load-balancer-and-ingress-controller/load-balancer-and-ingress-controller.adoc
+++ b/versions/v2.11/modules/en/pages/cluster-admin/kubernetes-resources/load-balancer-and-ingress-controller/load-balancer-and-ingress-controller.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-17
 :page-revdate: {revdate}
-:community-path: how-to-guides/new-user-guides/kubernetes-resources-setup/load-balancer-and-ingress-controller/load-balancer-and-ingress-controller 
+:community-path: how-to-guides/new-user-guides/kubernetes-resources-setup/load-balancer-and-ingress-controller/index 
 :product-path: cluster-admin/kubernetes-resources/load-balancer-and-ingress-controller/load-balancer-and-ingress-controller
 :description: Learn how you can set up load balancers and ingress controllers to redirect service requests within Rancher, and learn about the limitations of load balancers
 

--- a/versions/v2.11/modules/en/pages/cluster-admin/kubernetes-resources/workloads-and-pods/workloads-and-pods.adoc
+++ b/versions/v2.11/modules/en/pages/cluster-admin/kubernetes-resources/workloads-and-pods/workloads-and-pods.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-12
 :page-revdate: {revdate}
-:community-path: how-to-guides/new-user-guides/kubernetes-resources-setup/workloads-and-pods/workloads-and-pods 
+:community-path: how-to-guides/new-user-guides/kubernetes-resources-setup/workloads-and-pods/index 
 :product-path: cluster-admin/kubernetes-resources/workloads-and-pods/workloads-and-pods
 :description: Learn about the two constructs with which you can build any complex containerized application in Kubernetes: Kubernetes workloads and pods
 

--- a/versions/v2.11/modules/en/pages/cluster-admin/manage-clusters/access-clusters/access-clusters.adoc
+++ b/versions/v2.11/modules/en/pages/cluster-admin/manage-clusters/access-clusters/access-clusters.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-12
 :page-revdate: {revdate}
-:community-path: how-to-guides/new-user-guides/manage-clusters/access-clusters/access-clusters 
+:community-path: how-to-guides/new-user-guides/manage-clusters/access-clusters/index 
 :product-path: cluster-admin/manage-clusters/access-clusters/access-clusters
 
 This section is about what tools can be used to access clusters managed by Rancher.

--- a/versions/v2.11/modules/en/pages/cluster-admin/manage-clusters/install-cluster-autoscaler/install-cluster-autoscaler.adoc
+++ b/versions/v2.11/modules/en/pages/cluster-admin/manage-clusters/install-cluster-autoscaler/install-cluster-autoscaler.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-12
 :page-revdate: {revdate}
-:community-path: how-to-guides/new-user-guides/manage-clusters/install-cluster-autoscaler/install-cluster-autoscaler 
+:community-path: how-to-guides/new-user-guides/manage-clusters/install-cluster-autoscaler/index 
 :product-path: cluster-admin/manage-clusters/install-cluster-autoscaler/install-cluster-autoscaler
 
 In this section, you'll learn how to install and use the https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/[Kubernetes cluster-autoscaler] on Rancher custom clusters using AWS EC2 Auto Scaling Groups.

--- a/versions/v2.11/modules/en/pages/cluster-admin/manage-clusters/manage-clusters.adoc
+++ b/versions/v2.11/modules/en/pages/cluster-admin/manage-clusters/manage-clusters.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-12
 :page-revdate: {revdate}
-:community-path: how-to-guides/new-user-guides/manage-clusters/manage-clusters 
+:community-path: how-to-guides/new-user-guides/manage-clusters/index 
 :product-path: cluster-admin/manage-clusters/manage-clusters
 
 After you provision a cluster in Rancher, you can begin using powerful Kubernetes features to deploy and scale your containerized applications in development, testing, or production environments.

--- a/versions/v2.11/modules/en/pages/cluster-admin/manage-clusters/persistent-storage/examples/examples.adoc
+++ b/versions/v2.11/modules/en/pages/cluster-admin/manage-clusters/persistent-storage/examples/examples.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-12
 :page-revdate: {revdate}
-:community-path: how-to-guides/new-user-guides/manage-clusters/provisioning-storage-examples/provisioning-storage-examples 
+:community-path: how-to-guides/new-user-guides/manage-clusters/provisioning-storage-examples/index 
 :product-path: cluster-admin/manage-clusters/persistent-storage/examples/examples
 
 Rancher supports persistent storage with a variety of volume plugins. However, before you use any of these plugins to bind persistent storage to your workloads, you have to configure the storage itself, whether its a cloud-based solution from a service-provider or an on-prem solution that you manage yourself.

--- a/versions/v2.11/modules/en/pages/cluster-admin/manage-clusters/persistent-storage/manage-persistent-storage.adoc
+++ b/versions/v2.11/modules/en/pages/cluster-admin/manage-clusters/persistent-storage/manage-persistent-storage.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-06-20
 :page-revdate: {revdate}
-:community-path: how-to-guides/new-user-guides/manage-clusters/create-kubernetes-persistent-storage/create-kubernetes-persistent-storage 
+:community-path: how-to-guides/new-user-guides/manage-clusters/create-kubernetes-persistent-storage/index 
 :product-path: cluster-admin/manage-clusters/persistent-storage/manage-persistent-storage
 :description: Learn about the two ways with which you can create persistent storage in Kubernetes: persistent volumes and storage classes
 

--- a/versions/v2.11/modules/en/pages/cluster-admin/project-admin/project-admin.adoc
+++ b/versions/v2.11/modules/en/pages/cluster-admin/project-admin/project-admin.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-08-18
 :page-revdate: {revdate}
-:community-path: how-to-guides/advanced-user-guides/manage-projects/manage-projects 
+:community-path: how-to-guides/advanced-user-guides/manage-projects/index 
 :product-path: cluster-admin/project-admin/project-admin
 
 _Projects_ are objects introduced in Rancher that help organize namespaces in your Kubernetes cluster. You can use projects to create multi-tenant clusters, which allows a group of users to share the same underlying resources without interacting with each other's applications.

--- a/versions/v2.11/modules/en/pages/cluster-admin/project-admin/project-resource-quotas/project-resource-quotas.adoc
+++ b/versions/v2.11/modules/en/pages/cluster-admin/project-admin/project-resource-quotas/project-resource-quotas.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-12
 :page-revdate: {revdate}
-:community-path: how-to-guides/advanced-user-guides/manage-projects/manage-project-resource-quotas/manage-project-resource-quotas 
+:community-path: how-to-guides/advanced-user-guides/manage-projects/manage-project-resource-quotas/index 
 :product-path: cluster-admin/project-admin/project-resource-quotas/project-resource-quotas
 :experimental:
 

--- a/versions/v2.11/modules/en/pages/cluster-deployment/cluster-deployment.adoc
+++ b/versions/v2.11/modules/en/pages/cluster-deployment/cluster-deployment.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-17
 :page-revdate: {revdate}
-:community-path: how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/kubernetes-clusters-in-rancher-setup 
+:community-path: how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/index 
 :product-path: cluster-deployment/cluster-deployment
 :description: Provisioning Kubernetes Clusters
 

--- a/versions/v2.11/modules/en/pages/cluster-deployment/custom-clusters/custom-clusters.adoc
+++ b/versions/v2.11/modules/en/pages/cluster-deployment/custom-clusters/custom-clusters.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-12
 :page-revdate: {revdate}
-:community-path: reference-guides/cluster-configuration/rancher-server-configuration/use-existing-nodes/use-existing-nodes 
+:community-path: reference-guides/cluster-configuration/rancher-server-configuration/use-existing-nodes/index 
 :product-path: cluster-deployment/custom-clusters/custom-clusters
 :description: To create a cluster with custom nodes, you’ll need to access servers in your cluster and provision them according to Rancher requirements
 

--- a/versions/v2.11/modules/en/pages/cluster-deployment/custom-clusters/windows/use-windows-clusters.adoc
+++ b/versions/v2.11/modules/en/pages/cluster-deployment/custom-clusters/windows/use-windows-clusters.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-07-02
 :page-revdate: {revdate}
-:community-path: how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/use-windows-clusters/use-windows-clusters 
+:community-path: how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/use-windows-clusters/index 
 :product-path: cluster-deployment/custom-clusters/windows/use-windows-clusters
 
 When provisioning a xref:cluster-deployment/custom-clusters/custom-clusters.adoc[custom cluster] using Rancher, Rancher uses RKE (the Rancher Kubernetes Engine) to install Kubernetes on your existing nodes.

--- a/versions/v2.11/modules/en/pages/cluster-deployment/hosted-kubernetes/gke/configuration.adoc
+++ b/versions/v2.11/modules/en/pages/cluster-deployment/hosted-kubernetes/gke/configuration.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-12
 :page-revdate: {revdate}
-:community-path: reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration/gke-cluster-configuration 
+:community-path: reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration/index 
 :product-path: cluster-deployment/hosted-kubernetes/gke/configuration
 
 == Cluster Location

--- a/versions/v2.11/modules/en/pages/cluster-deployment/hosted-kubernetes/hosted-kubernetes.adoc
+++ b/versions/v2.11/modules/en/pages/cluster-deployment/hosted-kubernetes/hosted-kubernetes.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-12
 :page-revdate: {revdate}
-:community-path: how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/set-up-clusters-from-hosted-kubernetes-providers 
+:community-path: how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/index 
 :product-path: cluster-deployment/hosted-kubernetes/hosted-kubernetes
 
 In this scenario, Rancher does not provision Kubernetes because it is installed by providers such as Google Kubernetes Engine (GKE), Amazon Elastic Container Service for Kubernetes, or Azure Kubernetes Service.

--- a/versions/v2.11/modules/en/pages/cluster-deployment/infra-providers/infra-providers.adoc
+++ b/versions/v2.11/modules/en/pages/cluster-deployment/infra-providers/infra-providers.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-12
 :page-revdate: {revdate}
-:community-path: how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/use-new-nodes-in-an-infra-provider 
+:community-path: how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/index 
 :product-path: cluster-deployment/infra-providers/infra-providers
 :experimental:
 

--- a/versions/v2.11/modules/en/pages/cluster-deployment/infra-providers/nutanix/nutanix.adoc
+++ b/versions/v2.11/modules/en/pages/cluster-deployment/infra-providers/nutanix/nutanix.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-17
 :page-revdate: {revdate}
-:community-path: how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/nutanix/nutanix 
+:community-path: how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/nutanix/index 
 :product-path: cluster-deployment/infra-providers/nutanix/nutanix
 :description: Use Rancher to create a Nutanix AOS (AHV) cluster. It may consist of groups of VMs with distinct properties which allow for fine-grained control over the sizing of nodes.
 

--- a/versions/v2.11/modules/en/pages/cluster-deployment/infra-providers/vsphere/vsphere.adoc
+++ b/versions/v2.11/modules/en/pages/cluster-deployment/infra-providers/vsphere/vsphere.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-17
 :page-revdate: {revdate}
-:community-path: how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/vsphere 
+:community-path: how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/index 
 :product-path: cluster-deployment/infra-providers/vsphere/vsphere
 :description: Use Rancher to create a VMware vSphere cluster. It may consist of groups of VMs with distinct properties which allow for fine-grained control over the sizing of nodes.
 

--- a/versions/v2.11/modules/en/pages/cluster-deployment/launch-kubernetes-with-rancher.adoc
+++ b/versions/v2.11/modules/en/pages/cluster-deployment/launch-kubernetes-with-rancher.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-07-02
 :page-revdate: {revdate}
-:community-path: how-to-guides/new-user-guides/launch-kubernetes-with-rancher/launch-kubernetes-with-rancher 
+:community-path: how-to-guides/new-user-guides/launch-kubernetes-with-rancher/index 
 :product-path: cluster-deployment/launch-kubernetes-with-rancher
 
 You can have Rancher launch a Kubernetes cluster using any nodes you want. When Rancher deploys Kubernetes onto these nodes, you can choose between https://rancher.com/docs/rke/latest/en/[Rancher Kubernetes Engine] (RKE) or https://documentation.suse.com/cloudnative/rke2/latest/en/introduction.html[RKE2] distributions. Rancher can launch Kubernetes on any computers, including:

--- a/versions/v2.11/modules/en/pages/cluster-deployment/production-checklist/production-checklist.adoc
+++ b/versions/v2.11/modules/en/pages/cluster-deployment/production-checklist/production-checklist.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-12
 :page-revdate: {revdate}
-:community-path: how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/checklist-for-production-ready-clusters/checklist-for-production-ready-clusters 
+:community-path: how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/checklist-for-production-ready-clusters/index 
 :product-path: cluster-deployment/production-checklist/production-checklist
 
 In this section, we recommend best practices for creating the production-ready Kubernetes clusters that will run your apps and services.

--- a/versions/v2.11/modules/en/pages/cluster-deployment/set-up-cloud-providers/set-up-cloud-providers.adoc
+++ b/versions/v2.11/modules/en/pages/cluster-deployment/set-up-cloud-providers/set-up-cloud-providers.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-12
 :page-revdate: {revdate}
-:community-path: how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/set-up-cloud-providers 
+:community-path: how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/index 
 :product-path: cluster-deployment/set-up-cloud-providers/set-up-cloud-providers
 
 A _cloud provider_ is a module in Kubernetes that provides an interface for managing nodes, load balancers, and networking routes.

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/best-practices/best-practices.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/best-practices/best-practices.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-06-04
 :page-revdate: {revdate}
-:community-path: reference-guides/best-practices/rancher-server/rancher-server 
+:community-path: reference-guides/best-practices/rancher-server/index 
 :product-path: installation-and-upgrade/best-practices/best-practices
 
 This guide contains our recommendations for running the Rancher server, and is intended to be used in situations in which Rancher manages downstream Kubernetes clusters.

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/best-practices/resources.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/best-practices/resources.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-05-10
 :page-revdate: {revdate}
-:community-path: reference-guides/best-practices/best-practices 
+:community-path: reference-guides/best-practices/index 
 :product-path: installation-and-upgrade/best-practices/resources
 
 The purpose of this section is to consolidate best practices for Rancher implementations. This also includes recommendations for related technologies, such as Kubernetes, Docker, containers, and more. The objective is to improve the outcome of a Rancher implementation using the operational experience of Rancher and its customers.

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/hosted-kubernetes/cloud-marketplace/aws/aws.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/hosted-kubernetes/cloud-marketplace/aws/aws.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-12
 :page-revdate: {revdate}
-:community-path: integrations-in-rancher/cloud-marketplace/aws-cloud-marketplace/aws-cloud-marketplace 
+:community-path: integrations-in-rancher/cloud-marketplace/aws-cloud-marketplace/index 
 :product-path: installation-and-upgrade/hosted-kubernetes/cloud-marketplace/aws/aws
 
 == Overview

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/hosted-kubernetes/cloud-marketplace/cloud-marketplace.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/hosted-kubernetes/cloud-marketplace/cloud-marketplace.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-12
 :page-revdate: {revdate}
-:community-path: integrations-in-rancher/cloud-marketplace/cloud-marketplace 
+:community-path: integrations-in-rancher/cloud-marketplace/index 
 :product-path: installation-and-upgrade/hosted-kubernetes/cloud-marketplace/cloud-marketplace
 
 Rancher offers integration with cloud marketplaces to easily purchase support for installations hosted on certain cloud providers. In addition, this integration also provides the ability to generate a supportconfig bundle which can be provided to rancher support.

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/infrastructure-setup/infrastructure-setup.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/infrastructure-setup/infrastructure-setup.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-12
 :page-revdate: {revdate}
-:community-path: how-to-guides/new-user-guides/infrastructure-setup/infrastructure-setup 
+:community-path: how-to-guides/new-user-guides/infrastructure-setup/index 
 :product-path: installation-and-upgrade/infrastructure-setup/infrastructure-setup
 
 Don't have infrastructure for your Kubernetes cluster? Try one of these tutorials.

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/install-kubernetes/install-kubernetes.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/install-kubernetes/install-kubernetes.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-12
 :page-revdate: {revdate}
-:community-path: how-to-guides/new-user-guides/kubernetes-cluster-setup/kubernetes-cluster-setup 
+:community-path: how-to-guides/new-user-guides/kubernetes-cluster-setup/index 
 :product-path: installation-and-upgrade/install-kubernetes/install-kubernetes
 
 Don't have a Kubernetes cluster? Try one of these tutorials.

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/install-rancher.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/install-rancher.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-08-18
 :page-revdate: {revdate}
-:community-path: getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/install-upgrade-on-a-kubernetes-cluster 
+:community-path: getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/index 
 :product-path: installation-and-upgrade/install-rancher
 :description: Learn how to install Rancher in development and production environments. Read about single node and high availability installation
 

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/installation-and-upgrade.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/installation-and-upgrade.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-04-24
 :page-revdate: {revdate}
-:community-path: getting-started/installation-and-upgrade/installation-and-upgrade 
+:community-path: getting-started/installation-and-upgrade/index 
 :product-path: installation-and-upgrade/installation-and-upgrade
 :description: Learn how to install Rancher in development and production environments. Read about single node and high availability installation
 

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/air-gapped.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/air-gapped.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-12
 :page-revdate: {revdate}
-:community-path: getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/air-gapped-helm-cli-install 
+:community-path: getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/index 
 :product-path: installation-and-upgrade/other-installation-methods/air-gapped/air-gapped
 
 This section is about using the Helm CLI to install the Rancher server in an air gapped environment. An air gapped environment could be where Rancher server will be installed offline, behind a firewall, or behind a proxy.

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/http-proxy.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/http-proxy.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-12
 :page-revdate: {revdate}
-:community-path: getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/rancher-behind-an-http-proxy 
+:community-path: getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/index 
 :product-path: installation-and-upgrade/other-installation-methods/http-proxy/http-proxy
 
 In a lot of enterprise environments, servers or VMs running on premise do not have direct Internet access, but must connect to external services through a HTTP(S) proxy for security reasons. This tutorial shows step by step how to set up a highly available Rancher installation in such an environment.

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/other-installation-methods/other-installation-methods.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/other-installation-methods/other-installation-methods.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-12
 :page-revdate: {revdate}
-:community-path: getting-started/installation-and-upgrade/other-installation-methods/other-installation-methods 
+:community-path: getting-started/installation-and-upgrade/other-installation-methods/index 
 :product-path: installation-and-upgrade/other-installation-methods/other-installation-methods
 
 == Air Gapped Installations

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/deploy-rancher.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/deploy-rancher.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-05-15
 :page-revdate: {revdate}
-:community-path: getting-started/quick-start-guides/deploy-rancher-manager/deploy-rancher-manager 
+:community-path: getting-started/quick-start-guides/deploy-rancher-manager/index 
 :product-path: installation-and-upgrade/quick-start/deploy-rancher/deploy-rancher
 
 Use one of the following guides to deploy and provision Rancher and a Kubernetes cluster in the provider of your choice.

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/quick-start/deploy-workloads/deploy-workloads.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/quick-start/deploy-workloads/deploy-workloads.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-12
 :page-revdate: {revdate}
-:community-path: getting-started/quick-start-guides/deploy-workloads/deploy-workloads 
+:community-path: getting-started/quick-start-guides/deploy-workloads/index 
 :product-path: installation-and-upgrade/quick-start/deploy-workloads/deploy-workloads
 
 These guides walk you through the deployment of an application, including how to expose the application for use outside of the cluster.

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/quick-start/quick-start.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/quick-start/quick-start.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-12
 :page-revdate: {revdate}
-:community-path: getting-started/quick-start-guides/quick-start-guides 
+:community-path: getting-started/quick-start-guides/index 
 :product-path: installation-and-upgrade/quick-start/quick-start
 
 [CAUTION]

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/references/references.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/references/references.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-12
 :page-revdate: {revdate}
-:community-path: getting-started/installation-and-upgrade/installation-references/installation-references 
+:community-path: getting-started/installation-and-upgrade/installation-references/index 
 :product-path: installation-and-upgrade/references/references
 
 Please see the following reference guides for other installation resources: xref:installation-and-upgrade/references/helm-chart-options.adoc[Rancher Helm chart options], xref:installation-and-upgrade/references/tls-settings.adoc[TLS settings], and xref:installation-and-upgrade/references/feature-flags.adoc[feature flags].

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/requirements/requirements.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/requirements/requirements.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-12
 :page-revdate: {revdate}
-:community-path: getting-started/installation-and-upgrade/installation-requirements/installation-requirements 
+:community-path: getting-started/installation-and-upgrade/installation-requirements/index 
 :product-path: installation-and-upgrade/requirements/requirements
 :description: Learn the node requirements for each node running Rancher server when you’re configuring  Rancher to run either in a Docker or Kubernetes setup
 

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/resources/resources.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/resources/resources.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-12
 :page-revdate: {revdate}
-:community-path: getting-started/installation-and-upgrade/resources/resources 
+:community-path: getting-started/installation-and-upgrade/resources/index 
 :product-path: installation-and-upgrade/resources/resources
 
 == Docker Installations

--- a/versions/v2.11/modules/en/pages/integrations/cluster-api/cluster-api.adoc
+++ b/versions/v2.11/modules/en/pages/integrations/cluster-api/cluster-api.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-06-20
 :page-revdate: {revdate}
-:community-path: integrations-in-rancher/cluster-api/cluster-api 
+:community-path: integrations-in-rancher/cluster-api/index 
 :product-path: integrations/cluster-api/cluster-api
 
 https://documentation.suse.com/cloudnative/cluster-api/{turtles-docs-version}/en/index.html[{turtles-product-name}] is a https://kubernetes.io/docs/concepts/extend-kubernetes/operator/#operators-in-kubernetes[Kubernetes Operator] that manages the lifecycle of provisioned Kubernetes clusters, by providing integration between your Cluster API (CAPI) and Rancher. With Rancher Turtles, you can:

--- a/versions/v2.11/modules/en/pages/integrations/elemental.adoc
+++ b/versions/v2.11/modules/en/pages/integrations/elemental.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-12
 :page-revdate: {revdate}
-:community-path: integrations-in-rancher/elemental/elemental 
+:community-path: integrations-in-rancher/elemental/index 
 :product-path: integrations/elemental
 
 Elemental enables cloud-native host management. Elemental allows you to onboard any machine in any location, whether its in a datacenter or on the edge, and integrate them seamlessly into Kubernetes while managing your workflows (e.g., OS updates).

--- a/versions/v2.11/modules/en/pages/integrations/fleet/fleet.adoc
+++ b/versions/v2.11/modules/en/pages/integrations/fleet/fleet.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-12
 :page-revdate: {revdate}
-:community-path: integrations-in-rancher/fleet/fleet 
+:community-path: integrations-in-rancher/fleet/index 
 :product-path: integrations/fleet/fleet
 
 Fleet orchestrates and manages the continuous delivery of applications through the supply chain for fleets of clusters. Fleet organizes the supply chain to help teams deliver with confidence and trust in a timely manner using GitOps as a safe operating model.

--- a/versions/v2.11/modules/en/pages/integrations/harvester/harvester.adoc
+++ b/versions/v2.11/modules/en/pages/integrations/harvester/harvester.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-12
 :page-revdate: {revdate}
-:community-path: integrations-in-rancher/harvester/harvester 
+:community-path: integrations-in-rancher/harvester/index 
 :product-path: integrations/harvester/harvester
 
 Introduced in Rancher v2.6.1, Harvester is an open-source hyper-converged infrastructure (HCI) software built on Kubernetes. Harvester installs on bare metal servers and provides integrated virtualization and distributed storage capabilities. Although Harvester operates using Kubernetes, it does not require knowledge of Kubernetes concepts, making it more user-friendly.

--- a/versions/v2.11/modules/en/pages/integrations/integrations.adoc
+++ b/versions/v2.11/modules/en/pages/integrations/integrations.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-07-07
 :page-revdate: {revdate}
-:community-path: integrations-in-rancher/integrations-in-rancher 
+:community-path: integrations-in-rancher/index 
 :product-path: integrations/integrations
 
 Prime is the Rancher ecosystem's enterprise offering, with additional security, extended lifecycles, and access to Prime-exclusive documentation. Rancher Prime installation assets are hosted on a trusted SUSE registry, owned and managed by Rancher. The trusted Prime registry includes only stable releases that have been community-tested.

--- a/versions/v2.11/modules/en/pages/integrations/kubernetes-distributions.adoc
+++ b/versions/v2.11/modules/en/pages/integrations/kubernetes-distributions.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-12
 :page-revdate: {revdate}
-:community-path: integrations-in-rancher/kubernetes-distributions/kubernetes-distributions 
+:community-path: integrations-in-rancher/kubernetes-distributions/index 
 :product-path: integrations/kubernetes-distributions
 
 == {k3s-product-name}

--- a/versions/v2.11/modules/en/pages/integrations/kubewarden.adoc
+++ b/versions/v2.11/modules/en/pages/integrations/kubewarden.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-12
 :page-revdate: {revdate}
-:community-path: integrations-in-rancher/kubewarden/kubewarden 
+:community-path: integrations-in-rancher/kubewarden/index 
 :product-path: integrations/kubewarden
 
 Kubewarden is a Policy Engine that secures and helps manage your cluster resources. It allows for validation and mutation of resource requests via policies, including context-aware policies and verifying image signatures. It can run policies in monitor or enforcing mode and provides an overview of the state of the cluster.

--- a/versions/v2.11/modules/en/pages/integrations/longhorn/longhorn.adoc
+++ b/versions/v2.11/modules/en/pages/integrations/longhorn/longhorn.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-12
 :page-revdate: {revdate}
-:community-path: integrations-in-rancher/longhorn/longhorn 
+:community-path: integrations-in-rancher/longhorn/index 
 :product-path: integrations/longhorn/longhorn
 
 Longhorn is an official https://cncf.io/[Cloud Native Computing Foundation project (CNCF)] project that delivers a powerful cloud-native distributed storage platform for Kubernetes that can run anywhere. When combined with Rancher, Longhorn makes the deployment of highly available persistent block storage in your Kubernetes environment easy, fast and reliable.

--- a/versions/v2.11/modules/en/pages/integrations/neuvector/neuvector.adoc
+++ b/versions/v2.11/modules/en/pages/integrations/neuvector/neuvector.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-12
 :page-revdate: {revdate}
-:community-path: integrations-in-rancher/neuvector/neuvector 
+:community-path: integrations-in-rancher/neuvector/index 
 :product-path: integrations/neuvector/neuvector
 
 NeuVector is the only 100% open source, Zero Trust container security platform. Continuously scan throughout the container lifecycle. Remove security roadblocks. Bake in security policies at the start to maximize developer agility. NeuVector provides vulnerability and compliance scanning and management from build to production. The unique NeuVector run-time protection protects network connections within and ingress/egress to the cluster with a Layer7 container firewall. Additionally, NeuVector monitors process and file activity in containers and on hosts to stop unauthorized activity.

--- a/versions/v2.11/modules/en/pages/integrations/suse-observability.adoc
+++ b/versions/v2.11/modules/en/pages/integrations/suse-observability.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-07-23
 :page-revdate: {revdate}
-:community-path: integrations-in-rancher/suse-observability/suse-observability 
+:community-path: integrations-in-rancher/suse-observability/index 
 :product-path: integrations/suse-observability
 
 SUSE Observability is a complete observability solution that provides deep insights into the health of your clusters and nodes, and the workloads running on them. Designed to give you clear visibility into your entire Kubernetes environment, SUSE Observability's full-stack approach allows you to seamlessly explore everything from services to infrastructure within a single platform, eliminating the need for multiple observability tools.

--- a/versions/v2.11/modules/en/pages/observability/istio/configuration/configuration.adoc
+++ b/versions/v2.11/modules/en/pages/observability/istio/configuration/configuration.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-08-18
 :page-revdate: {revdate}
-:community-path: integrations-in-rancher/istio/configuration-options/configuration-options 
+:community-path: integrations-in-rancher/istio/configuration-options/index 
 :product-path: observability/istio/configuration/configuration
 
 [WARNING]

--- a/versions/v2.11/modules/en/pages/observability/istio/guides/guides.adoc
+++ b/versions/v2.11/modules/en/pages/observability/istio/guides/guides.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-04-24
 :page-revdate: {revdate}
-:community-path: how-to-guides/advanced-user-guides/istio-setup-guide/istio-setup-guide 
+:community-path: how-to-guides/advanced-user-guides/istio-setup-guide/index 
 :product-path: observability/istio/guides/guides
 
 [WARNING]

--- a/versions/v2.11/modules/en/pages/observability/istio/istio.adoc
+++ b/versions/v2.11/modules/en/pages/observability/istio/istio.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-04-09
 :page-revdate: {revdate}
-:community-path: integrations-in-rancher/istio/istio 
+:community-path: integrations-in-rancher/istio/index 
 :product-path: observability/istio/istio
 
 [WARNING]

--- a/versions/v2.11/modules/en/pages/observability/logging/logging.adoc
+++ b/versions/v2.11/modules/en/pages/observability/logging/logging.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-07-07
 :page-revdate: {revdate}
-:community-path: integrations-in-rancher/logging/logging 
+:community-path: integrations-in-rancher/logging/index 
 :product-path: observability/logging/logging
 :description: Rancher integrates with popular logging services. Learn the requirements and benefits of integrating with logging services, and enable logging on your cluster.
 

--- a/versions/v2.11/modules/en/pages/observability/monitoring-and-dashboards/configuration/advanced/advanced.adoc
+++ b/versions/v2.11/modules/en/pages/observability/monitoring-and-dashboards/configuration/advanced/advanced.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-12
 :page-revdate: {revdate}
-:community-path: how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/advanced-configuration/advanced-configuration 
+:community-path: how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/advanced-configuration/index 
 :product-path: observability/monitoring-and-dashboards/configuration/advanced/advanced
 
 == Alertmanager

--- a/versions/v2.11/modules/en/pages/observability/monitoring-and-dashboards/configuration/configuration.adoc
+++ b/versions/v2.11/modules/en/pages/observability/monitoring-and-dashboards/configuration/configuration.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-05-28
 :page-revdate: {revdate}
-:community-path: how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/monitoring-v2-configuration-guides 
+:community-path: how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/index 
 :product-path: observability/monitoring-and-dashboards/configuration/configuration
 
 This page captures some of the most important options for configuring Monitoring V2 in the Rancher UI.

--- a/versions/v2.11/modules/en/pages/observability/monitoring-and-dashboards/monitoring-and-dashboards.adoc
+++ b/versions/v2.11/modules/en/pages/observability/monitoring-and-dashboards/monitoring-and-dashboards.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-17
 :page-revdate: {revdate}
-:community-path: integrations-in-rancher/monitoring-and-alerting/monitoring-and-alerting 
+:community-path: integrations-in-rancher/monitoring-and-alerting/index 
 :product-path: observability/monitoring-and-dashboards/monitoring-and-dashboards
 :description: Prometheus lets you view metrics from your different Rancher and Kubernetes objects. Learn about the scope of monitoring and how to enable cluster monitoring
 

--- a/versions/v2.11/modules/en/pages/observability/monitoring-and-dashboards/prometheus-federator/prometheus-federator.adoc
+++ b/versions/v2.11/modules/en/pages/observability/monitoring-and-dashboards/prometheus-federator/prometheus-federator.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-05-27
 :page-revdate: {revdate}
-:community-path: reference-guides/prometheus-federator/prometheus-federator 
+:community-path: reference-guides/prometheus-federator/index 
 :product-path: observability/monitoring-and-dashboards/prometheus-federator/prometheus-federator
 
 Prometheus Federator, also referred to as Project Monitoring v2, deploys a Helm Project Operator (based on the https://github.com/rancher/helm-project-operator[rancher/helm-project-operator]), an operator that manages deploying Helm charts each containing a Project Monitoring Stack, where each stack contains:

--- a/versions/v2.11/modules/en/pages/rancher-admin/back-up-restore-and-disaster-recovery/back-up-restore-and-disaster-recovery.adoc
+++ b/versions/v2.11/modules/en/pages/rancher-admin/back-up-restore-and-disaster-recovery/back-up-restore-and-disaster-recovery.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-06-20
 :page-revdate: {revdate}
-:community-path: how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/backup-restore-and-disaster-recovery 
+:community-path: how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/index 
 :product-path: rancher-admin/back-up-restore-and-disaster-recovery/back-up-restore-and-disaster-recovery
 :experimental:
 :keywords: ["rancher backup restore", "rancher backup and restore", "backup restore rancher", "rancher backup and restore rancher"]

--- a/versions/v2.11/modules/en/pages/rancher-admin/back-up-restore-and-disaster-recovery/migrate-to-a-new-cluster.adoc
+++ b/versions/v2.11/modules/en/pages/rancher-admin/back-up-restore-and-disaster-recovery/migrate-to-a-new-cluster.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2026-02-11
 :page-revdate: {revdate}
-:community-path: how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster
+:community-path: how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/migrate-rancher-to-new-cluster 
 :product-path: rancher-admin/back-up-restore-and-disaster-recovery/migrate-to-a-new-cluster
 
 If you are migrating Rancher to a new Kubernetes cluster, you don't need to install Rancher on the new cluster first. If Rancher is restored to a new cluster with Rancher already installed, it can cause problems.

--- a/versions/v2.11/modules/en/pages/rancher-admin/experimental-features/experimental-features.adoc
+++ b/versions/v2.11/modules/en/pages/rancher-admin/experimental-features/experimental-features.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-08-18
 :page-revdate: {revdate}
-:community-path: how-to-guides/advanced-user-guides/enable-experimental-features/enable-experimental-features 
+:community-path: how-to-guides/advanced-user-guides/enable-experimental-features/index 
 :product-path: rancher-admin/experimental-features/experimental-features
 
 Rancher includes some features that are experimental and disabled by default. You might want to enable these features, for example, if you decide that the benefits of using an xref:rancher-admin/experimental-features/unsupported-storage-drivers.adoc[unsupported storage type] outweighs the risk of using an untested feature. Feature flags were introduced to allow you to try these features that are not enabled by default.

--- a/versions/v2.11/modules/en/pages/rancher-admin/global-configuration/provisioning-drivers/provisioning-drivers.adoc
+++ b/versions/v2.11/modules/en/pages/rancher-admin/global-configuration/provisioning-drivers/provisioning-drivers.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-06-20
 :page-revdate: {revdate}
-:community-path: how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/about-provisioning-drivers 
+:community-path: how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/index 
 :product-path: rancher-admin/global-configuration/provisioning-drivers/provisioning-drivers
 
 Drivers in Rancher allow you to manage which providers can be used to deploy xref:cluster-deployment/hosted-kubernetes/hosted-kubernetes.adoc[hosted Kubernetes clusters] or xref:cluster-deployment/infra-providers/infra-providers.adoc[nodes in an infrastructure provider] to allow Rancher to deploy and manage Kubernetes.

--- a/versions/v2.11/modules/en/pages/rancher-admin/global-configuration/rke1-templates/rke1-templates.adoc
+++ b/versions/v2.11/modules/en/pages/rancher-admin/global-configuration/rke1-templates/rke1-templates.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-21
 :page-revdate: {revdate}
-:community-path: how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-rke1-templates/about-rke1-templates 
+:community-path: how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-rke1-templates/index 
 :product-path: rancher-admin/global-configuration/rke1-templates/rke1-templates
 
 include::shared:ROOT:partial$en/eol-rke1-warning.adoc[]

--- a/versions/v2.11/modules/en/pages/rancher-admin/rancher-admin.adoc
+++ b/versions/v2.11/modules/en/pages/rancher-admin/rancher-admin.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-08-18
 :page-revdate: {revdate}
-:community-path: how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-permissions-and-global-configuration 
+:community-path: how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/index 
 :product-path: rancher-admin/rancher-admin
 
 After installation, the xref:rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/global-permissions.adoc[system administrator] should configure Rancher to configure authentication, authorization, security, default settings, security policies, drivers and global DNS entries.

--- a/versions/v2.11/modules/en/pages/rancher-admin/users/authn-and-authz/authn-and-authz.adoc
+++ b/versions/v2.11/modules/en/pages/rancher-admin/users/authn-and-authz/authn-and-authz.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-09-18
 :page-revdate: {revdate}
-:community-path: how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/authentication-config 
+:community-path: how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/index 
 :product-path: rancher-admin/users/authn-and-authz/authn-and-authz
 :weight: 10
 

--- a/versions/v2.11/modules/en/pages/rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/manage-role-based-access-control-rbac.adoc
+++ b/versions/v2.11/modules/en/pages/rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/manage-role-based-access-control-rbac.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-12
 :page-revdate: {revdate}
-:community-path: how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/manage-role-based-access-control-rbac 
+:community-path: how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/index 
 :product-path: rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/manage-role-based-access-control-rbac
 
 Within Rancher, each person authenticates as a _user_, which is a login that grants you access to Rancher. As mentioned in xref:rancher-admin/users/authn-and-authz/authn-and-authz.adoc[Authentication], users can either be local or external.

--- a/versions/v2.11/modules/en/pages/rancher-admin/users/authn-and-authz/microsoft-ad-federation-service-saml/microsoft-ad-federation-service-saml.adoc
+++ b/versions/v2.11/modules/en/pages/rancher-admin/users/authn-and-authz/microsoft-ad-federation-service-saml/microsoft-ad-federation-service-saml.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-09-18
 :page-revdate: {revdate}
-:community-path: how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-microsoft-ad-federation-service-saml/configure-microsoft-ad-federation-service-saml 
+:community-path: how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-microsoft-ad-federation-service-saml/index 
 :product-path: rancher-admin/users/authn-and-authz/microsoft-ad-federation-service-saml/microsoft-ad-federation-service-saml
 
 If your organization uses Microsoft Active Directory Federation Services (AD FS) for user authentication, you can configure Rancher to allow your users to log in using their AD FS credentials.

--- a/versions/v2.11/modules/en/pages/rancher-admin/users/authn-and-authz/openldap/openldap.adoc
+++ b/versions/v2.11/modules/en/pages/rancher-admin/users/authn-and-authz/openldap/openldap.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-12
 :page-revdate: {revdate}
-:community-path: how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-openldap/configure-openldap 
+:community-path: how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-openldap/index 
 :product-path: rancher-admin/users/authn-and-authz/openldap/openldap
 
 If your organization uses LDAP for user authentication, you can configure Rancher to communicate with an OpenLDAP server to authenticate users. This allows Rancher admins to control access to clusters and projects based on users and groups managed externally in the organisation's central user repository, while allowing end-users to authenticate with their LDAP credentials when logging in to the Rancher UI.

--- a/versions/v2.11/modules/en/pages/rancher-admin/users/authn-and-authz/shibboleth-saml/shibboleth-saml.adoc
+++ b/versions/v2.11/modules/en/pages/rancher-admin/users/authn-and-authz/shibboleth-saml/shibboleth-saml.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-09-18
 :page-revdate: {revdate}
-:community-path: how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-shibboleth-saml/configure-shibboleth-saml 
+:community-path: how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-shibboleth-saml/index 
 :product-path: rancher-admin/users/authn-and-authz/shibboleth-saml/shibboleth-saml
 
 If your organization uses Shibboleth Identity Provider (IdP) for user authentication, you can configure Rancher to allow your users to log in to Rancher using their Shibboleth credentials.

--- a/versions/v2.11/modules/en/pages/rancher-admin/users/settings/settings.adoc
+++ b/versions/v2.11/modules/en/pages/rancher-admin/users/settings/settings.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-12
 :page-revdate: {revdate}
-:community-path: reference-guides/user-settings/user-settings 
+:community-path: reference-guides/user-settings/index 
 :product-path: rancher-admin/users/settings/settings
 
 Within Rancher, each user has a number of settings associated with their login: personal preferences, API keys, etc. You can configure these settings by choosing from the *User Settings* menu. You can open this menu by clicking your avatar, located within the main menu.

--- a/versions/v2.11/modules/en/pages/security/cis-scans/cis-scans.adoc
+++ b/versions/v2.11/modules/en/pages/security/cis-scans/cis-scans.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-12
 :page-revdate: {revdate}
-:community-path: integrations-in-rancher/cis-scans/cis-scans 
+:community-path: integrations-in-rancher/cis-scans/index 
 :product-path: security/cis-scans/cis-scans
 
 Rancher can run a security scan to check whether Kubernetes is deployed according to security best practices as defined in the CIS Kubernetes Benchmark. The CIS scans can run on any Kubernetes cluster, including hosted Kubernetes providers such as EKS, AKS, and GKE.

--- a/versions/v2.11/modules/en/pages/security/cis-scans/how-to.adoc
+++ b/versions/v2.11/modules/en/pages/security/cis-scans/how-to.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-12
 :page-revdate: {revdate}
-:community-path: how-to-guides/advanced-user-guides/cis-scan-guides/cis-scan-guides 
+:community-path: how-to-guides/advanced-user-guides/cis-scan-guides/index 
 :product-path: security/cis-scans/how-to
 
 * xref:security/cis-scans/install-rancher-cis-benchmark.adoc[Install rancher-cis-benchmark]

--- a/versions/v2.11/modules/en/pages/security/hardening-guides/hardening-guides.adoc
+++ b/versions/v2.11/modules/en/pages/security/hardening-guides/hardening-guides.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-05-22
 :page-revdate: {revdate}
-:community-path: reference-guides/rancher-security/hardening-guides/hardening-guides 
+:community-path: reference-guides/rancher-security/hardening-guides/index 
 :product-path: security/hardening-guides/hardening-guides
 
 Rancher provides specific security hardening guides for each supported Rancher version's Kubernetes distributions.

--- a/versions/v2.11/modules/en/pages/security/hardening-guides/k3s/k3s.adoc
+++ b/versions/v2.11/modules/en/pages/security/hardening-guides/k3s/k3s.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-08-18
 :page-revdate: {revdate}
-:community-path: reference-guides/rancher-security/hardening-guides/k3s-hardening-guide/k3s-hardening-guide 
+:community-path: reference-guides/rancher-security/hardening-guides/k3s-hardening-guide/index 
 :product-path: security/hardening-guides/k3s/k3s
 
 This document provides prescriptive guidance for how to harden a K3s cluster intended for production, before provisioning it with Rancher. It outlines the configurations and controls required for Center for Information Security (CIS) Kubernetes benchmark controls.

--- a/versions/v2.11/modules/en/pages/security/hardening-guides/rke1/rke1.adoc
+++ b/versions/v2.11/modules/en/pages/security/hardening-guides/rke1/rke1.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-08-18
 :page-revdate: {revdate}
-:community-path: reference-guides/rancher-security/hardening-guides/rke1-hardening-guide/rke1-hardening-guide 
+:community-path: reference-guides/rancher-security/hardening-guides/rke1-hardening-guide/index 
 :product-path: security/hardening-guides/rke1/rke1
 
 include::shared:ROOT:partial$en/eol-rke1-warning.adoc[]

--- a/versions/v2.11/modules/en/pages/security/hardening-guides/rke2/rke2.adoc
+++ b/versions/v2.11/modules/en/pages/security/hardening-guides/rke2/rke2.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-12
 :page-revdate: {revdate}
-:community-path: reference-guides/rancher-security/hardening-guides/rke2-hardening-guide/rke2-hardening-guide 
+:community-path: reference-guides/rancher-security/hardening-guides/rke2-hardening-guide/index 
 :product-path: security/hardening-guides/rke2/rke2
 
 This document provides prescriptive guidance for how to harden an RKE2 cluster intended for production, before provisioning it with Rancher. It outlines the configurations and controls required for Center for Information Security (CIS) Kubernetes benchmark controls.

--- a/versions/v2.11/modules/en/pages/security/security-overview.adoc
+++ b/versions/v2.11/modules/en/pages/security/security-overview.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-06-20
 :page-revdate: {revdate}
-:community-path: reference-guides/rancher-security/rancher-security 
+:community-path: reference-guides/rancher-security/index 
 :product-path: security/security-overview
 
 [pass]

--- a/versions/v2.11/modules/en/pages/security/selinux-rpm/selinux-rpm.adoc
+++ b/versions/v2.11/modules/en/pages/security/selinux-rpm/selinux-rpm.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-12
 :page-revdate: {revdate}
-:community-path: reference-guides/rancher-security/selinux-rpm/selinux-rpm 
+:community-path: reference-guides/rancher-security/selinux-rpm/index 
 :product-path: security/selinux-rpm/selinux-rpm
 
 https://en.wikipedia.org/wiki/Security-Enhanced_Linux[Security-Enhanced Linux (SELinux)] is a security enhancement to Linux.

--- a/versions/v2.11/modules/en/pages/troubleshooting/kubernetes-components/kubernetes-components.adoc
+++ b/versions/v2.11/modules/en/pages/troubleshooting/kubernetes-components/kubernetes-components.adoc
@@ -2,7 +2,7 @@
 :page-languages: [en, zh]
 :revdate: 2025-03-12
 :page-revdate: {revdate}
-:community-path: troubleshooting/kubernetes-components/kubernetes-components 
+:community-path: troubleshooting/kubernetes-components/index 
 :product-path: troubleshooting/kubernetes-components/kubernetes-components
 
 The commands and steps listed in this section apply to the core Kubernetes components on xref:cluster-deployment/launch-kubernetes-with-rancher.adoc[Rancher Launched Kubernetes] clusters.


### PR DESCRIPTION
My initial script had a logic error resulting in some files that should be named index.adoc not being named properly. This is a follow-up to fix such files.