### PR TITLE
[Community] Add images dir (as symlink) to modules

### DIFF
--- a/community-docs/v2.10/modules/ROOT/images
+++ b/community-docs/v2.10/modules/ROOT/images
@@ -1,0 +1,1 @@
+../../../../versions/v2.10/modules/en/images/

--- a/community-docs/v2.11/modules/ROOT/images
+++ b/community-docs/v2.11/modules/ROOT/images
@@ -1,0 +1,1 @@
+../../../../versions/v2.11/modules/en/images/

--- a/community-docs/v2.12/modules/ROOT/images
+++ b/community-docs/v2.12/modules/ROOT/images
@@ -1,0 +1,1 @@
+../../../../versions/v2.12/modules/en/images/

--- a/community-docs/v2.13/modules/ROOT/images
+++ b/community-docs/v2.13/modules/ROOT/images
@@ -1,0 +1,1 @@
+../../../../versions/v2.13/modules/en/images/

--- a/community-docs/v2.9/modules/ROOT/images
+++ b/community-docs/v2.9/modules/ROOT/images
@@ -1,0 +1,1 @@
+../../../../versions/v2.9/modules/en/images/


### PR DESCRIPTION
Similar to the adoc files, most images are shared across Community and Product builds so a symlink is used.