### PR TITLE
Add swagger symlinks to community-docs

### DIFF
--- a/community-docs/v2.10/modules/ROOT/attachments/swagger-v2.10.json
+++ b/community-docs/v2.10/modules/ROOT/attachments/swagger-v2.10.json
@@ -1,0 +1,1 @@
+../../../../../versions/v2.10/modules/en/attachments/swagger-v2.10.json

--- a/community-docs/v2.11/modules/ROOT/attachments/swagger-v2.11.json
+++ b/community-docs/v2.11/modules/ROOT/attachments/swagger-v2.11.json
@@ -1,0 +1,1 @@
+../../../../../versions/v2.11/modules/en/attachments/swagger-v2.11.json

--- a/community-docs/v2.12/modules/ROOT/attachments/swagger-v2.12.json
+++ b/community-docs/v2.12/modules/ROOT/attachments/swagger-v2.12.json
@@ -1,0 +1,1 @@
+../../../../../versions/v2.12/modules/en/attachments/swagger-v2.12.json

--- a/community-docs/v2.13/modules/ROOT/attachments/swagger-v2.13.json
+++ b/community-docs/v2.13/modules/ROOT/attachments/swagger-v2.13.json
@@ -1,0 +1,1 @@
+../../../../../versions/v2.13/modules/en/attachments/swagger-v2.13.json

--- a/community-docs/v2.9/modules/ROOT/attachments/swagger-v2.9.json
+++ b/community-docs/v2.9/modules/ROOT/attachments/swagger-v2.9.json
@@ -1,0 +1,1 @@
+../../../../../versions/v2.9/modules/en/attachments/swagger-v2.9.json


### PR DESCRIPTION
Should fix a  `Failed to load...` error on GH Pages.

However,  when browsing a local build for both community and product, there seems to be a separate ` process is not defined ` error ending in a stack trace...