### PR TITLE
Replace ingress-nginx with AppCo Traefik

### DIFF
--- a/versions/v2.10/modules/en/pages/installation-and-upgrade/hosted-kubernetes/rancher-on-aks.adoc
+++ b/versions/v2.10/modules/en/pages/installation-and-upgrade/hosted-kubernetes/rancher-on-aks.adoc
@@ -1,6 +1,6 @@
 = Installing {rancher-product-name} on Azure Kubernetes Service
 :page-languages: [en, zh]
-:revdate: 2025-03-17
+:revdate: 2026-03-09
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-aks.adoc 
 :product-path: installation-and-upgrade/hosted-kubernetes/rancher-on-aks.adoc
@@ -60,13 +60,6 @@ az group create --name rancher-rg --location eastus
 
 To create an AKS cluster, run the following command. Use a VM size that applies to your use case. Refer to https://docs.microsoft.com/en-us/azure/virtual-machines/sizes[this article] for available sizes and options. When choosing a Kubernetes version, be sure to first consult the https://rancher.com/support-matrix/[support matrix] to find the highest version of Kubernetes that has been validated for your Rancher version.
 
-[NOTE]
-====
-
-If you're updating from an older version of Kubernetes, to Kubernetes v1.22 or above, you also need to https://kubernetes.github.io/ingress-nginx/user-guide/k8s-122-migration/[update] ingress-nginx.
-====
-
-
 ----
 az aks create \
   --resource-group rancher-rg \
@@ -90,40 +83,29 @@ This command merges your cluster's credentials into the existing kubeconfig and 
 
 == 5. Install an Ingress
 
-The cluster needs an Ingress so that Rancher can be accessed from outside the cluster. Installing an Ingress requires allocating a public IP address. Ensure you have sufficient quota, otherwise it will fail to assign the IP address. Limits for public IP addresses are applicable at a regional level per subscription.
+The cluster needs an Ingress so that Rancher can be accessed from outside the cluster. Installing an Ingress requires allocating a public IP address. Ensure you have sufficient quota, otherwise it will fail to assign the IP address. Limits for public IP addresses are applicable at a regional level per subscription. You can use a managed ingress controller provided by Azure or a third-party ingress controller like Traefik.
 
-To make sure that you choose the correct Ingress-NGINX Helm chart, first find an `Ingress-NGINX version` that's compatible with your Kubernetes version in the https://github.com/kubernetes/ingress-nginx#supported-versions-table[Kubernetes/ingress-nginx support table].
+[WARNING]
+====
+It is not recommended to install a third-party ingress controller, like Traefik, if a managed ingress controller is already being used.
+====
 
-Then, list the Helm charts available to you by running the following command:
+[WARNING]
+====
+**Ingress-NGINX EOL:** The community `ingress-nginx` controller reaches End-of-Life (EOL) in March 2026. This page uses Traefik, which is the recommended migration path for Rancher environments.
+====
 
-----
-helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
-helm repo update
-helm search repo ingress-nginx -l
-----
+Traefik includes a native Ingress NGINX provider. This allows you to migrate from NGINX without rewriting your existing Ingress objects, as Traefik will automatically interpret `nginx.ingress.kubernetes.io` annotations. If you are upgrading a cluster that is already using `ingress-nginx`, follow this https://doc.traefik.io/traefik/migrate/nginx-to-traefik/[guide] for more information.
 
-The `helm search` command's output contains an `APP VERSION` column. The versions under this column are equivalent to the `Ingress-NGINX version` you chose earlier. Using the app version, select a chart version that bundles an app compatible with your Kubernetes install. For example, if you have Kubernetes v1.24, you can select the v4.6.0 Helm chart, since Ingress-NGINX v1.7.0 comes bundled with that chart, and v1.7.0 is compatible with Kubernetes v1.24. When in doubt, select the most recent compatible version.
+To install Traefik, we highly recommend using the Traefik application in the https://apps.rancher.io/applications/traefik-proxy[Rancher Prime Application Collection]. Check their https://docs.apps.rancher.io/howto-guides/integrate-with-rancher-manager[documentation to integrate with Rancher Manager].
 
-Now that you know which Helm chart `version` you need, run the following command. It installs an `nginx-ingress-controller` with a Kubernetes load balancer service:
-
-----
-helm search repo ingress-nginx -l
-helm upgrade --install \
-  ingress-nginx ingress-nginx/ingress-nginx \
-  --namespace ingress-nginx \
-  --set controller.service.type=LoadBalancer \
-  --set controller.service.annotations."service\.beta\.kubernetes\.io/azure-load-balancer-health-probe-request-path"=/healthz \
-  --set controller.service.externalTrafficPolicy=Local \
-  --version 4.6.0 \
-  --create-namespace
-----
 
 == 6. Get Load Balancer IP
 
 To get the address of the load balancer, run:
 
 ----
-kubectl get service ingress-nginx-controller --namespace=ingress-nginx
+kubectl get service traefik --namespace=traefik
 ----
 
 The result should look similar to the following:
@@ -131,8 +113,7 @@ The result should look similar to the following:
 ----
 NAME                       TYPE           CLUSTER-IP     EXTERNAL-IP    PORT(S)
  AGE
-ingress-nginx-controller   LoadBalancer   10.0.116.18    40.31.180.83   80:31229/TCP,443:31050/TCP
- 67s
+traefik  LoadBalancer   10.0.116.18    40.31.180.83   80:31229/TCP,443:31050/TCP 67s
 ----
 
 Save the `EXTERNAL-IP`.
@@ -154,7 +135,7 @@ Use that DNS name from the previous step as the Rancher server URL when you inst
 When installing Rancher on top of this setup, you will also need to pass the value below into the Rancher Helm install command in order to set the name of the ingress controller to be used with Rancher's ingress resource:
 
 ----
---set ingress.ingressClassName=nginx
+--set ingress.ingressClassName=traefik
 ----
 
 Refer {xref-install-rancher}#_5_install_rancher_with_helm_and_your_chosen_certificate_option[here for the Helm install command] for your chosen certificate option.

--- a/versions/v2.10/modules/en/pages/installation-and-upgrade/hosted-kubernetes/rancher-on-amazon-eks.adoc
+++ b/versions/v2.10/modules/en/pages/installation-and-upgrade/hosted-kubernetes/rancher-on-amazon-eks.adoc
@@ -1,6 +1,6 @@
 = Installing {rancher-product-name} on Amazon EKS
 :page-languages: [en, zh]
-:revdate: 2024-12-13
+:revdate: 2026-03-09
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-amazon-eks.adoc 
 :product-path: installation-and-upgrade/hosted-kubernetes/rancher-on-amazon-eks.adoc
@@ -70,8 +70,6 @@ Then enter the following values:
 
 To create an EKS cluster, run the following command. Use the AWS region that applies to your use case. When choosing a Kubernetes version, be sure to first consult the https://rancher.com/support-matrix/[support matrix] to find the highest version of Kubernetes that has been validated for your Rancher version.
 
-NOTE: If you're updating from an older version of Kubernetes, to Kubernetes v1.22 or above, you also need to https://kubernetes.github.io/ingress-nginx/user-guide/k8s-122-migration/[update] ingress-nginx.
-
 ----
 eksctl create cluster \
   --name rancher-server \
@@ -106,37 +104,29 @@ rancher-server-cluster		us-west-2	True
 
 === 5. Install an Ingress
 
-The cluster needs an Ingress so that Rancher can be accessed from outside the cluster.
+The cluster needs an Ingress so that Rancher can be accessed from outside the cluster. Installing an Ingress requires allocating a public IP address. Ensure you have sufficient quota, otherwise it will fail to assign the IP address. Limits for public IP addresses are applicable at a regional level per subscription. You can use a managed ingress controller provided by AWS (ALB) or a third-party ingress controller like Traefik.
 
-To make sure that you choose the correct Ingress-NGINX Helm chart, first find an `Ingress-NGINX version` that's compatible with your Kubernetes version in the https://github.com/kubernetes/ingress-nginx#supported-versions-table[Kubernetes/ingress-nginx support table].
+[WARNING]
+====
+It is not recommended to install a third-party ingress controller, like Traefik, if a managed ingress controller is already being used.
+====
 
-Then, list the Helm charts available to you by running the following command:
+[WARNING]
+====
+**Ingress-NGINX EOL:** The community `ingress-nginx` controller reaches End-of-Life (EOL) in March 2026. This page uses Traefik, which is the recommended migration path for Rancher environments.
+====
 
-----
-helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
-helm repo update
-helm search repo ingress-nginx -l
-----
+Traefik includes a native Ingress NGINX provider. This allows you to migrate from NGINX without rewriting your existing Ingress objects, as Traefik will automatically interpret `nginx.ingress.kubernetes.io` annotations. If you are upgrading a cluster that is already using `ingress-nginx`, follow this https://doc.traefik.io/traefik/migrate/nginx-to-traefik/[guide] for more information.
 
-The `helm search` command's output contains an `APP VERSION` column. The versions under this column are equivalent to the `Ingress-NGINX version` you chose earlier. Using the app version, select a chart version that bundles an app compatible with your Kubernetes install. For example, if you have Kubernetes v1.23, you can select the v4.6.0 Helm chart, since Ingress-NGINX v1.7.0 comes bundled with that chart, and v1.7.0 is compatible with Kubernetes v1.23. When in doubt, select the most recent compatible version.
+To install Traefik, we highly recommend using the Traefik application in the https://apps.rancher.io/applications/traefik-proxy[Rancher Prime Application Collection]. Check their https://docs.apps.rancher.io/howto-guides/integrate-with-rancher-manager[documentation to integrate with Rancher Manager].
 
-Now that you know which Helm chart `version` you need, run the following command. It installs an `nginx-ingress-controller` with a Kubernetes load balancer service:
-
-----
-helm upgrade --install \
-  ingress-nginx ingress-nginx/ingress-nginx \
-  --namespace ingress-nginx \
-  --set controller.service.type=LoadBalancer \
-  --version 4.6.0 \
-  --create-namespace
-----
 
 === 6. Get Load Balancer IP
 
 To get the address of the load balancer, run:
 
 ----
-kubectl get service ingress-nginx-controller --namespace=ingress-nginx
+kubectl get service traefik --namespace=traefik
 ----
 
 The result should look similar to the following:
@@ -144,8 +134,7 @@ The result should look similar to the following:
 ----
 NAME                       TYPE           CLUSTER-IP     EXTERNAL-IP                                                              PORT(S)
  AGE
-ingress-nginx-controller   LoadBalancer   10.100.90.18   a904a952c73bf4f668a17c46ac7c56ab-962521486.us-west-2.elb.amazonaws.com   80:31229/TCP,443:31050/TCP
- 27m
+traefik  LoadBalancer   10.0.116.18    40.31.180.83   80:31229/TCP,443:31050/TCP 27m
 ----
 
 Save the `EXTERNAL-IP`.
@@ -167,7 +156,7 @@ Use that DNS name from the previous step as the Rancher server URL when you inst
 When installing Rancher on top of this setup, you will also need to pass the value below into the Rancher Helm install command in order to set the name of the ingress controller to be used with Rancher's ingress resource:
 
 ----
---set ingress.ingressClassName=nginx
+--set ingress.ingressClassName=traefik
 ----
 
 Refer {xref-install-rancher}#_5_install_rancher_with_helm_and_your_chosen_certificate_option[here for the Helm install command] for your chosen certificate option.

--- a/versions/v2.10/modules/en/pages/installation-and-upgrade/hosted-kubernetes/rancher-on-gke.adoc
+++ b/versions/v2.10/modules/en/pages/installation-and-upgrade/hosted-kubernetes/rancher-on-gke.adoc
@@ -1,6 +1,6 @@
 = Installing {rancher-product-name} on a Google Kubernetes Engine Cluster
 :page-languages: [en, zh]
-:revdate: 2024-12-13
+:revdate: 2026-03-09
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-gke.adoc 
 :product-path: installation-and-upgrade/hosted-kubernetes/rancher-on-gke.adoc
@@ -139,8 +139,6 @@ When choosing a Kubernetes version, be sure to first consult the https://rancher
 
 To successfully create a GKE cluster with Rancher, your GKE must be in Standard mode. GKE has two modes of operation when creating a Kubernetes cluster, Autopilot and Standard mode. The cluster configuration for Autopilot mode has restrictions on editing the kube-system namespace. However, Rancher needs to create resources in the kube-system namespace during installation. As a result, you will not be able to install Rancher on a GKE cluster created in Autopilot mode. For more information about the difference between GKE Autopilot mode and Standard mode, visit https://cloud.google.com/kubernetes-engine/docs/resources/autopilot-standard-feature-comparison[Compare GKE Autopilot and Standard.]
 
-NOTE: If you're updating from an older version of Kubernetes, to Kubernetes v1.22 or above, you also need to https://kubernetes.github.io/ingress-nginx/user-guide/k8s-122-migration/[update] ingress-nginx.
-
 ----
 gcloud container clusters create cluster-name --num-nodes=3 --cluster-version=<VERSION>
 ----
@@ -157,34 +155,37 @@ This command configures `kubectl` to use the cluster you created.
 
 == 7. Install an Ingress
 
-The cluster needs an Ingress so that Rancher can be accessed from outside the cluster.
+The cluster needs an Ingress so that Rancher can be accessed from outside the cluster. Installing an Ingress requires allocating a public IP address. Ensure you have sufficient quota, otherwise it will fail to assign the IP address. Limits for public IP addresses are applicable at a regional level per subscription. You can use a managed ingress controller provided by GCP or a third-party ingress controller like Traefik.
 
-The following command installs an `nginx-ingress-controller` with a LoadBalancer service:
+[WARNING]
+====
+It is not recommended to install a third-party ingress controller, like Traefik, if a managed ingress controller is already being used
+====
 
-----
-helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
-helm repo update
-helm upgrade --install \
-  ingress-nginx ingress-nginx/ingress-nginx \
-  --namespace ingress-nginx \
-  --set controller.service.type=LoadBalancer \
-  --version 4.0.18 \
-  --create-namespace
-----
+[WARNING]
+====
+**Ingress-NGINX EOL:** The community `ingress-nginx` controller reaches End-of-Life (EOL) in March 2026. This page uses Traefik, which is the recommended migration path for Rancher environments.
+====
 
-== 8. Get the Load Balancer IP
+Traefik includes a native Ingress NGINX provider. This allows you to migrate from NGINX without rewriting your existing Ingress objects, as Traefik will automatically interpret `nginx.ingress.kubernetes.io` annotations. If you are upgrading a cluster that is already using `ingress-nginx`, follow this https://doc.traefik.io/traefik/migrate/nginx-to-traefik/[guide] for more information.
+
+To install Traefik, we highly recommend using the Traefik application in the https://apps.rancher.io/applications/traefik-proxy[Rancher Prime Application Collection]. Check their https://docs.apps.rancher.io/howto-guides/integrate-with-rancher-manager[documentation to integrate with Rancher Manager].
+
+
+== 8. Get Load Balancer IP
 
 To get the address of the load balancer, run:
 
 ----
-kubectl get service ingress-nginx-controller --namespace=ingress-nginx
+kubectl get service traefik --namespace=traefik
 ----
 
 The result should look similar to the following:
 
 ----
-NAME                       TYPE           CLUSTER-IP     EXTERNAL-IP     PORT(S)                      AGE
-ingress-nginx-controller   LoadBalancer   10.3.244.156   35.233.206.34   80:31876/TCP,443:32497/TCP   81s
+NAME                       TYPE           CLUSTER-IP     EXTERNAL-IP                                                              PORT(S)
+ AGE
+traefik  LoadBalancer   10.0.116.18    40.31.180.83   80:31229/TCP,443:31050/TCP 27m
 ----
 
 Save the `EXTERNAL-IP`.
@@ -206,7 +207,7 @@ Use the DNS name from the previous step as the Rancher server URL when you insta
 When installing Rancher on top of this setup, you will also need to set the name of the ingress controller to be used with Rancher's ingress resource:
 
 ----
---set ingress.ingressClassName=nginx
+--set ingress.ingressClassName=traefik
 ----
 
 Refer {xref-install-rancher}#_5_install_rancher_with_helm_and_your_chosen_certificate_option[here for the Helm install command] for your chosen certificate option.

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/hosted-kubernetes/rancher-on-aks.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/hosted-kubernetes/rancher-on-aks.adoc
@@ -1,6 +1,6 @@
 = Installing {rancher-product-name} on Azure Kubernetes Service
 :page-languages: [en, zh]
-:revdate: 2025-03-17
+:revdate: 2026-03-09
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-aks.adoc 
 :product-path: installation-and-upgrade/hosted-kubernetes/rancher-on-aks.adoc
@@ -60,13 +60,6 @@ az group create --name rancher-rg --location eastus
 
 To create an AKS cluster, run the following command. Use a VM size that applies to your use case. Refer to https://docs.microsoft.com/en-us/azure/virtual-machines/sizes[this article] for available sizes and options. When choosing a Kubernetes version, be sure to first consult the https://rancher.com/support-matrix/[support matrix] to find the highest version of Kubernetes that has been validated for your Rancher version.
 
-[NOTE]
-====
-
-If you're updating from an older version of Kubernetes, to Kubernetes v1.22 or above, you also need to https://kubernetes.github.io/ingress-nginx/user-guide/k8s-122-migration/[update] ingress-nginx.
-====
-
-
 ----
 az aks create \
   --resource-group rancher-rg \
@@ -90,40 +83,29 @@ This command merges your cluster's credentials into the existing kubeconfig and 
 
 == 5. Install an Ingress
 
-The cluster needs an Ingress so that Rancher can be accessed from outside the cluster. Installing an Ingress requires allocating a public IP address. Ensure you have sufficient quota, otherwise it will fail to assign the IP address. Limits for public IP addresses are applicable at a regional level per subscription.
+The cluster needs an Ingress so that Rancher can be accessed from outside the cluster. Installing an Ingress requires allocating a public IP address. Ensure you have sufficient quota, otherwise it will fail to assign the IP address. Limits for public IP addresses are applicable at a regional level per subscription. You can use a managed ingress controller provided by Azure or a third-party ingress controller like Traefik.
 
-To make sure that you choose the correct Ingress-NGINX Helm chart, first find an `Ingress-NGINX version` that's compatible with your Kubernetes version in the https://github.com/kubernetes/ingress-nginx#supported-versions-table[Kubernetes/ingress-nginx support table].
+[WARNING]
+====
+It is not recommended to install a third-party ingress controller, like Traefik, if a managed ingress controller is already being used.
+====
 
-Then, list the Helm charts available to you by running the following command:
+[WARNING]
+====
+**Ingress-NGINX EOL:** The community `ingress-nginx` controller reaches End-of-Life (EOL) in March 2026. This page uses Traefik, which is the recommended migration path for Rancher environments.
+====
 
-----
-helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
-helm repo update
-helm search repo ingress-nginx -l
-----
+Traefik includes a native Ingress NGINX provider. This allows you to migrate from NGINX without rewriting your existing Ingress objects, as Traefik will automatically interpret `nginx.ingress.kubernetes.io` annotations. If you are upgrading a cluster that is already using `ingress-nginx`, follow this https://doc.traefik.io/traefik/migrate/nginx-to-traefik/[guide] for more information.
 
-The `helm search` command's output contains an `APP VERSION` column. The versions under this column are equivalent to the `Ingress-NGINX version` you chose earlier. Using the app version, select a chart version that bundles an app compatible with your Kubernetes install. For example, if you have Kubernetes v1.24, you can select the v4.6.0 Helm chart, since Ingress-NGINX v1.7.0 comes bundled with that chart, and v1.7.0 is compatible with Kubernetes v1.24. When in doubt, select the most recent compatible version.
+To install Traefik, we highly recommend using the Traefik application in the https://apps.rancher.io/applications/traefik-proxy[Rancher Prime Application Collection]. Check their https://docs.apps.rancher.io/howto-guides/integrate-with-rancher-manager[documentation to integrate with Rancher Manager].
 
-Now that you know which Helm chart `version` you need, run the following command. It installs an `nginx-ingress-controller` with a Kubernetes load balancer service:
-
-----
-helm search repo ingress-nginx -l
-helm upgrade --install \
-  ingress-nginx ingress-nginx/ingress-nginx \
-  --namespace ingress-nginx \
-  --set controller.service.type=LoadBalancer \
-  --set controller.service.annotations."service\.beta\.kubernetes\.io/azure-load-balancer-health-probe-request-path"=/healthz \
-  --set controller.service.externalTrafficPolicy=Local \
-  --version 4.6.0 \
-  --create-namespace
-----
 
 == 6. Get Load Balancer IP
 
 To get the address of the load balancer, run:
 
 ----
-kubectl get service ingress-nginx-controller --namespace=ingress-nginx
+kubectl get service traefik --namespace=traefik
 ----
 
 The result should look similar to the following:
@@ -131,8 +113,7 @@ The result should look similar to the following:
 ----
 NAME                       TYPE           CLUSTER-IP     EXTERNAL-IP    PORT(S)
  AGE
-ingress-nginx-controller   LoadBalancer   10.0.116.18    40.31.180.83   80:31229/TCP,443:31050/TCP
- 67s
+traefik  LoadBalancer   10.0.116.18    40.31.180.83   80:31229/TCP,443:31050/TCP 67s
 ----
 
 Save the `EXTERNAL-IP`.
@@ -154,7 +135,7 @@ Use that DNS name from the previous step as the Rancher server URL when you inst
 When installing Rancher on top of this setup, you will also need to pass the value below into the Rancher Helm install command in order to set the name of the ingress controller to be used with Rancher's ingress resource:
 
 ----
---set ingress.ingressClassName=nginx
+--set ingress.ingressClassName=traefik
 ----
 
 Refer {xref-install-rancher}#_5_install_rancher_with_helm_and_your_chosen_certificate_option[here for the Helm install command] for your chosen certificate option.

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/hosted-kubernetes/rancher-on-amazon-eks.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/hosted-kubernetes/rancher-on-amazon-eks.adoc
@@ -1,6 +1,6 @@
 = Installing {rancher-product-name} on Amazon EKS
 :page-languages: [en, zh]
-:revdate: 2025-03-12
+:revdate: 2026-03-09
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-amazon-eks.adoc 
 :product-path: installation-and-upgrade/hosted-kubernetes/rancher-on-amazon-eks.adoc
@@ -70,8 +70,6 @@ Then enter the following values:
 
 To create an EKS cluster, run the following command. Use the AWS region that applies to your use case. When choosing a Kubernetes version, be sure to first consult the https://rancher.com/support-matrix/[support matrix] to find the highest version of Kubernetes that has been validated for your Rancher version.
 
-NOTE: If you're updating from an older version of Kubernetes, to Kubernetes v1.22 or above, you also need to https://kubernetes.github.io/ingress-nginx/user-guide/k8s-122-migration/[update] ingress-nginx.
-
 ----
 eksctl create cluster \
   --name rancher-server \
@@ -106,37 +104,29 @@ rancher-server-cluster		us-west-2	True
 
 === 5. Install an Ingress
 
-The cluster needs an Ingress so that Rancher can be accessed from outside the cluster.
+The cluster needs an Ingress so that Rancher can be accessed from outside the cluster. Installing an Ingress requires allocating a public IP address. Ensure you have sufficient quota, otherwise it will fail to assign the IP address. Limits for public IP addresses are applicable at a regional level per subscription. You can use a managed ingress controller provided by AWS (ALB) or a third-party ingress controller like Traefik.
 
-To make sure that you choose the correct Ingress-NGINX Helm chart, first find an `Ingress-NGINX version` that's compatible with your Kubernetes version in the https://github.com/kubernetes/ingress-nginx#supported-versions-table[Kubernetes/ingress-nginx support table].
+[WARNING]
+====
+It is not recommended to install a third-party ingress controller, like Traefik, if a managed ingress controller is already being used.
+====
 
-Then, list the Helm charts available to you by running the following command:
+[WARNING]
+====
+**Ingress-NGINX EOL:** The community `ingress-nginx` controller reaches End-of-Life (EOL) in March 2026. This page uses Traefik, which is the recommended migration path for Rancher environments.
+====
 
-----
-helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
-helm repo update
-helm search repo ingress-nginx -l
-----
+Traefik includes a native Ingress NGINX provider. This allows you to migrate from NGINX without rewriting your existing Ingress objects, as Traefik will automatically interpret `nginx.ingress.kubernetes.io` annotations. If you are upgrading a cluster that is already using `ingress-nginx`, follow this https://doc.traefik.io/traefik/migrate/nginx-to-traefik/[guide] for more information.
 
-The `helm search` command's output contains an `APP VERSION` column. The versions under this column are equivalent to the `Ingress-NGINX version` you chose earlier. Using the app version, select a chart version that bundles an app compatible with your Kubernetes install. For example, if you have Kubernetes v1.23, you can select the v4.6.0 Helm chart, since Ingress-NGINX v1.7.0 comes bundled with that chart, and v1.7.0 is compatible with Kubernetes v1.23. When in doubt, select the most recent compatible version.
+To install Traefik, we highly recommend using the Traefik application in the https://apps.rancher.io/applications/traefik-proxy[Rancher Prime Application Collection]. Check their https://docs.apps.rancher.io/howto-guides/integrate-with-rancher-manager[documentation to integrate with Rancher Manager].
 
-Now that you know which Helm chart `version` you need, run the following command. It installs an `nginx-ingress-controller` with a Kubernetes load balancer service:
-
-----
-helm upgrade --install \
-  ingress-nginx ingress-nginx/ingress-nginx \
-  --namespace ingress-nginx \
-  --set controller.service.type=LoadBalancer \
-  --version 4.6.0 \
-  --create-namespace
-----
 
 === 6. Get Load Balancer IP
 
 To get the address of the load balancer, run:
 
 ----
-kubectl get service ingress-nginx-controller --namespace=ingress-nginx
+kubectl get service traefik --namespace=traefik
 ----
 
 The result should look similar to the following:
@@ -144,8 +134,7 @@ The result should look similar to the following:
 ----
 NAME                       TYPE           CLUSTER-IP     EXTERNAL-IP                                                              PORT(S)
  AGE
-ingress-nginx-controller   LoadBalancer   10.100.90.18   a904a952c73bf4f668a17c46ac7c56ab-962521486.us-west-2.elb.amazonaws.com   80:31229/TCP,443:31050/TCP
- 27m
+traefik  LoadBalancer   10.0.116.18    40.31.180.83   80:31229/TCP,443:31050/TCP 27m
 ----
 
 Save the `EXTERNAL-IP`.
@@ -167,7 +156,7 @@ Use that DNS name from the previous step as the Rancher server URL when you inst
 When installing Rancher on top of this setup, you will also need to pass the value below into the Rancher Helm install command in order to set the name of the ingress controller to be used with Rancher's ingress resource:
 
 ----
---set ingress.ingressClassName=nginx
+--set ingress.ingressClassName=traefik
 ----
 
 Refer {xref-install-rancher}#_5_install_rancher_with_helm_and_your_chosen_certificate_option[here for the Helm install command] for your chosen certificate option.

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/hosted-kubernetes/rancher-on-gke.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/hosted-kubernetes/rancher-on-gke.adoc
@@ -1,6 +1,6 @@
 = Installing {rancher-product-name} on a Google Kubernetes Engine Cluster
 :page-languages: [en, zh]
-:revdate: 2025-03-12
+:revdate: 2026-03-09
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-gke.adoc 
 :product-path: installation-and-upgrade/hosted-kubernetes/rancher-on-gke.adoc
@@ -139,8 +139,6 @@ When choosing a Kubernetes version, be sure to first consult the https://rancher
 
 To successfully create a GKE cluster with Rancher, your GKE must be in Standard mode. GKE has two modes of operation when creating a Kubernetes cluster, Autopilot and Standard mode. The cluster configuration for Autopilot mode has restrictions on editing the kube-system namespace. However, Rancher needs to create resources in the kube-system namespace during installation. As a result, you will not be able to install Rancher on a GKE cluster created in Autopilot mode. For more information about the difference between GKE Autopilot mode and Standard mode, visit https://cloud.google.com/kubernetes-engine/docs/resources/autopilot-standard-feature-comparison[Compare GKE Autopilot and Standard.]
 
-NOTE: If you're updating from an older version of Kubernetes, to Kubernetes v1.22 or above, you also need to https://kubernetes.github.io/ingress-nginx/user-guide/k8s-122-migration/[update] ingress-nginx.
-
 ----
 gcloud container clusters create cluster-name --num-nodes=3 --cluster-version=<VERSION>
 ----
@@ -157,34 +155,37 @@ This command configures `kubectl` to use the cluster you created.
 
 == 7. Install an Ingress
 
-The cluster needs an Ingress so that Rancher can be accessed from outside the cluster.
+The cluster needs an Ingress so that Rancher can be accessed from outside the cluster. Installing an Ingress requires allocating a public IP address. Ensure you have sufficient quota, otherwise it will fail to assign the IP address. Limits for public IP addresses are applicable at a regional level per subscription. You can use a managed ingress controller provided by GCP or a third-party ingress controller like Traefik.
 
-The following command installs an `nginx-ingress-controller` with a LoadBalancer service:
+[WARNING]
+====
+It is not recommended to install a third-party ingress controller, like Traefik, if a managed ingress controller is already being used
+====
 
-----
-helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
-helm repo update
-helm upgrade --install \
-  ingress-nginx ingress-nginx/ingress-nginx \
-  --namespace ingress-nginx \
-  --set controller.service.type=LoadBalancer \
-  --version 4.0.18 \
-  --create-namespace
-----
+[WARNING]
+====
+**Ingress-NGINX EOL:** The community `ingress-nginx` controller reaches End-of-Life (EOL) in March 2026. This page uses Traefik, which is the recommended migration path for Rancher environments.
+====
 
-== 8. Get the Load Balancer IP
+Traefik includes a native Ingress NGINX provider. This allows you to migrate from NGINX without rewriting your existing Ingress objects, as Traefik will automatically interpret `nginx.ingress.kubernetes.io` annotations. If you are upgrading a cluster that is already using `ingress-nginx`, follow this https://doc.traefik.io/traefik/migrate/nginx-to-traefik/[guide] for more information.
+
+To install Traefik, we highly recommend using the Traefik application in the https://apps.rancher.io/applications/traefik-proxy[Rancher Prime Application Collection]. Check their https://docs.apps.rancher.io/howto-guides/integrate-with-rancher-manager[documentation to integrate with Rancher Manager].
+
+
+== 8. Get Load Balancer IP
 
 To get the address of the load balancer, run:
 
 ----
-kubectl get service ingress-nginx-controller --namespace=ingress-nginx
+kubectl get service traefik --namespace=traefik
 ----
 
 The result should look similar to the following:
 
 ----
-NAME                       TYPE           CLUSTER-IP     EXTERNAL-IP     PORT(S)                      AGE
-ingress-nginx-controller   LoadBalancer   10.3.244.156   35.233.206.34   80:31876/TCP,443:32497/TCP   81s
+NAME                       TYPE           CLUSTER-IP     EXTERNAL-IP                                                              PORT(S)
+ AGE
+traefik  LoadBalancer   10.0.116.18    40.31.180.83   80:31229/TCP,443:31050/TCP 27m
 ----
 
 Save the `EXTERNAL-IP`.
@@ -206,7 +207,7 @@ Use the DNS name from the previous step as the Rancher server URL when you insta
 When installing Rancher on top of this setup, you will also need to set the name of the ingress controller to be used with Rancher's ingress resource:
 
 ----
---set ingress.ingressClassName=nginx
+--set ingress.ingressClassName=traefik
 ----
 
 Refer {xref-install-rancher}#_5_install_rancher_with_helm_and_your_chosen_certificate_option[here for the Helm install command] for your chosen certificate option.

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/hosted-kubernetes/rancher-on-aks.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/hosted-kubernetes/rancher-on-aks.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-05
+:revdate: 2026-03-09
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-aks.adoc 
 :product-path: installation-and-upgrade/hosted-kubernetes/rancher-on-aks.adoc
@@ -62,13 +62,6 @@ az group create --name rancher-rg --location eastus
 
 To create an AKS cluster, run the following command. Use a VM size that applies to your use case. Refer to https://docs.microsoft.com/en-us/azure/virtual-machines/sizes[this article] for available sizes and options. When choosing a Kubernetes version, be sure to first consult the https://rancher.com/support-matrix/[support matrix] to find the highest version of Kubernetes that has been validated for your Rancher version.
 
-[NOTE]
-====
-
-If you're updating from an older version of Kubernetes, to Kubernetes v1.22 or above, you also need to https://kubernetes.github.io/ingress-nginx/user-guide/k8s-122-migration/[update] ingress-nginx.
-====
-
-
 ----
 az aks create \
   --resource-group rancher-rg \
@@ -92,40 +85,29 @@ This command merges your cluster's credentials into the existing kubeconfig and 
 
 == 5. Install an Ingress
 
-The cluster needs an Ingress so that Rancher can be accessed from outside the cluster. Installing an Ingress requires allocating a public IP address. Ensure you have sufficient quota, otherwise it will fail to assign the IP address. Limits for public IP addresses are applicable at a regional level per subscription.
+The cluster needs an Ingress so that Rancher can be accessed from outside the cluster. Installing an Ingress requires allocating a public IP address. Ensure you have sufficient quota, otherwise it will fail to assign the IP address. Limits for public IP addresses are applicable at a regional level per subscription. You can use a managed ingress controller provided by Azure or a third-party ingress controller like Traefik.
 
-To make sure that you choose the correct Ingress-NGINX Helm chart, first find an `Ingress-NGINX version` that's compatible with your Kubernetes version in the https://github.com/kubernetes/ingress-nginx#supported-versions-table[Kubernetes/ingress-nginx support table].
+[WARNING]
+====
+It is not recommended to install a third-party ingress controller, like Traefik, if a managed ingress controller is already being used.
+====
 
-Then, list the Helm charts available to you by running the following command:
+[WARNING]
+====
+**Ingress-NGINX EOL:** The community `ingress-nginx` controller reaches End-of-Life (EOL) in March 2026. This page uses Traefik, which is the recommended migration path for Rancher environments.
+====
 
-----
-helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
-helm repo update
-helm search repo ingress-nginx -l
-----
+Traefik includes a native Ingress NGINX provider. This allows you to migrate from NGINX without rewriting your existing Ingress objects, as Traefik will automatically interpret `nginx.ingress.kubernetes.io` annotations. If you are upgrading a cluster that is already using `ingress-nginx`, follow this https://doc.traefik.io/traefik/migrate/nginx-to-traefik/[guide] for more information.
 
-The `helm search` command's output contains an `APP VERSION` column. The versions under this column are equivalent to the `Ingress-NGINX version` you chose earlier. Using the app version, select a chart version that bundles an app compatible with your Kubernetes install. For example, if you have Kubernetes v1.24, you can select the v4.6.0 Helm chart, since Ingress-NGINX v1.7.0 comes bundled with that chart, and v1.7.0 is compatible with Kubernetes v1.24. When in doubt, select the most recent compatible version.
+To install Traefik, we highly recommend using the Traefik application in the https://apps.rancher.io/applications/traefik-proxy[Rancher Prime Application Collection]. Check their https://docs.apps.rancher.io/howto-guides/integrate-with-rancher-manager[documentation to integrate with Rancher Manager].
 
-Now that you know which Helm chart `version` you need, run the following command. It installs an `nginx-ingress-controller` with a Kubernetes load balancer service:
-
-----
-helm search repo ingress-nginx -l
-helm upgrade --install \
-  ingress-nginx ingress-nginx/ingress-nginx \
-  --namespace ingress-nginx \
-  --set controller.service.type=LoadBalancer \
-  --set controller.service.annotations."service\.beta\.kubernetes\.io/azure-load-balancer-health-probe-request-path"=/healthz \
-  --set controller.service.externalTrafficPolicy=Local \
-  --version 4.6.0 \
-  --create-namespace
-----
 
 == 6. Get Load Balancer IP
 
 To get the address of the load balancer, run:
 
 ----
-kubectl get service ingress-nginx-controller --namespace=ingress-nginx
+kubectl get service traefik --namespace=traefik
 ----
 
 The result should look similar to the following:
@@ -133,8 +115,7 @@ The result should look similar to the following:
 ----
 NAME                       TYPE           CLUSTER-IP     EXTERNAL-IP    PORT(S)
  AGE
-ingress-nginx-controller   LoadBalancer   10.0.116.18    40.31.180.83   80:31229/TCP,443:31050/TCP
- 67s
+traefik  LoadBalancer   10.0.116.18    40.31.180.83   80:31229/TCP,443:31050/TCP 67s
 ----
 
 Save the `EXTERNAL-IP`.
@@ -156,7 +137,7 @@ Use that DNS name from the previous step as the Rancher server URL when you inst
 When installing Rancher on top of this setup, you will also need to pass the value below into the Rancher Helm install command in order to set the name of the ingress controller to be used with Rancher's ingress resource:
 
 ----
---set ingress.ingressClassName=nginx
+--set ingress.ingressClassName=traefik
 ----
 
 Refer {xref-install-rancher}#_5_install_rancher_with_helm_and_your_chosen_certificate_option[here for the Helm install command] for your chosen certificate option.

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/hosted-kubernetes/rancher-on-amazon-eks.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/hosted-kubernetes/rancher-on-amazon-eks.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-05
+:revdate: 2026-03-09
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-amazon-eks.adoc 
 :product-path: installation-and-upgrade/hosted-kubernetes/rancher-on-amazon-eks.adoc
@@ -72,8 +72,6 @@ Then enter the following values:
 
 To create an EKS cluster, run the following command. Use the AWS region that applies to your use case. When choosing a Kubernetes version, be sure to first consult the https://rancher.com/support-matrix/[support matrix] to find the highest version of Kubernetes that has been validated for your Rancher version.
 
-NOTE: If you're updating from an older version of Kubernetes, to Kubernetes v1.22 or above, you also need to https://kubernetes.github.io/ingress-nginx/user-guide/k8s-122-migration/[update] ingress-nginx.
-
 ----
 eksctl create cluster \
   --name rancher-server \
@@ -108,37 +106,29 @@ rancher-server-cluster		us-west-2	True
 
 === 5. Install an Ingress
 
-The cluster needs an Ingress so that Rancher can be accessed from outside the cluster.
+The cluster needs an Ingress so that Rancher can be accessed from outside the cluster. Installing an Ingress requires allocating a public IP address. Ensure you have sufficient quota, otherwise it will fail to assign the IP address. Limits for public IP addresses are applicable at a regional level per subscription. You can use a managed ingress controller provided by AWS (ALB) or a third-party ingress controller like Traefik.
 
-To make sure that you choose the correct Ingress-NGINX Helm chart, first find an `Ingress-NGINX version` that's compatible with your Kubernetes version in the https://github.com/kubernetes/ingress-nginx#supported-versions-table[Kubernetes/ingress-nginx support table].
+[WARNING]
+====
+It is not recommended to install a third-party ingress controller, like Traefik, if a managed ingress controller is already being used.
+====
 
-Then, list the Helm charts available to you by running the following command:
+[WARNING]
+====
+**Ingress-NGINX EOL:** The community `ingress-nginx` controller reaches End-of-Life (EOL) in March 2026. This page uses Traefik, which is the recommended migration path for Rancher environments.
+====
 
-----
-helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
-helm repo update
-helm search repo ingress-nginx -l
-----
+Traefik includes a native Ingress NGINX provider. This allows you to migrate from NGINX without rewriting your existing Ingress objects, as Traefik will automatically interpret `nginx.ingress.kubernetes.io` annotations. If you are upgrading a cluster that is already using `ingress-nginx`, follow this https://doc.traefik.io/traefik/migrate/nginx-to-traefik/[guide] for more information.
 
-The `helm search` command's output contains an `APP VERSION` column. The versions under this column are equivalent to the `Ingress-NGINX version` you chose earlier. Using the app version, select a chart version that bundles an app compatible with your Kubernetes install. For example, if you have Kubernetes v1.23, you can select the v4.6.0 Helm chart, since Ingress-NGINX v1.7.0 comes bundled with that chart, and v1.7.0 is compatible with Kubernetes v1.23. When in doubt, select the most recent compatible version.
+To install Traefik, we highly recommend using the Traefik application in the https://apps.rancher.io/applications/traefik-proxy[Rancher Prime Application Collection]. Check their https://docs.apps.rancher.io/howto-guides/integrate-with-rancher-manager[documentation to integrate with Rancher Manager].
 
-Now that you know which Helm chart `version` you need, run the following command. It installs an `nginx-ingress-controller` with a Kubernetes load balancer service:
-
-----
-helm upgrade --install \
-  ingress-nginx ingress-nginx/ingress-nginx \
-  --namespace ingress-nginx \
-  --set controller.service.type=LoadBalancer \
-  --version 4.6.0 \
-  --create-namespace
-----
 
 === 6. Get Load Balancer IP
 
 To get the address of the load balancer, run:
 
 ----
-kubectl get service ingress-nginx-controller --namespace=ingress-nginx
+kubectl get service traefik --namespace=traefik
 ----
 
 The result should look similar to the following:
@@ -146,8 +136,7 @@ The result should look similar to the following:
 ----
 NAME                       TYPE           CLUSTER-IP     EXTERNAL-IP                                                              PORT(S)
  AGE
-ingress-nginx-controller   LoadBalancer   10.100.90.18   a904a952c73bf4f668a17c46ac7c56ab-962521486.us-west-2.elb.amazonaws.com   80:31229/TCP,443:31050/TCP
- 27m
+traefik  LoadBalancer   10.0.116.18    40.31.180.83   80:31229/TCP,443:31050/TCP 27m
 ----
 
 Save the `EXTERNAL-IP`.
@@ -169,7 +158,7 @@ Use that DNS name from the previous step as the Rancher server URL when you inst
 When installing Rancher on top of this setup, you will also need to pass the value below into the Rancher Helm install command in order to set the name of the ingress controller to be used with Rancher's ingress resource:
 
 ----
---set ingress.ingressClassName=nginx
+--set ingress.ingressClassName=traefik
 ----
 
 Refer {xref-install-rancher}#_5_install_rancher_with_helm_and_your_chosen_certificate_option[here for the Helm install command] for your chosen certificate option.

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/hosted-kubernetes/rancher-on-gke.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/hosted-kubernetes/rancher-on-gke.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-05
+:revdate: 2026-03-09
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-gke.adoc 
 :product-path: installation-and-upgrade/hosted-kubernetes/rancher-on-gke.adoc
@@ -141,8 +141,6 @@ When choosing a Kubernetes version, be sure to first consult the https://rancher
 
 To successfully create a GKE cluster with Rancher, your GKE must be in Standard mode. GKE has two modes of operation when creating a Kubernetes cluster, Autopilot and Standard mode. The cluster configuration for Autopilot mode has restrictions on editing the kube-system namespace. However, Rancher needs to create resources in the kube-system namespace during installation. As a result, you will not be able to install Rancher on a GKE cluster created in Autopilot mode. For more information about the difference between GKE Autopilot mode and Standard mode, visit https://cloud.google.com/kubernetes-engine/docs/resources/autopilot-standard-feature-comparison[Compare GKE Autopilot and Standard.]
 
-NOTE: If you're updating from an older version of Kubernetes, to Kubernetes v1.22 or above, you also need to https://kubernetes.github.io/ingress-nginx/user-guide/k8s-122-migration/[update] ingress-nginx.
-
 ----
 gcloud container clusters create cluster-name --num-nodes=3 --cluster-version=<VERSION>
 ----
@@ -159,34 +157,37 @@ This command configures `kubectl` to use the cluster you created.
 
 == 7. Install an Ingress
 
-The cluster needs an Ingress so that Rancher can be accessed from outside the cluster.
+The cluster needs an Ingress so that Rancher can be accessed from outside the cluster. Installing an Ingress requires allocating a public IP address. Ensure you have sufficient quota, otherwise it will fail to assign the IP address. Limits for public IP addresses are applicable at a regional level per subscription. You can use a managed ingress controller provided by GCP or a third-party ingress controller like Traefik.
 
-The following command installs an `nginx-ingress-controller` with a LoadBalancer service:
+[WARNING]
+====
+It is not recommended to install a third-party ingress controller, like Traefik, if a managed ingress controller is already being used
+====
 
-----
-helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
-helm repo update
-helm upgrade --install \
-  ingress-nginx ingress-nginx/ingress-nginx \
-  --namespace ingress-nginx \
-  --set controller.service.type=LoadBalancer \
-  --version 4.0.18 \
-  --create-namespace
-----
+[WARNING]
+====
+**Ingress-NGINX EOL:** The community `ingress-nginx` controller reaches End-of-Life (EOL) in March 2026. This page uses Traefik, which is the recommended migration path for Rancher environments.
+====
 
-== 8. Get the Load Balancer IP
+Traefik includes a native Ingress NGINX provider. This allows you to migrate from NGINX without rewriting your existing Ingress objects, as Traefik will automatically interpret `nginx.ingress.kubernetes.io` annotations. If you are upgrading a cluster that is already using `ingress-nginx`, follow this https://doc.traefik.io/traefik/migrate/nginx-to-traefik/[guide] for more information.
+
+To install Traefik, we highly recommend using the Traefik application in the https://apps.rancher.io/applications/traefik-proxy[Rancher Prime Application Collection]. Check their https://docs.apps.rancher.io/howto-guides/integrate-with-rancher-manager[documentation to integrate with Rancher Manager].
+
+
+== 8. Get Load Balancer IP
 
 To get the address of the load balancer, run:
 
 ----
-kubectl get service ingress-nginx-controller --namespace=ingress-nginx
+kubectl get service traefik --namespace=traefik
 ----
 
 The result should look similar to the following:
 
 ----
-NAME                       TYPE           CLUSTER-IP     EXTERNAL-IP     PORT(S)                      AGE
-ingress-nginx-controller   LoadBalancer   10.3.244.156   35.233.206.34   80:31876/TCP,443:32497/TCP   81s
+NAME                       TYPE           CLUSTER-IP     EXTERNAL-IP                                                              PORT(S)
+ AGE
+traefik  LoadBalancer   10.0.116.18    40.31.180.83   80:31229/TCP,443:31050/TCP 27m
 ----
 
 Save the `EXTERNAL-IP`.
@@ -208,7 +209,7 @@ Use the DNS name from the previous step as the Rancher server URL when you insta
 When installing Rancher on top of this setup, you will also need to set the name of the ingress controller to be used with Rancher's ingress resource:
 
 ----
---set ingress.ingressClassName=nginx
+--set ingress.ingressClassName=traefik
 ----
 
 Refer {xref-install-rancher}#_5_install_rancher_with_helm_and_your_chosen_certificate_option[here for the Helm install command] for your chosen certificate option.

--- a/versions/v2.13/modules/en/pages/installation-and-upgrade/hosted-kubernetes/rancher-on-aks.adoc
+++ b/versions/v2.13/modules/en/pages/installation-and-upgrade/hosted-kubernetes/rancher-on-aks.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-05
+:revdate: 2026-03-09
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-aks.adoc 
 :product-path: installation-and-upgrade/hosted-kubernetes/rancher-on-aks.adoc
@@ -89,17 +89,17 @@ The cluster needs an Ingress so that Rancher can be accessed from outside the cl
 
 [WARNING]
 ====
-It is not recommended to install a third-party ingress controller like Traefik if a managed ingress controller is already being used
+It is not recommended to install a third-party ingress controller, like Traefik, if a managed ingress controller is already being used.
 ====
 
 [WARNING]
 ====
-**Ingress-NGINX EOL:** The community `ingress-nginx` controller reaches End-of-Life (EOL) in March 2026. This guide uses Traefik, which is the recommended migration path for Rancher environments. 
+**Ingress-NGINX EOL:** The community `ingress-nginx` controller reaches End-of-Life (EOL) in March 2026. This page uses Traefik, which is the recommended migration path for Rancher environments.
 ====
 
-Traefik includes a native Ingress NGINX provider. This allows you to migrate from NGINX without rewriting your existing Ingress objects, as Traefik will automatically interpret `nginx.ingress.kubernetes.io` annotations. If you are upgrading a cluster that is already using `ingress-nginx` follow this [guide](https://doc.traefik.io/traefik/migrate/nginx-to-traefik/) for more information.
+Traefik includes a native Ingress NGINX provider. This allows you to migrate from NGINX without rewriting your existing Ingress objects, as Traefik will automatically interpret `nginx.ingress.kubernetes.io` annotations. If you are upgrading a cluster that is already using `ingress-nginx`, follow this https://doc.traefik.io/traefik/migrate/nginx-to-traefik/[guide] for more information.
 
-To install Traefik, we highly recommend using the Traefik application in the https://apps.rancher.io/applications/traefik-proxy[Rancher Prime Application Collection]. Check their https://docs.apps.rancher.io/howto-guides/integrate-with-rancher-manager[documentation to integrate with Rancher Manager]. 
+To install Traefik, we highly recommend using the Traefik application in the https://apps.rancher.io/applications/traefik-proxy[Rancher Prime Application Collection]. Check their https://docs.apps.rancher.io/howto-guides/integrate-with-rancher-manager[documentation to integrate with Rancher Manager].
 
 
 == 6. Get Load Balancer IP

--- a/versions/v2.13/modules/en/pages/installation-and-upgrade/hosted-kubernetes/rancher-on-amazon-eks.adoc
+++ b/versions/v2.13/modules/en/pages/installation-and-upgrade/hosted-kubernetes/rancher-on-amazon-eks.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-05
+:revdate: 2026-03-09
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-amazon-eks.adoc 
 :product-path: installation-and-upgrade/hosted-kubernetes/rancher-on-amazon-eks.adoc
@@ -104,23 +104,23 @@ NAME		REGION		EKSCTL CREATED
 rancher-server-cluster		us-west-2	True
 ----
 
-== 5. Install an Ingress
+=== 5. Install an Ingress
 
 The cluster needs an Ingress so that Rancher can be accessed from outside the cluster. Installing an Ingress requires allocating a public IP address. Ensure you have sufficient quota, otherwise it will fail to assign the IP address. Limits for public IP addresses are applicable at a regional level per subscription. You can use a managed ingress controller provided by AWS (ALB) or a third-party ingress controller like Traefik.
 
 [WARNING]
 ====
-It is not recommended to install a third-party ingress controller like Traefik if a managed ingress controller is already being used
+It is not recommended to install a third-party ingress controller, like Traefik, if a managed ingress controller is already being used.
 ====
 
 [WARNING]
 ====
-**Ingress-NGINX EOL:** The community `ingress-nginx` controller reaches End-of-Life (EOL) in March 2026. This guide uses Traefik, which is the recommended migration path for Rancher environments. 
+**Ingress-NGINX EOL:** The community `ingress-nginx` controller reaches End-of-Life (EOL) in March 2026. This page uses Traefik, which is the recommended migration path for Rancher environments.
 ====
 
-Traefik includes a native Ingress NGINX provider. This allows you to migrate from NGINX without rewriting your existing Ingress objects, as Traefik will automatically interpret `nginx.ingress.kubernetes.io` annotations. If you are upgrading a cluster that is already using `ingress-nginx` follow this [guide](https://doc.traefik.io/traefik/migrate/nginx-to-traefik/) for more information.
+Traefik includes a native Ingress NGINX provider. This allows you to migrate from NGINX without rewriting your existing Ingress objects, as Traefik will automatically interpret `nginx.ingress.kubernetes.io` annotations. If you are upgrading a cluster that is already using `ingress-nginx`, follow this https://doc.traefik.io/traefik/migrate/nginx-to-traefik/[guide] for more information.
 
-To install Traefik, we highly recommend using the Traefik application in the https://apps.rancher.io/applications/traefik-proxy[Rancher Prime Application Collection]. Check their https://docs.apps.rancher.io/howto-guides/integrate-with-rancher-manager[documentation to integrate with Rancher Manager]. 
+To install Traefik, we highly recommend using the Traefik application in the https://apps.rancher.io/applications/traefik-proxy[Rancher Prime Application Collection]. Check their https://docs.apps.rancher.io/howto-guides/integrate-with-rancher-manager[documentation to integrate with Rancher Manager].
 
 
 === 6. Get Load Balancer IP

--- a/versions/v2.13/modules/en/pages/installation-and-upgrade/hosted-kubernetes/rancher-on-gke.adoc
+++ b/versions/v2.13/modules/en/pages/installation-and-upgrade/hosted-kubernetes/rancher-on-gke.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-05
+:revdate: 2026-03-09
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/rancher-on-gke.adoc 
 :product-path: installation-and-upgrade/hosted-kubernetes/rancher-on-gke.adoc
@@ -161,20 +161,20 @@ The cluster needs an Ingress so that Rancher can be accessed from outside the cl
 
 [WARNING]
 ====
-It is not recommended to install a third-party ingress controller like Traefik if a managed ingress controller is already being used
+It is not recommended to install a third-party ingress controller, like Traefik, if a managed ingress controller is already being used
 ====
 
 [WARNING]
 ====
-**Ingress-NGINX EOL:** The community `ingress-nginx` controller reaches End-of-Life (EOL) in March 2026. This guide uses Traefik, which is the recommended migration path for Rancher environments. 
+**Ingress-NGINX EOL:** The community `ingress-nginx` controller reaches End-of-Life (EOL) in March 2026. This page uses Traefik, which is the recommended migration path for Rancher environments.
 ====
 
-Traefik includes a native Ingress NGINX provider. This allows you to migrate from NGINX without rewriting your existing Ingress objects, as Traefik will automatically interpret `nginx.ingress.kubernetes.io` annotations. If you are upgrading a cluster that is already using `ingress-nginx` follow this [guide](https://doc.traefik.io/traefik/migrate/nginx-to-traefik/) for more information.
+Traefik includes a native Ingress NGINX provider. This allows you to migrate from NGINX without rewriting your existing Ingress objects, as Traefik will automatically interpret `nginx.ingress.kubernetes.io` annotations. If you are upgrading a cluster that is already using `ingress-nginx`, follow this https://doc.traefik.io/traefik/migrate/nginx-to-traefik/[guide] for more information.
 
-To install Traefik, we highly recommend using the Traefik application in the https://apps.rancher.io/applications/traefik-proxy[Rancher Prime Application Collection]. Check their https://docs.apps.rancher.io/howto-guides/integrate-with-rancher-manager[documentation to integrate with Rancher Manager]. 
+To install Traefik, we highly recommend using the Traefik application in the https://apps.rancher.io/applications/traefik-proxy[Rancher Prime Application Collection]. Check their https://docs.apps.rancher.io/howto-guides/integrate-with-rancher-manager[documentation to integrate with Rancher Manager].
 
 
-=== 8. Get Load Balancer IP
+== 8. Get Load Balancer IP
 
 To get the address of the load balancer, run:
 


### PR DESCRIPTION
Following from https://github.com/rancher/rancher-docs/pull/2184, create a similar PR for Rancher Prime docs. The recommendation here is to use AppCo Traefik