### PR TITLE
[Community v2.13] Index pages should be named index

### DIFF
--- a/community-docs/v2.13/modules/ROOT/pages/getting-started/installation-and-upgrade/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/getting-started/installation-and-upgrade/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../versions/v2.13/modules/en/pages/installation-and-upgrade/installation-and-upgrade.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.13/modules/en/pages/installation-and-upgrade/install-rancher.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/getting-started/installation-and-upgrade/installation-references/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/getting-started/installation-and-upgrade/installation-references/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.13/modules/en/pages/installation-and-upgrade/references/references.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/getting-started/installation-and-upgrade/installation-requirements/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/getting-started/installation-and-upgrade/installation-requirements/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.13/modules/en/pages/installation-and-upgrade/requirements/requirements.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.13/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/air-gapped.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/getting-started/installation-and-upgrade/other-installation-methods/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/getting-started/installation-and-upgrade/other-installation-methods/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.13/modules/en/pages/installation-and-upgrade/other-installation-methods/other-installation-methods.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.13/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/http-proxy.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/getting-started/installation-and-upgrade/resources/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/getting-started/installation-and-upgrade/resources/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.13/modules/en/pages/installation-and-upgrade/resources/resources.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/getting-started/quick-start-guides/deploy-rancher-manager/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/getting-started/quick-start-guides/deploy-rancher-manager/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.13/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/deploy-rancher.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/getting-started/quick-start-guides/deploy-workloads/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/getting-started/quick-start-guides/deploy-workloads/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.13/modules/en/pages/installation-and-upgrade/quick-start/deploy-workloads/deploy-workloads.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/getting-started/quick-start-guides/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/getting-started/quick-start-guides/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../versions/v2.13/modules/en/pages/installation-and-upgrade/quick-start/quick-start.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/how-to-guides/advanced-user-guides/compliance-scan-guides/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/how-to-guides/advanced-user-guides/compliance-scan-guides/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.13/modules/en/pages/security/compliance-scans/how-to.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/how-to-guides/advanced-user-guides/enable-experimental-features/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/how-to-guides/advanced-user-guides/enable-experimental-features/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.13/modules/en/pages/rancher-admin/experimental-features/experimental-features.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/how-to-guides/advanced-user-guides/istio-setup-guide/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/how-to-guides/advanced-user-guides/istio-setup-guide/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.13/modules/en/pages/observability/istio/guides/guides.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/how-to-guides/advanced-user-guides/manage-projects/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/how-to-guides/advanced-user-guides/manage-projects/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.13/modules/en/pages/cluster-admin/project-admin/project-admin.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/how-to-guides/advanced-user-guides/manage-projects/manage-project-resource-quotas/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/how-to-guides/advanced-user-guides/manage-projects/manage-project-resource-quotas/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.13/modules/en/pages/cluster-admin/project-admin/project-resource-quotas/project-resource-quotas.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/advanced-configuration/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/advanced-configuration/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.13/modules/en/pages/observability/monitoring-and-dashboards/configuration/advanced/advanced.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.13/modules/en/pages/observability/monitoring-and-dashboards/configuration/configuration.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.13/modules/en/pages/rancher-admin/global-configuration/provisioning-drivers/provisioning-drivers.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-rke1-templates/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-rke1-templates/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.13/modules/en/pages/rancher-admin/global-configuration/rke1-templates/rke1-templates.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.13/modules/en/pages/rancher-admin/users/authn-and-authz/authn-and-authz.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-microsoft-ad-federation-service-saml/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-microsoft-ad-federation-service-saml/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.13/modules/en/pages/rancher-admin/users/authn-and-authz/microsoft-ad-federation-service-saml/microsoft-ad-federation-service-saml.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-openldap/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-openldap/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.13/modules/en/pages/rancher-admin/users/authn-and-authz/openldap/openldap.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-shibboleth-saml/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/configure-shibboleth-saml/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.13/modules/en/pages/rancher-admin/users/authn-and-authz/shibboleth-saml/shibboleth-saml.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.13/modules/en/pages/rancher-admin/rancher-admin.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.13/modules/en/pages/rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/manage-role-based-access-control-rbac.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.13/modules/en/pages/rancher-admin/back-up-restore-and-disaster-recovery/back-up-restore-and-disaster-recovery.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/helm-charts-in-rancher/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/helm-charts-in-rancher/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.13/modules/en/pages/cluster-admin/helm-charts-in-rancher/helm-charts-in-rancher.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/infrastructure-setup/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/infrastructure-setup/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.13/modules/en/pages/installation-and-upgrade/infrastructure-setup/infrastructure-setup.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/kubernetes-cluster-setup/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/kubernetes-cluster-setup/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.13/modules/en/pages/installation-and-upgrade/install-kubernetes/install-kubernetes.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/checklist-for-production-ready-clusters/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/checklist-for-production-ready-clusters/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.13/modules/en/pages/cluster-deployment/production-checklist/production-checklist.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.13/modules/en/pages/cluster-deployment/cluster-deployment.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.13/modules/en/pages/cluster-deployment/set-up-cloud-providers/set-up-cloud-providers.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.13/modules/en/pages/cluster-deployment/hosted-kubernetes/hosted-kubernetes.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/use-windows-clusters/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/use-windows-clusters/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.13/modules/en/pages/cluster-deployment/custom-clusters/windows/use-windows-clusters.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/kubernetes-resources-setup/horizontal-pod-autoscaler/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/kubernetes-resources-setup/horizontal-pod-autoscaler/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.13/modules/en/pages/cluster-admin/kubernetes-resources/horizontal-pod-autoscaler/horizontal-pod-autoscaler.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/kubernetes-resources-setup/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/kubernetes-resources-setup/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.13/modules/en/pages/cluster-admin/kubernetes-resources/kubernetes-resources-setup.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/kubernetes-resources-setup/load-balancer-and-ingress-controller/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/kubernetes-resources-setup/load-balancer-and-ingress-controller/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.13/modules/en/pages/cluster-admin/kubernetes-resources/load-balancer-and-ingress-controller/load-balancer-and-ingress-controller.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/kubernetes-resources-setup/workloads-and-pods/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/kubernetes-resources-setup/workloads-and-pods/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.13/modules/en/pages/cluster-admin/kubernetes-resources/workloads-and-pods/workloads-and-pods.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.13/modules/en/pages/cluster-deployment/launch-kubernetes-with-rancher.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.13/modules/en/pages/cluster-deployment/infra-providers/infra-providers.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/nutanix/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/nutanix/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../../versions/v2.13/modules/en/pages/cluster-deployment/infra-providers/nutanix/nutanix.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../../versions/v2.13/modules/en/pages/cluster-deployment/infra-providers/vsphere/vsphere.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/manage-clusters/access-clusters/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/manage-clusters/access-clusters/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.13/modules/en/pages/cluster-admin/manage-clusters/access-clusters/access-clusters.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/manage-clusters/create-kubernetes-persistent-storage/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/manage-clusters/create-kubernetes-persistent-storage/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.13/modules/en/pages/cluster-admin/manage-clusters/persistent-storage/manage-persistent-storage.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/manage-clusters/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/manage-clusters/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.13/modules/en/pages/cluster-admin/manage-clusters/manage-clusters.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/manage-clusters/provisioning-storage-examples/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/how-to-guides/new-user-guides/manage-clusters/provisioning-storage-examples/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.13/modules/en/pages/cluster-admin/manage-clusters/persistent-storage/examples/examples.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/integrations-in-rancher/cloud-marketplace/aws-cloud-marketplace/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/integrations-in-rancher/cloud-marketplace/aws-cloud-marketplace/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.13/modules/en/pages/installation-and-upgrade/hosted-kubernetes/cloud-marketplace/aws/aws.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/integrations-in-rancher/cloud-marketplace/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/integrations-in-rancher/cloud-marketplace/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../versions/v2.13/modules/en/pages/installation-and-upgrade/hosted-kubernetes/cloud-marketplace/cloud-marketplace.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/integrations-in-rancher/cluster-api/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/integrations-in-rancher/cluster-api/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../versions/v2.13/modules/en/pages/integrations/cluster-api/cluster-api.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/integrations-in-rancher/compliance-scans/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/integrations-in-rancher/compliance-scans/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../versions/v2.13/modules/en/pages/security/compliance-scans/compliance-scans.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/integrations-in-rancher/elemental/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/integrations-in-rancher/elemental/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../versions/v2.13/modules/en/pages/integrations/elemental.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/integrations-in-rancher/fleet/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/integrations-in-rancher/fleet/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../versions/v2.13/modules/en/pages/integrations/fleet/fleet.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/integrations-in-rancher/harvester/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/integrations-in-rancher/harvester/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../versions/v2.13/modules/en/pages/integrations/harvester/harvester.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/integrations-in-rancher/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/integrations-in-rancher/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../versions/v2.13/modules/en/pages/integrations/integrations.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/integrations-in-rancher/istio/configuration-options/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/integrations-in-rancher/istio/configuration-options/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.13/modules/en/pages/observability/istio/configuration/configuration.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/integrations-in-rancher/istio/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/integrations-in-rancher/istio/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../versions/v2.13/modules/en/pages/observability/istio/istio.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/integrations-in-rancher/kubernetes-distributions/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/integrations-in-rancher/kubernetes-distributions/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../versions/v2.13/modules/en/pages/integrations/kubernetes-distributions.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/integrations-in-rancher/kubewarden/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/integrations-in-rancher/kubewarden/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../versions/v2.13/modules/en/pages/integrations/kubewarden.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/integrations-in-rancher/logging/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/integrations-in-rancher/logging/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../versions/v2.13/modules/en/pages/observability/logging/logging.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/integrations-in-rancher/longhorn/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/integrations-in-rancher/longhorn/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../versions/v2.13/modules/en/pages/integrations/longhorn/longhorn.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/integrations-in-rancher/monitoring-and-alerting/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/integrations-in-rancher/monitoring-and-alerting/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../versions/v2.13/modules/en/pages/observability/monitoring-and-dashboards/monitoring-and-dashboards.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/integrations-in-rancher/neuvector/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/integrations-in-rancher/neuvector/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../versions/v2.13/modules/en/pages/integrations/neuvector/neuvector.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/integrations-in-rancher/suse-observability/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/integrations-in-rancher/suse-observability/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../versions/v2.13/modules/en/pages/integrations/suse-observability.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/reference-guides/best-practices/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/reference-guides/best-practices/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../versions/v2.13/modules/en/pages/installation-and-upgrade/best-practices/resources.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/reference-guides/best-practices/rancher-server/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/reference-guides/best-practices/rancher-server/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.13/modules/en/pages/installation-and-upgrade/best-practices/best-practices.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/reference-guides/cluster-configuration/rancher-server-configuration/gke-cluster-configuration/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.13/modules/en/pages/cluster-deployment/hosted-kubernetes/gke/configuration.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/reference-guides/cluster-configuration/rancher-server-configuration/use-existing-nodes/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/reference-guides/cluster-configuration/rancher-server-configuration/use-existing-nodes/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../../versions/v2.13/modules/en/pages/cluster-deployment/custom-clusters/custom-clusters.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/reference-guides/prometheus-federator/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/reference-guides/prometheus-federator/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../versions/v2.13/modules/en/pages/observability/monitoring-and-dashboards/prometheus-federator/prometheus-federator.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/reference-guides/rancher-manager-architecture/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/reference-guides/rancher-manager-architecture/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../versions/v2.13/modules/en/pages/about-rancher/architecture/architecture.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/reference-guides/rancher-security/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/reference-guides/rancher-security/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../versions/v2.13/modules/en/pages/security/security-overview.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/reference-guides/rancher-security/selinux-rpm/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/reference-guides/rancher-security/selinux-rpm/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../../versions/v2.13/modules/en/pages/security/selinux-rpm/selinux-rpm.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/reference-guides/user-settings/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/reference-guides/user-settings/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../versions/v2.13/modules/en/pages/rancher-admin/users/settings/settings.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/troubleshooting/kubernetes-components/index.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/troubleshooting/kubernetes-components/index.adoc
@@ -1,0 +1,1 @@
+../../../../../../../versions/v2.13/modules/en/pages/troubleshooting/kubernetes-components/kubernetes-components.adoc


### PR DESCRIPTION
My initial script had a logic error resulting in some files that should be named index.adoc not being named properly. This is a follow-up to fix such files.