### PR TITLE
Sync Community PR #2237 (Ingress nginx replacement)

### DIFF
--- a/versions/v2.10/modules/en/pages/cluster-deployment/custom-clusters/custom-clusters.adoc
+++ b/versions/v2.10/modules/en/pages/cluster-deployment/custom-clusters/custom-clusters.adoc
@@ -1,6 +1,6 @@
 = Launching Kubernetes on Existing Custom Nodes
 :page-languages: [en, zh]
-:revdate: 2024-12-13
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: reference-guides/cluster-configuration/rancher-server-configuration/use-existing-nodes/index.adoc 
 :product-path: cluster-deployment/custom-clusters/custom-clusters.adoc
@@ -116,7 +116,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 === 3. Amazon Only: Tag Resources
 

--- a/versions/v2.10/modules/en/pages/cluster-deployment/hosted-kubernetes/eks/eks.adoc
+++ b/versions/v2.10/modules/en/pages/cluster-deployment/hosted-kubernetes/eks/eks.adoc
@@ -1,6 +1,6 @@
 = Creating an EKS Cluster
 :page-languages: [en, zh]
-:revdate: 2025-03-17
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/eks.adoc 
 :product-path: cluster-deployment/hosted-kubernetes/eks/eks.adoc
@@ -69,7 +69,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 == EKS Cluster Configuration Reference
 

--- a/versions/v2.10/modules/en/pages/cluster-deployment/hosted-kubernetes/gke/gke.adoc
+++ b/versions/v2.10/modules/en/pages/cluster-deployment/hosted-kubernetes/gke/gke.adoc
@@ -1,6 +1,6 @@
 = Creating a GKE Cluster
 :page-languages: [en, zh]
-:revdate: 2025-03-17
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/gke.adoc 
 :product-path: cluster-deployment/hosted-kubernetes/gke/gke.adoc
@@ -85,7 +85,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 == Private Clusters
 

--- a/versions/v2.10/modules/en/pages/cluster-deployment/infra-providers/aws/aws.adoc
+++ b/versions/v2.10/modules/en/pages/cluster-deployment/infra-providers/aws/aws.adoc
@@ -1,6 +1,6 @@
 = Creating an Amazon EC2 Cluster
 :page-languages: [en, zh]
-:revdate: 2024-12-13
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-an-amazon-ec2-cluster.adoc 
 :product-path: cluster-deployment/infra-providers/aws/aws.adoc
@@ -150,7 +150,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 === Optional Next Steps
 

--- a/versions/v2.10/modules/en/pages/cluster-deployment/infra-providers/azure/azure.adoc
+++ b/versions/v2.10/modules/en/pages/cluster-deployment/infra-providers/azure/azure.adoc
@@ -1,6 +1,6 @@
 = Creating an Azure Cluster
 :page-languages: [en, zh]
-:revdate: 2025-03-17
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-an-azure-cluster.adoc 
 :product-path: cluster-deployment/infra-providers/azure/azure.adoc
@@ -160,7 +160,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 === Optional Next Steps
 

--- a/versions/v2.10/modules/en/pages/cluster-deployment/infra-providers/digitalocean/digitalocean.adoc
+++ b/versions/v2.10/modules/en/pages/cluster-deployment/infra-providers/digitalocean/digitalocean.adoc
@@ -1,6 +1,6 @@
 = Creating a DigitalOcean Cluster
 :page-languages: [en, zh]
-:revdate: 2024-12-13
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-a-digitalocean-cluster.adoc 
 :product-path: cluster-deployment/infra-providers/digitalocean/digitalocean.adoc
@@ -118,7 +118,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 == Optional Next Steps
 

--- a/versions/v2.10/modules/en/pages/cluster-deployment/infra-providers/nutanix/provision-kubernetes-clusters-in-aos.adoc
+++ b/versions/v2.10/modules/en/pages/cluster-deployment/infra-providers/nutanix/provision-kubernetes-clusters-in-aos.adoc
@@ -1,6 +1,6 @@
 = Provisioning Kubernetes Clusters in Nutanix AOS
 :page-languages: [en, zh]
-:revdate: 2024-12-13
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/nutanix/provision-kubernetes-clusters-in-aos.adoc 
 :product-path: cluster-deployment/infra-providers/nutanix/provision-kubernetes-clusters-in-aos.adoc
@@ -98,7 +98,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 == Optional Next Steps
 

--- a/versions/v2.10/modules/en/pages/cluster-deployment/infra-providers/vsphere/provision-kubernetes-clusters-in-vsphere.adoc
+++ b/versions/v2.10/modules/en/pages/cluster-deployment/infra-providers/vsphere/provision-kubernetes-clusters-in-vsphere.adoc
@@ -1,6 +1,6 @@
 = Provisioning Kubernetes Clusters in VMware vSphere
 :page-languages: [en, zh]
-:revdate: 2024-12-13
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/provision-kubernetes-clusters-in-vsphere.adoc 
 :product-path: cluster-deployment/infra-providers/vsphere/provision-kubernetes-clusters-in-vsphere.adoc
@@ -119,7 +119,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 == Optional Next Steps
 

--- a/versions/v2.10/modules/en/pages/cluster-deployment/register-existing-clusters.adoc
+++ b/versions/v2.10/modules/en/pages/cluster-deployment/register-existing-clusters.adoc
@@ -1,6 +1,6 @@
 = Registering Existing Clusters
 :page-languages: [en, zh]
-:revdate: 2025-08-25
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.adoc 
 :product-path: cluster-deployment/register-existing-clusters.adoc
@@ -86,7 +86,7 @@ Specifically, the value should be a comma-delimited string which only contains I
 
 * Your cluster is registered and assigned a state of *Pending*. Rancher is deploying resources to manage your cluster.
 * You can access your cluster after its state is updated to *Active*.
-* *Active* clusters are assigned two Projects: `Default` (containing the namespace `default`) and `System` (containing the namespaces `cattle-system`, `ingress-nginx`, `kube-public` and `kube-system`, if present).
+* *Active* clusters are assigned two Projects: `Default` (containing the namespace `default`) and `System` (containing the namespaces `cattle-system`, `traefik`, `kube-public` and `kube-system`, if present).
 
 [NOTE]
 ====

--- a/versions/v2.10/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
+++ b/versions/v2.10/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
@@ -1,6 +1,6 @@
 = {rancher-product-name} Equinix Metal Quick Start
 :page-languages: [en, zh]
-:revdate: 2025-04-30
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal.adoc 
 :product-path: installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
@@ -109,7 +109,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 ==== Finished
 

--- a/versions/v2.10/modules/en/pages/installation-and-upgrade/references/helm-chart-options.adoc
+++ b/versions/v2.10/modules/en/pages/installation-and-upgrade/references/helm-chart-options.adoc
@@ -1,6 +1,6 @@
 = {rancher-product-name} Helm Chart Options
 :page-languages: [en, zh]
-:revdate: 2025-08-18
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/installation-references/helm-chart-options.adoc 
 :product-path: installation-and-upgrade/references/helm-chart-options.adoc
@@ -300,18 +300,13 @@ This option is only effective on the initial Rancher install. See https://github
 
 To customize or use a different ingress with Rancher server you can set your own Ingress annotations.
 
+Please refer to the Traefik documentation for the full list of Ingress NGINX annotations that are https://doc.traefik.io/traefik/reference/routing-configuration/kubernetes/ingress-nginx/#annotations-support[supported] and https://doc.traefik.io/traefik/reference/routing-configuration/kubernetes/ingress-nginx/#unsupported-annotations[unsupported] by Traefik's kubernetesIngressNginx provider.
+
 Example on setting a custom certificate issuer:
 
 [,plain]
 ----
 --set ingress.extraAnnotations.'cert-manager\.io/cluster-issuer'=issuer-name
-----
-
-Example on setting a static proxy header with `ingress.configurationSnippet`. This value is parsed like a template so variables can be used.
-
-[,plain]
-----
---set ingress.configurationSnippet='more_set_input_headers X-Forwarded-Host {{ .Values.hostname }};'
 ----
 
 === HTTP Proxy
@@ -395,36 +390,6 @@ If you are using a Private CA signed certificate (or if `agent-tls-mode` is set 
 
 Your load balancer must support long lived websocket connections and will need to insert proxy headers so Rancher can route links correctly.
 
-=== Configuring Ingress for External TLS when Using NGINX v0.22
-
-In NGINX v0.22, the behavior of NGINX has https://github.com/kubernetes/ingress-nginx/blob/06efac9f0b6f8f84b553f58ccecf79dc42c75cc6/Changelog.md[changed] regarding forwarding headers and external TLS termination. Therefore, in the scenario that you are using external TLS termination configuration with NGINX v0.22, you must enable the `use-forwarded-headers` option for ingress:
-
-For RKE installations, edit the `cluster.yml` to add the following settings.
-
-[,yaml]
-----
-ingress:
-  provider: nginx
-  options:
-    use-forwarded-headers: 'true'
-----
-
-For RKE2 installations, you can create a custom `rke2-ingress-nginx-config.yaml` file at `/var/lib/rancher/rke2/server/manifests/rke2-ingress-nginx-config.yaml` containing this required setting to enable using forwarded headers with external TLS termination. Without this required setting applied, the external LB will continuously respond with redirect loops it receives from the ingress controller. (This can be created before or after rancher is installed, rke2 server agent will notice this addition and automatically apply it.)
-
-[,yaml]
-----
-apiVersion: helm.cattle.io/v1
-kind: HelmChartConfig
-metadata:
-  name: rke2-ingress-nginx
-  namespace: kube-system
-spec:
-  valuesContent: |-
-    controller:
-      config:
-        use-forwarded-headers: "true"
-----
-
 === Required Headers
 
 * `Host`
@@ -441,67 +406,3 @@ spec:
 === Health Checks
 
 Rancher will respond `200` to health checks on the `/healthz` endpoint.
-
-=== Example NGINX config
-
-This NGINX configuration is tested on NGINX 1.14.
-
-[CAUTION]
-====
-
-This NGINX configuration is only an example and may not suit your environment. For complete documentation, see https://docs.nginx.com/nginx/admin-guide/load-balancer/http-load-balancer/[NGINX Load Balancing - HTTP Load Balancing].
-====
-
-
-* Replace `IP_NODE1`, `IP_NODE2` and `IP_NODE3` with the IP addresses of the nodes in your cluster.
-* Replace both occurrences of `FQDN` to the DNS name for Rancher.
-* Replace `/certs/fullchain.pem` and `/certs/privkey.pem` to the location of the server certificate and the server certificate key respectively.
-
-----
-worker_processes 4;
-worker_rlimit_nofile 40000;
-
-events {
-    worker_connections 8192;
-}
-
-http {
-    upstream rancher {
-        server IP_NODE_1:80;
-        server IP_NODE_2:80;
-        server IP_NODE_3:80;
-    }
-
-    map $http_upgrade $connection_upgrade {
-        default Upgrade;
-        ''      close;
-    }
-
-    server {
-        listen 443 ssl http2;
-        server_name FQDN;
-        ssl_certificate /certs/fullchain.pem;
-        ssl_certificate_key /certs/privkey.pem;
-
-        location / {
-            proxy_set_header Host $host;
-            proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_set_header X-Forwarded-Port $server_port;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_pass http://rancher;
-            proxy_http_version 1.1;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection $connection_upgrade;
-            # This allows the ability for the execute shell window to remain open for up to 15 minutes. Without this parameter, the default is 1 minute and will automatically close.
-            proxy_read_timeout 900s;
-            proxy_buffering off;
-        }
-    }
-
-    server {
-        listen 80;
-        server_name FQDN;
-        return 301 https://$server_name$request_uri;
-    }
-}
-----

--- a/versions/v2.10/modules/en/pages/installation-and-upgrade/troubleshooting/troubleshooting.adoc
+++ b/versions/v2.10/modules/en/pages/installation-and-upgrade/troubleshooting/troubleshooting.adoc
@@ -1,6 +1,6 @@
 = Troubleshooting the {rancher-product-name} Server Kubernetes Cluster
 :page-languages: [en, zh]
-:revdate: 2024-12-13
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/troubleshooting.adoc 
 :product-path: installation-and-upgrade/troubleshooting/troubleshooting.adoc
@@ -18,7 +18,7 @@ This section describes how to troubleshoot an installation of Rancher on a Kuber
 Most of the troubleshooting will be done on objects in these 3 namespaces.
 
 * `cattle-system` - `rancher` deployment and pods.
-* `ingress-nginx` - Ingress controller pods and services.
+* `traefik` - Ingress controller pods and services.
 * `cert-manager` - `cert-manager` pods.
 
 == "default backend - 404"
@@ -132,7 +132,7 @@ If its ready and the SSL is still not working you may have a malformed cert or s
 Check the nginx-ingress-controller logs. Because the nginx-ingress-controller has multiple containers in its pod you will need to specify the name of the container.
 
 ----
-kubectl -n ingress-nginx logs -f nginx-ingress-controller-rfjrq nginx-ingress-controller
+kubectl logs -n traefik traefik-6b94b8b688-bngw2
 ...
 W0705 23:04:58.240571       7 backend_ssl.go:49] error obtaining PEM from secret cattle-system/tls-rancher-ingress: error retrieving secret cattle-system/tls-rancher-ingress: secret cattle-system/tls-rancher-ingress was not found
 ----
@@ -152,10 +152,6 @@ Install cert-manager and try installing Rancher again.
 The most common cause of this issue is port 8472/UDP is not open between the nodes. Check your local firewall, network routing or security groups.
 
 Once the network issue is resolved, the `canal` pods should timeout and restart to establish their connections.
-
-== nginx-ingress-controller Pods show RESTARTS
-
-The most common cause of this issue is the `canal` pods have failed to establish the overlay network. See <<_canal_pods_show_ready_23,canal Pods show READY `2/3`>> for troubleshooting.
 
 == Failed to dial to /var/run/docker.sock: ssh: rejected: administratively prohibited (open failed)
 

--- a/versions/v2.11/modules/en/pages/cluster-deployment/custom-clusters/custom-clusters.adoc
+++ b/versions/v2.11/modules/en/pages/cluster-deployment/custom-clusters/custom-clusters.adoc
@@ -1,6 +1,6 @@
 = Launching Kubernetes on Existing Custom Nodes
 :page-languages: [en, zh]
-:revdate: 2025-03-12
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: reference-guides/cluster-configuration/rancher-server-configuration/use-existing-nodes/index.adoc 
 :product-path: cluster-deployment/custom-clusters/custom-clusters.adoc
@@ -116,7 +116,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 === 3. Amazon Only: Tag Resources
 

--- a/versions/v2.11/modules/en/pages/cluster-deployment/hosted-kubernetes/eks/eks.adoc
+++ b/versions/v2.11/modules/en/pages/cluster-deployment/hosted-kubernetes/eks/eks.adoc
@@ -1,6 +1,6 @@
 = Creating an EKS Cluster
 :page-languages: [en, zh]
-:revdate: 2025-03-17
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/eks.adoc 
 :product-path: cluster-deployment/hosted-kubernetes/eks/eks.adoc
@@ -69,7 +69,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 == EKS Cluster Configuration Reference
 

--- a/versions/v2.11/modules/en/pages/cluster-deployment/hosted-kubernetes/gke/gke.adoc
+++ b/versions/v2.11/modules/en/pages/cluster-deployment/hosted-kubernetes/gke/gke.adoc
@@ -1,6 +1,6 @@
 = Creating a GKE Cluster
 :page-languages: [en, zh]
-:revdate: 2025-03-17
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/gke.adoc 
 :product-path: cluster-deployment/hosted-kubernetes/gke/gke.adoc
@@ -85,7 +85,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 == Private Clusters
 

--- a/versions/v2.11/modules/en/pages/cluster-deployment/infra-providers/aws/aws.adoc
+++ b/versions/v2.11/modules/en/pages/cluster-deployment/infra-providers/aws/aws.adoc
@@ -1,6 +1,6 @@
 = Creating an Amazon EC2 Cluster
 :page-languages: [en, zh]
-:revdate: 2025-03-12
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-an-amazon-ec2-cluster.adoc 
 :product-path: cluster-deployment/infra-providers/aws/aws.adoc
@@ -150,7 +150,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 === Optional Next Steps
 

--- a/versions/v2.11/modules/en/pages/cluster-deployment/infra-providers/azure/azure.adoc
+++ b/versions/v2.11/modules/en/pages/cluster-deployment/infra-providers/azure/azure.adoc
@@ -1,6 +1,6 @@
 = Creating an Azure Cluster
 :page-languages: [en, zh]
-:revdate: 2025-03-17
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-an-azure-cluster.adoc 
 :product-path: cluster-deployment/infra-providers/azure/azure.adoc
@@ -160,7 +160,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 === Optional Next Steps
 

--- a/versions/v2.11/modules/en/pages/cluster-deployment/infra-providers/digitalocean/digitalocean.adoc
+++ b/versions/v2.11/modules/en/pages/cluster-deployment/infra-providers/digitalocean/digitalocean.adoc
@@ -1,6 +1,6 @@
 = Creating a DigitalOcean Cluster
 :page-languages: [en, zh]
-:revdate: 2025-03-12
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-a-digitalocean-cluster.adoc 
 :product-path: cluster-deployment/infra-providers/digitalocean/digitalocean.adoc
@@ -118,7 +118,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 == Optional Next Steps
 

--- a/versions/v2.11/modules/en/pages/cluster-deployment/infra-providers/nutanix/provision-kubernetes-clusters-in-aos.adoc
+++ b/versions/v2.11/modules/en/pages/cluster-deployment/infra-providers/nutanix/provision-kubernetes-clusters-in-aos.adoc
@@ -1,6 +1,6 @@
 = Provisioning Kubernetes Clusters in Nutanix AOS
 :page-languages: [en, zh]
-:revdate: 2025-03-12
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/nutanix/provision-kubernetes-clusters-in-aos.adoc 
 :product-path: cluster-deployment/infra-providers/nutanix/provision-kubernetes-clusters-in-aos.adoc
@@ -98,7 +98,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 == Optional Next Steps
 

--- a/versions/v2.11/modules/en/pages/cluster-deployment/infra-providers/vsphere/provision-kubernetes-clusters-in-vsphere.adoc
+++ b/versions/v2.11/modules/en/pages/cluster-deployment/infra-providers/vsphere/provision-kubernetes-clusters-in-vsphere.adoc
@@ -1,6 +1,6 @@
 = Provisioning Kubernetes Clusters in VMware vSphere
 :page-languages: [en, zh]
-:revdate: 2025-03-12
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/provision-kubernetes-clusters-in-vsphere.adoc 
 :product-path: cluster-deployment/infra-providers/vsphere/provision-kubernetes-clusters-in-vsphere.adoc
@@ -119,7 +119,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 == Optional Next Steps
 

--- a/versions/v2.11/modules/en/pages/cluster-deployment/register-existing-clusters.adoc
+++ b/versions/v2.11/modules/en/pages/cluster-deployment/register-existing-clusters.adoc
@@ -1,6 +1,6 @@
 = Registering Existing Clusters
 :page-languages: [en, zh]
-:revdate: 2025-08-25
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.adoc 
 :product-path: cluster-deployment/register-existing-clusters.adoc
@@ -85,7 +85,7 @@ Specifically, the value should be a comma-delimited string which only contains I
 
 * Your cluster is registered and assigned a state of *Pending*. Rancher is deploying resources to manage your cluster.
 * You can access your cluster after its state is updated to *Active*.
-* *Active* clusters are assigned two Projects: `Default` (containing the namespace `default`) and `System` (containing the namespaces `cattle-system`, `ingress-nginx`, `kube-public` and `kube-system`, if present).
+* *Active* clusters are assigned two Projects: `Default` (containing the namespace `default`) and `System` (containing the namespaces `cattle-system`, `traefik`, `kube-public` and `kube-system`, if present).
 
 [NOTE]
 ====

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
@@ -1,6 +1,6 @@
 = {rancher-product-name} Equinix Metal Quick Start
 :page-languages: [en, zh]
-:revdate: 2025-04-30
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal.adoc 
 :product-path: installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
@@ -109,7 +109,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 ==== Finished
 

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/references/helm-chart-options.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/references/helm-chart-options.adoc
@@ -1,6 +1,6 @@
 = {rancher-product-name} Helm Chart Options
 :page-languages: [en, zh]
-:revdate: 2025-08-18
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/installation-references/helm-chart-options.adoc 
 :product-path: installation-and-upgrade/references/helm-chart-options.adoc
@@ -293,18 +293,13 @@ This option is only effective on the initial Rancher install. See https://github
 
 To customize or use a different ingress with Rancher server you can set your own Ingress annotations.
 
+Please refer to the Traefik documentation for the full list of Ingress NGINX annotations that are https://doc.traefik.io/traefik/reference/routing-configuration/kubernetes/ingress-nginx/#annotations-support[supported] and https://doc.traefik.io/traefik/reference/routing-configuration/kubernetes/ingress-nginx/#unsupported-annotations[unsupported] by Traefik's kubernetesIngressNginx provider.
+
 Example on setting a custom certificate issuer:
 
 [,plain]
 ----
 --set ingress.extraAnnotations.'cert-manager\.io/cluster-issuer'=issuer-name
-----
-
-Example on setting a static proxy header with `ingress.configurationSnippet`. This value is parsed like a template so variables can be used.
-
-[,plain]
-----
---set ingress.configurationSnippet='more_set_input_headers X-Forwarded-Host {{ .Values.hostname }};'
 ----
 
 === HTTP Proxy
@@ -388,36 +383,6 @@ If you are using a Private CA signed certificate (or if `agent-tls-mode` is set 
 
 Your load balancer must support long lived websocket connections and will need to insert proxy headers so Rancher can route links correctly.
 
-=== Configuring Ingress for External TLS when Using NGINX v0.22
-
-In NGINX v0.22, the behavior of NGINX has https://github.com/kubernetes/ingress-nginx/blob/06efac9f0b6f8f84b553f58ccecf79dc42c75cc6/Changelog.md[changed] regarding forwarding headers and external TLS termination. Therefore, in the scenario that you are using external TLS termination configuration with NGINX v0.22, you must enable the `use-forwarded-headers` option for ingress:
-
-For RKE installations, edit the `cluster.yml` to add the following settings.
-
-[,yaml]
-----
-ingress:
-  provider: nginx
-  options:
-    use-forwarded-headers: 'true'
-----
-
-For RKE2 installations, you can create a custom `rke2-ingress-nginx-config.yaml` file at `/var/lib/rancher/rke2/server/manifests/rke2-ingress-nginx-config.yaml` containing this required setting to enable using forwarded headers with external TLS termination. Without this required setting applied, the external LB will continuously respond with redirect loops it receives from the ingress controller. (This can be created before or after rancher is installed, rke2 server agent will notice this addition and automatically apply it.)
-
-[,yaml]
-----
-apiVersion: helm.cattle.io/v1
-kind: HelmChartConfig
-metadata:
-  name: rke2-ingress-nginx
-  namespace: kube-system
-spec:
-  valuesContent: |-
-    controller:
-      config:
-        use-forwarded-headers: "true"
-----
-
 === Required Headers
 
 * `Host`
@@ -434,67 +399,3 @@ spec:
 === Health Checks
 
 Rancher will respond `200` to health checks on the `/healthz` endpoint.
-
-=== Example NGINX config
-
-This NGINX configuration is tested on NGINX 1.14.
-
-[CAUTION]
-====
-
-This NGINX configuration is only an example and may not suit your environment. For complete documentation, see https://docs.nginx.com/nginx/admin-guide/load-balancer/http-load-balancer/[NGINX Load Balancing - HTTP Load Balancing].
-====
-
-
-* Replace `IP_NODE1`, `IP_NODE2` and `IP_NODE3` with the IP addresses of the nodes in your cluster.
-* Replace both occurrences of `FQDN` to the DNS name for Rancher.
-* Replace `/certs/fullchain.pem` and `/certs/privkey.pem` to the location of the server certificate and the server certificate key respectively.
-
-----
-worker_processes 4;
-worker_rlimit_nofile 40000;
-
-events {
-    worker_connections 8192;
-}
-
-http {
-    upstream rancher {
-        server IP_NODE_1:80;
-        server IP_NODE_2:80;
-        server IP_NODE_3:80;
-    }
-
-    map $http_upgrade $connection_upgrade {
-        default Upgrade;
-        ''      close;
-    }
-
-    server {
-        listen 443 ssl http2;
-        server_name FQDN;
-        ssl_certificate /certs/fullchain.pem;
-        ssl_certificate_key /certs/privkey.pem;
-
-        location / {
-            proxy_set_header Host $host;
-            proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_set_header X-Forwarded-Port $server_port;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_pass http://rancher;
-            proxy_http_version 1.1;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection $connection_upgrade;
-            # This allows the ability for the execute shell window to remain open for up to 15 minutes. Without this parameter, the default is 1 minute and will automatically close.
-            proxy_read_timeout 900s;
-            proxy_buffering off;
-        }
-    }
-
-    server {
-        listen 80;
-        server_name FQDN;
-        return 301 https://$server_name$request_uri;
-    }
-}
-----

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/troubleshooting/troubleshooting.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/troubleshooting/troubleshooting.adoc
@@ -1,6 +1,6 @@
 = Troubleshooting the {rancher-product-name} Server Kubernetes Cluster
 :page-languages: [en, zh]
-:revdate: 2025-03-12
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/troubleshooting.adoc 
 :product-path: installation-and-upgrade/troubleshooting/troubleshooting.adoc
@@ -18,7 +18,7 @@ This section describes how to troubleshoot an installation of Rancher on a Kuber
 Most of the troubleshooting will be done on objects in these 3 namespaces.
 
 * `cattle-system` - `rancher` deployment and pods.
-* `ingress-nginx` - Ingress controller pods and services.
+* `traefik` - Ingress controller pods and services.
 * `cert-manager` - `cert-manager` pods.
 
 == "default backend - 404"
@@ -132,7 +132,7 @@ If its ready and the SSL is still not working you may have a malformed cert or s
 Check the nginx-ingress-controller logs. Because the nginx-ingress-controller has multiple containers in its pod you will need to specify the name of the container.
 
 ----
-kubectl -n ingress-nginx logs -f nginx-ingress-controller-rfjrq nginx-ingress-controller
+kubectl logs -n traefik traefik-6b94b8b688-bngw2
 ...
 W0705 23:04:58.240571       7 backend_ssl.go:49] error obtaining PEM from secret cattle-system/tls-rancher-ingress: error retrieving secret cattle-system/tls-rancher-ingress: secret cattle-system/tls-rancher-ingress was not found
 ----
@@ -152,10 +152,6 @@ Install cert-manager and try installing Rancher again.
 The most common cause of this issue is port 8472/UDP is not open between the nodes. Check your local firewall, network routing or security groups.
 
 Once the network issue is resolved, the `canal` pods should timeout and restart to establish their connections.
-
-== nginx-ingress-controller Pods show RESTARTS
-
-The most common cause of this issue is the `canal` pods have failed to establish the overlay network. See <<_canal_pods_show_ready_23,canal Pods show READY `2/3`>> for troubleshooting.
 
 == Failed to dial to /var/run/docker.sock: ssh: rejected: administratively prohibited (open failed)
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/custom-clusters/custom-clusters.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/custom-clusters/custom-clusters.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-10-01
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: reference-guides/cluster-configuration/rancher-server-configuration/use-existing-nodes/index.adoc 
 :product-path: cluster-deployment/custom-clusters/custom-clusters.adoc
@@ -118,7 +118,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 === 3. Amazon Only: Tag Resources
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/hosted-kubernetes/eks/eks.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/hosted-kubernetes/eks/eks.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-05
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/eks.adoc 
 :product-path: cluster-deployment/hosted-kubernetes/eks/eks.adoc
@@ -71,7 +71,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 == EKS Cluster Configuration Reference
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/hosted-kubernetes/gke/gke.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/hosted-kubernetes/gke/gke.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-05
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/gke.adoc 
 :product-path: cluster-deployment/hosted-kubernetes/gke/gke.adoc
@@ -87,7 +87,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 == Private Clusters
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/aws/aws.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/aws/aws.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-25
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-an-amazon-ec2-cluster.adoc 
 :product-path: cluster-deployment/infra-providers/aws/aws.adoc
@@ -81,7 +81,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 === Optional Next Steps
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/azure/azure.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/azure/azure.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-25
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-an-azure-cluster.adoc 
 :product-path: cluster-deployment/infra-providers/azure/azure.adoc
@@ -104,7 +104,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 === Optional Next Steps
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/digitalocean/digitalocean.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/digitalocean/digitalocean.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-25
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-a-digitalocean-cluster.adoc 
 :product-path: cluster-deployment/infra-providers/digitalocean/digitalocean.adoc
@@ -63,7 +63,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 == Optional Next Steps
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/gce/gce.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/gce/gce.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-27
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-a-google-compute-engine-cluster.adoc 
 :product-path: cluster-deployment/infra-providers/gce/gce.adoc
@@ -81,7 +81,7 @@ You can access your cluster after its state is updated to **Active**.
 **Active** clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 == GCE Best Practices
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/nutanix/provision-kubernetes-clusters-in-aos.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/nutanix/provision-kubernetes-clusters-in-aos.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-05
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/nutanix/provision-kubernetes-clusters-in-aos.adoc 
 :product-path: cluster-deployment/infra-providers/nutanix/provision-kubernetes-clusters-in-aos.adoc
@@ -100,7 +100,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 == Optional Next Steps
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/vsphere/provision-kubernetes-clusters-in-vsphere.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/infra-providers/vsphere/provision-kubernetes-clusters-in-vsphere.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-25
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/provision-kubernetes-clusters-in-vsphere.adoc 
 :product-path: cluster-deployment/infra-providers/vsphere/provision-kubernetes-clusters-in-vsphere.adoc
@@ -102,7 +102,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 == Optional Next Steps
 

--- a/versions/v2.12/modules/en/pages/cluster-deployment/register-existing-clusters.adoc
+++ b/versions/v2.12/modules/en/pages/cluster-deployment/register-existing-clusters.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-25
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.adoc 
 :product-path: cluster-deployment/register-existing-clusters.adoc
@@ -99,7 +99,7 @@ Specifically, the value should be a comma-delimited string which only contains I
 
 * Your cluster is registered and assigned a state of *Pending*. Rancher is deploying resources to manage your cluster.
 * You can access your cluster after its state is updated to *Active*.
-* *Active* clusters are assigned two Projects: `Default` (containing the namespace `default`) and `System` (containing the namespaces `cattle-system`, `ingress-nginx`, `kube-public` and `kube-system`, if present).
+* *Active* clusters are assigned two Projects: `Default` (containing the namespace `default`) and `System` (containing the namespaces `cattle-system`, `traefik`, `kube-public` and `kube-system`, if present).
 
 [NOTE]
 ====

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-05
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal.adoc 
 :product-path: installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
@@ -111,7 +111,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 ==== Finished
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/references/helm-chart-options.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/references/helm-chart-options.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-27
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/installation-references/helm-chart-options.adoc 
 :product-path: installation-and-upgrade/references/helm-chart-options.adoc
@@ -267,18 +267,13 @@ This option is only effective on the initial Rancher install. See https://github
 
 To customize or use a different ingress with Rancher server you can set your own Ingress annotations.
 
+Please refer to the Traefik documentation for the full list of Ingress NGINX annotations that are https://doc.traefik.io/traefik/reference/routing-configuration/kubernetes/ingress-nginx/#annotations-support[supported] and https://doc.traefik.io/traefik/reference/routing-configuration/kubernetes/ingress-nginx/#unsupported-annotations[unsupported] by Traefik's kubernetesIngressNginx provider.
+
 Example on setting a custom certificate issuer:
 
 [,plain]
 ----
 --set ingress.extraAnnotations.'cert-manager\.io/cluster-issuer'=issuer-name
-----
-
-Example on setting a static proxy header with `ingress.configurationSnippet`. This value is parsed like a template so variables can be used.
-
-[,plain]
-----
---set ingress.configurationSnippet='more_set_input_headers X-Forwarded-Host {{ .Values.hostname }};'
 ----
 
 === HTTP Proxy
@@ -362,26 +357,6 @@ If you are using a Private CA signed certificate (or if `agent-tls-mode` is set 
 
 Your load balancer must support long lived websocket connections and will need to insert proxy headers so Rancher can route links correctly.
 
-=== Configuring Ingress for External TLS when Using NGINX v0.22
-
-In NGINX v0.22, the behavior of NGINX has https://github.com/kubernetes/ingress-nginx/blob/06efac9f0b6f8f84b553f58ccecf79dc42c75cc6/Changelog.md[changed] regarding forwarding headers and external TLS termination. Therefore, in the scenario that you are using external TLS termination configuration with NGINX v0.22, you must enable the `use-forwarded-headers` option for ingress:
-
-For RKE2 installations, you can create a custom `rke2-ingress-nginx-config.yaml` file at `/var/lib/rancher/rke2/server/manifests/rke2-ingress-nginx-config.yaml` containing this required setting to enable using forwarded headers with external TLS termination. Without this required setting applied, the external LB will continuously respond with redirect loops it receives from the ingress controller. (This can be created before or after rancher is installed, rke2 server agent will notice this addition and automatically apply it.)
-
-[,yaml]
-----
-apiVersion: helm.cattle.io/v1
-kind: HelmChartConfig
-metadata:
-  name: rke2-ingress-nginx
-  namespace: kube-system
-spec:
-  valuesContent: |-
-    controller:
-      config:
-        use-forwarded-headers: "true"
-----
-
 === Required Headers
 
 * `Host`
@@ -398,67 +373,3 @@ spec:
 === Health Checks
 
 Rancher will respond `200` to health checks on the `/healthz` endpoint.
-
-=== Example NGINX config
-
-This NGINX configuration is tested on NGINX 1.14.
-
-[CAUTION]
-====
-
-This NGINX configuration is only an example and may not suit your environment. For complete documentation, see https://docs.nginx.com/nginx/admin-guide/load-balancer/http-load-balancer/[NGINX Load Balancing - HTTP Load Balancing].
-====
-
-
-* Replace `IP_NODE1`, `IP_NODE2` and `IP_NODE3` with the IP addresses of the nodes in your cluster.
-* Replace both occurrences of `FQDN` to the DNS name for Rancher.
-* Replace `/certs/fullchain.pem` and `/certs/privkey.pem` to the location of the server certificate and the server certificate key respectively.
-
-----
-worker_processes 4;
-worker_rlimit_nofile 40000;
-
-events {
-    worker_connections 8192;
-}
-
-http {
-    upstream rancher {
-        server IP_NODE_1:80;
-        server IP_NODE_2:80;
-        server IP_NODE_3:80;
-    }
-
-    map $http_upgrade $connection_upgrade {
-        default Upgrade;
-        ''      close;
-    }
-
-    server {
-        listen 443 ssl http2;
-        server_name FQDN;
-        ssl_certificate /certs/fullchain.pem;
-        ssl_certificate_key /certs/privkey.pem;
-
-        location / {
-            proxy_set_header Host $host;
-            proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_set_header X-Forwarded-Port $server_port;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_pass http://rancher;
-            proxy_http_version 1.1;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection $connection_upgrade;
-            # This allows the ability for the execute shell window to remain open for up to 15 minutes. Without this parameter, the default is 1 minute and will automatically close.
-            proxy_read_timeout 900s;
-            proxy_buffering off;
-        }
-    }
-
-    server {
-        listen 80;
-        server_name FQDN;
-        return 301 https://$server_name$request_uri;
-    }
-}
-----

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/troubleshooting/troubleshooting.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/troubleshooting/troubleshooting.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-25
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/troubleshooting.adoc 
 :product-path: installation-and-upgrade/troubleshooting/troubleshooting.adoc
@@ -20,7 +20,7 @@ This section describes how to troubleshoot an installation of Rancher on a Kuber
 Most of the troubleshooting will be done on objects in these 3 namespaces.
 
 * `cattle-system` - `rancher` deployment and pods.
-* `ingress-nginx` - Ingress controller pods and services.
+* `traefik` - Ingress controller pods and services.
 * `cert-manager` - `cert-manager` pods.
 
 == "default backend - 404"
@@ -134,7 +134,7 @@ If its ready and the SSL is still not working you may have a malformed cert or s
 Check the nginx-ingress-controller logs. Because the nginx-ingress-controller has multiple containers in its pod you will need to specify the name of the container.
 
 ----
-kubectl -n ingress-nginx logs -f nginx-ingress-controller-rfjrq nginx-ingress-controller
+kubectl logs -n traefik traefik-6b94b8b688-bngw2
 ...
 W0705 23:04:58.240571       7 backend_ssl.go:49] error obtaining PEM from secret cattle-system/tls-rancher-ingress: error retrieving secret cattle-system/tls-rancher-ingress: secret cattle-system/tls-rancher-ingress was not found
 ----
@@ -154,10 +154,6 @@ Install cert-manager and try installing Rancher again.
 The most common cause of this issue is port 8472/UDP is not open between the nodes. Check your local firewall, network routing or security groups.
 
 Once the network issue is resolved, the `canal` pods should timeout and restart to establish their connections.
-
-== nginx-ingress-controller Pods show RESTARTS
-
-The most common cause of this issue is the `canal` pods have failed to establish the overlay network. See <<_canal_pods_show_ready_23,canal Pods show READY `2/3`>> for troubleshooting.
 
 == Failed to dial to /var/run/docker.sock: ssh: rejected: administratively prohibited (open failed)
 

--- a/versions/v2.13/modules/en/pages/cluster-deployment/custom-clusters/custom-clusters.adoc
+++ b/versions/v2.13/modules/en/pages/cluster-deployment/custom-clusters/custom-clusters.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-12-10
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: reference-guides/cluster-configuration/rancher-server-configuration/use-existing-nodes/index.adoc 
 :product-path: cluster-deployment/custom-clusters/custom-clusters.adoc
@@ -122,7 +122,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 === 3. Amazon Only: Tag Resources
 

--- a/versions/v2.13/modules/en/pages/cluster-deployment/hosted-kubernetes/eks/eks.adoc
+++ b/versions/v2.13/modules/en/pages/cluster-deployment/hosted-kubernetes/eks/eks.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-05
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/eks.adoc 
 :product-path: cluster-deployment/hosted-kubernetes/eks/eks.adoc
@@ -71,7 +71,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 == EKS Cluster Configuration Reference
 

--- a/versions/v2.13/modules/en/pages/cluster-deployment/hosted-kubernetes/gke/gke.adoc
+++ b/versions/v2.13/modules/en/pages/cluster-deployment/hosted-kubernetes/gke/gke.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-05
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/gke.adoc 
 :product-path: cluster-deployment/hosted-kubernetes/gke/gke.adoc
@@ -87,7 +87,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 == Private Clusters
 

--- a/versions/v2.13/modules/en/pages/cluster-deployment/infra-providers/aws/aws.adoc
+++ b/versions/v2.13/modules/en/pages/cluster-deployment/infra-providers/aws/aws.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-12-10
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-an-amazon-ec2-cluster.adoc 
 :product-path: cluster-deployment/infra-providers/aws/aws.adoc
@@ -82,7 +82,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 === Optional Next Steps
 

--- a/versions/v2.13/modules/en/pages/cluster-deployment/infra-providers/azure/azure.adoc
+++ b/versions/v2.13/modules/en/pages/cluster-deployment/infra-providers/azure/azure.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-25
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-an-azure-cluster.adoc 
 :product-path: cluster-deployment/infra-providers/azure/azure.adoc
@@ -104,7 +104,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 === Optional Next Steps
 

--- a/versions/v2.13/modules/en/pages/cluster-deployment/infra-providers/digitalocean/digitalocean.adoc
+++ b/versions/v2.13/modules/en/pages/cluster-deployment/infra-providers/digitalocean/digitalocean.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-25
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-a-digitalocean-cluster.adoc 
 :product-path: cluster-deployment/infra-providers/digitalocean/digitalocean.adoc
@@ -63,7 +63,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 == Optional Next Steps
 

--- a/versions/v2.13/modules/en/pages/cluster-deployment/infra-providers/gce/gce.adoc
+++ b/versions/v2.13/modules/en/pages/cluster-deployment/infra-providers/gce/gce.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-27
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-a-google-compute-engine-cluster.adoc 
 :product-path: cluster-deployment/infra-providers/gce/gce.adoc
@@ -81,7 +81,7 @@ You can access your cluster after its state is updated to **Active**.
 **Active** clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 == GCE Best Practices
 

--- a/versions/v2.13/modules/en/pages/cluster-deployment/infra-providers/nutanix/provision-kubernetes-clusters-in-aos.adoc
+++ b/versions/v2.13/modules/en/pages/cluster-deployment/infra-providers/nutanix/provision-kubernetes-clusters-in-aos.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-05
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/nutanix/provision-kubernetes-clusters-in-aos.adoc 
 :product-path: cluster-deployment/infra-providers/nutanix/provision-kubernetes-clusters-in-aos.adoc
@@ -100,7 +100,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 == Optional Next Steps
 

--- a/versions/v2.13/modules/en/pages/cluster-deployment/infra-providers/vsphere/provision-kubernetes-clusters-in-vsphere.adoc
+++ b/versions/v2.13/modules/en/pages/cluster-deployment/infra-providers/vsphere/provision-kubernetes-clusters-in-vsphere.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-25
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/provision-kubernetes-clusters-in-vsphere.adoc 
 :product-path: cluster-deployment/infra-providers/vsphere/provision-kubernetes-clusters-in-vsphere.adoc
@@ -102,7 +102,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 == Optional Next Steps
 

--- a/versions/v2.13/modules/en/pages/cluster-deployment/register-existing-clusters.adoc
+++ b/versions/v2.13/modules/en/pages/cluster-deployment/register-existing-clusters.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-25
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.adoc 
 :product-path: cluster-deployment/register-existing-clusters.adoc
@@ -99,7 +99,7 @@ Specifically, the value should be a comma-delimited string which only contains I
 
 * Your cluster is registered and assigned a state of *Pending*. Rancher is deploying resources to manage your cluster.
 * You can access your cluster after its state is updated to *Active*.
-* *Active* clusters are assigned two Projects: `Default` (containing the namespace `default`) and `System` (containing the namespaces `cattle-system`, `ingress-nginx`, `kube-public` and `kube-system`, if present).
+* *Active* clusters are assigned two Projects: `Default` (containing the namespace `default`) and `System` (containing the namespaces `cattle-system`, `traefik`, `kube-public` and `kube-system`, if present).
 
 [NOTE]
 ====

--- a/versions/v2.13/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
+++ b/versions/v2.13/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-05
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal.adoc 
 :product-path: installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
@@ -111,7 +111,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 ==== Finished
 

--- a/versions/v2.13/modules/en/pages/installation-and-upgrade/references/helm-chart-options.adoc
+++ b/versions/v2.13/modules/en/pages/installation-and-upgrade/references/helm-chart-options.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-27
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/installation-references/helm-chart-options.adoc 
 :product-path: installation-and-upgrade/references/helm-chart-options.adoc
@@ -267,18 +267,13 @@ This option is only effective on the initial Rancher install. See https://github
 
 To customize or use a different ingress with Rancher server you can set your own Ingress annotations.
 
+Please refer to the Traefik documentation for the full list of Ingress NGINX annotations that are https://doc.traefik.io/traefik/reference/routing-configuration/kubernetes/ingress-nginx/#annotations-support[supported] and https://doc.traefik.io/traefik/reference/routing-configuration/kubernetes/ingress-nginx/#unsupported-annotations[unsupported] by Traefik's kubernetesIngressNginx provider.
+
 Example on setting a custom certificate issuer:
 
 [,plain]
 ----
 --set ingress.extraAnnotations.'cert-manager\.io/cluster-issuer'=issuer-name
-----
-
-Example on setting a static proxy header with `ingress.configurationSnippet`. This value is parsed like a template so variables can be used.
-
-[,plain]
-----
---set ingress.configurationSnippet='more_set_input_headers X-Forwarded-Host {{ .Values.hostname }};'
 ----
 
 === HTTP Proxy
@@ -362,26 +357,6 @@ If you are using a Private CA signed certificate (or if `agent-tls-mode` is set 
 
 Your load balancer must support long lived websocket connections and will need to insert proxy headers so Rancher can route links correctly.
 
-=== Configuring Ingress for External TLS when Using NGINX v0.22
-
-In NGINX v0.22, the behavior of NGINX has https://github.com/kubernetes/ingress-nginx/blob/06efac9f0b6f8f84b553f58ccecf79dc42c75cc6/Changelog.md[changed] regarding forwarding headers and external TLS termination. Therefore, in the scenario that you are using external TLS termination configuration with NGINX v0.22, you must enable the `use-forwarded-headers` option for ingress:
-
-For RKE2 installations, you can create a custom `rke2-ingress-nginx-config.yaml` file at `/var/lib/rancher/rke2/server/manifests/rke2-ingress-nginx-config.yaml` containing this required setting to enable using forwarded headers with external TLS termination. Without this required setting applied, the external LB will continuously respond with redirect loops it receives from the ingress controller. (This can be created before or after rancher is installed, rke2 server agent will notice this addition and automatically apply it.)
-
-[,yaml]
-----
-apiVersion: helm.cattle.io/v1
-kind: HelmChartConfig
-metadata:
-  name: rke2-ingress-nginx
-  namespace: kube-system
-spec:
-  valuesContent: |-
-    controller:
-      config:
-        use-forwarded-headers: "true"
-----
-
 === Required Headers
 
 * `Host`
@@ -398,67 +373,3 @@ spec:
 === Health Checks
 
 Rancher will respond `200` to health checks on the `/healthz` endpoint.
-
-=== Example NGINX config
-
-This NGINX configuration is tested on NGINX 1.14.
-
-[CAUTION]
-====
-
-This NGINX configuration is only an example and may not suit your environment. For complete documentation, see https://docs.nginx.com/nginx/admin-guide/load-balancer/http-load-balancer/[NGINX Load Balancing - HTTP Load Balancing].
-====
-
-
-* Replace `IP_NODE1`, `IP_NODE2` and `IP_NODE3` with the IP addresses of the nodes in your cluster.
-* Replace both occurrences of `FQDN` to the DNS name for Rancher.
-* Replace `/certs/fullchain.pem` and `/certs/privkey.pem` to the location of the server certificate and the server certificate key respectively.
-
-----
-worker_processes 4;
-worker_rlimit_nofile 40000;
-
-events {
-    worker_connections 8192;
-}
-
-http {
-    upstream rancher {
-        server IP_NODE_1:80;
-        server IP_NODE_2:80;
-        server IP_NODE_3:80;
-    }
-
-    map $http_upgrade $connection_upgrade {
-        default Upgrade;
-        ''      close;
-    }
-
-    server {
-        listen 443 ssl http2;
-        server_name FQDN;
-        ssl_certificate /certs/fullchain.pem;
-        ssl_certificate_key /certs/privkey.pem;
-
-        location / {
-            proxy_set_header Host $host;
-            proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_set_header X-Forwarded-Port $server_port;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_pass http://rancher;
-            proxy_http_version 1.1;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection $connection_upgrade;
-            # This allows the ability for the execute shell window to remain open for up to 15 minutes. Without this parameter, the default is 1 minute and will automatically close.
-            proxy_read_timeout 900s;
-            proxy_buffering off;
-        }
-    }
-
-    server {
-        listen 80;
-        server_name FQDN;
-        return 301 https://$server_name$request_uri;
-    }
-}
-----

--- a/versions/v2.13/modules/en/pages/installation-and-upgrade/troubleshooting/troubleshooting.adoc
+++ b/versions/v2.13/modules/en/pages/installation-and-upgrade/troubleshooting/troubleshooting.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-25
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/troubleshooting.adoc 
 :product-path: installation-and-upgrade/troubleshooting/troubleshooting.adoc
@@ -20,7 +20,7 @@ This section describes how to troubleshoot an installation of Rancher on a Kuber
 Most of the troubleshooting will be done on objects in these 3 namespaces.
 
 * `cattle-system` - `rancher` deployment and pods.
-* `ingress-nginx` - Ingress controller pods and services.
+* `traefik` - Ingress controller pods and services.
 * `cert-manager` - `cert-manager` pods.
 
 == "default backend - 404"
@@ -134,7 +134,7 @@ If its ready and the SSL is still not working you may have a malformed cert or s
 Check the nginx-ingress-controller logs. Because the nginx-ingress-controller has multiple containers in its pod you will need to specify the name of the container.
 
 ----
-kubectl -n ingress-nginx logs -f nginx-ingress-controller-rfjrq nginx-ingress-controller
+kubectl logs -n traefik traefik-6b94b8b688-bngw2
 ...
 W0705 23:04:58.240571       7 backend_ssl.go:49] error obtaining PEM from secret cattle-system/tls-rancher-ingress: error retrieving secret cattle-system/tls-rancher-ingress: secret cattle-system/tls-rancher-ingress was not found
 ----
@@ -154,10 +154,6 @@ Install cert-manager and try installing Rancher again.
 The most common cause of this issue is port 8472/UDP is not open between the nodes. Check your local firewall, network routing or security groups.
 
 Once the network issue is resolved, the `canal` pods should timeout and restart to establish their connections.
-
-== nginx-ingress-controller Pods show RESTARTS
-
-The most common cause of this issue is the `canal` pods have failed to establish the overlay network. See <<_canal_pods_show_ready_23,canal Pods show READY `2/3`>> for troubleshooting.
 
 == Failed to dial to /var/run/docker.sock: ssh: rejected: administratively prohibited (open failed)
 

--- a/versions/v2.14/modules/en/pages/cluster-deployment/custom-clusters/custom-clusters.adoc
+++ b/versions/v2.14/modules/en/pages/cluster-deployment/custom-clusters/custom-clusters.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-12-10
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: reference-guides/cluster-configuration/rancher-server-configuration/use-existing-nodes/index.adoc 
 :product-path: cluster-deployment/custom-clusters/custom-clusters.adoc
@@ -122,7 +122,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 === 3. Amazon Only: Tag Resources
 

--- a/versions/v2.14/modules/en/pages/cluster-deployment/hosted-kubernetes/eks/eks.adoc
+++ b/versions/v2.14/modules/en/pages/cluster-deployment/hosted-kubernetes/eks/eks.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-05
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/eks.adoc 
 :product-path: cluster-deployment/hosted-kubernetes/eks/eks.adoc
@@ -71,7 +71,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 == EKS Cluster Configuration Reference
 

--- a/versions/v2.14/modules/en/pages/cluster-deployment/hosted-kubernetes/gke/gke.adoc
+++ b/versions/v2.14/modules/en/pages/cluster-deployment/hosted-kubernetes/gke/gke.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-05
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/gke.adoc 
 :product-path: cluster-deployment/hosted-kubernetes/gke/gke.adoc
@@ -87,7 +87,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 == Private Clusters
 

--- a/versions/v2.14/modules/en/pages/cluster-deployment/infra-providers/aws/aws.adoc
+++ b/versions/v2.14/modules/en/pages/cluster-deployment/infra-providers/aws/aws.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-12-10
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-an-amazon-ec2-cluster.adoc 
 :product-path: cluster-deployment/infra-providers/aws/aws.adoc
@@ -82,7 +82,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 === Optional Next Steps
 

--- a/versions/v2.14/modules/en/pages/cluster-deployment/infra-providers/azure/azure.adoc
+++ b/versions/v2.14/modules/en/pages/cluster-deployment/infra-providers/azure/azure.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-25
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-an-azure-cluster.adoc 
 :product-path: cluster-deployment/infra-providers/azure/azure.adoc
@@ -104,7 +104,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 === Optional Next Steps
 

--- a/versions/v2.14/modules/en/pages/cluster-deployment/infra-providers/digitalocean/digitalocean.adoc
+++ b/versions/v2.14/modules/en/pages/cluster-deployment/infra-providers/digitalocean/digitalocean.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-25
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-a-digitalocean-cluster.adoc 
 :product-path: cluster-deployment/infra-providers/digitalocean/digitalocean.adoc
@@ -63,7 +63,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 == Optional Next Steps
 

--- a/versions/v2.14/modules/en/pages/cluster-deployment/infra-providers/gce/gce.adoc
+++ b/versions/v2.14/modules/en/pages/cluster-deployment/infra-providers/gce/gce.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-27
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-a-google-compute-engine-cluster.adoc 
 :product-path: cluster-deployment/infra-providers/gce/gce.adoc
@@ -81,7 +81,7 @@ You can access your cluster after its state is updated to **Active**.
 **Active** clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 == GCE Best Practices
 

--- a/versions/v2.14/modules/en/pages/cluster-deployment/infra-providers/nutanix/provision-kubernetes-clusters-in-aos.adoc
+++ b/versions/v2.14/modules/en/pages/cluster-deployment/infra-providers/nutanix/provision-kubernetes-clusters-in-aos.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-05
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/nutanix/provision-kubernetes-clusters-in-aos.adoc 
 :product-path: cluster-deployment/infra-providers/nutanix/provision-kubernetes-clusters-in-aos.adoc
@@ -100,7 +100,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 == Optional Next Steps
 

--- a/versions/v2.14/modules/en/pages/cluster-deployment/infra-providers/vsphere/provision-kubernetes-clusters-in-vsphere.adoc
+++ b/versions/v2.14/modules/en/pages/cluster-deployment/infra-providers/vsphere/provision-kubernetes-clusters-in-vsphere.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-25
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/provision-kubernetes-clusters-in-vsphere.adoc 
 :product-path: cluster-deployment/infra-providers/vsphere/provision-kubernetes-clusters-in-vsphere.adoc
@@ -102,7 +102,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 == Optional Next Steps
 

--- a/versions/v2.14/modules/en/pages/cluster-deployment/register-existing-clusters.adoc
+++ b/versions/v2.14/modules/en/pages/cluster-deployment/register-existing-clusters.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-25
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.adoc 
 :product-path: cluster-deployment/register-existing-clusters.adoc
@@ -99,7 +99,7 @@ Specifically, the value should be a comma-delimited string which only contains I
 
 * Your cluster is registered and assigned a state of *Pending*. Rancher is deploying resources to manage your cluster.
 * You can access your cluster after its state is updated to *Active*.
-* *Active* clusters are assigned two Projects: `Default` (containing the namespace `default`) and `System` (containing the namespaces `cattle-system`, `ingress-nginx`, `kube-public` and `kube-system`, if present).
+* *Active* clusters are assigned two Projects: `Default` (containing the namespace `default`) and `System` (containing the namespaces `cattle-system`, `traefik`, `kube-public` and `kube-system`, if present).
 
 [NOTE]
 ====

--- a/versions/v2.14/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
+++ b/versions/v2.14/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-05
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal.adoc 
 :product-path: installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
@@ -111,7 +111,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 ==== Finished
 

--- a/versions/v2.14/modules/en/pages/installation-and-upgrade/references/helm-chart-options.adoc
+++ b/versions/v2.14/modules/en/pages/installation-and-upgrade/references/helm-chart-options.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-27
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/installation-references/helm-chart-options.adoc 
 :product-path: installation-and-upgrade/references/helm-chart-options.adoc
@@ -267,18 +267,13 @@ This option is only effective on the initial Rancher install. See https://github
 
 To customize or use a different ingress with Rancher server you can set your own Ingress annotations.
 
+Please refer to the Traefik documentation for the full list of Ingress NGINX annotations that are https://doc.traefik.io/traefik/reference/routing-configuration/kubernetes/ingress-nginx/#annotations-support[supported] and https://doc.traefik.io/traefik/reference/routing-configuration/kubernetes/ingress-nginx/#unsupported-annotations[unsupported] by Traefik's kubernetesIngressNginx provider.
+
 Example on setting a custom certificate issuer:
 
 [,plain]
 ----
 --set ingress.extraAnnotations.'cert-manager\.io/cluster-issuer'=issuer-name
-----
-
-Example on setting a static proxy header with `ingress.configurationSnippet`. This value is parsed like a template so variables can be used.
-
-[,plain]
-----
---set ingress.configurationSnippet='more_set_input_headers X-Forwarded-Host {{ .Values.hostname }};'
 ----
 
 === HTTP Proxy
@@ -362,26 +357,6 @@ If you are using a Private CA signed certificate (or if `agent-tls-mode` is set 
 
 Your load balancer must support long lived websocket connections and will need to insert proxy headers so Rancher can route links correctly.
 
-=== Configuring Ingress for External TLS when Using NGINX v0.22
-
-In NGINX v0.22, the behavior of NGINX has https://github.com/kubernetes/ingress-nginx/blob/06efac9f0b6f8f84b553f58ccecf79dc42c75cc6/Changelog.md[changed] regarding forwarding headers and external TLS termination. Therefore, in the scenario that you are using external TLS termination configuration with NGINX v0.22, you must enable the `use-forwarded-headers` option for ingress:
-
-For RKE2 installations, you can create a custom `rke2-ingress-nginx-config.yaml` file at `/var/lib/rancher/rke2/server/manifests/rke2-ingress-nginx-config.yaml` containing this required setting to enable using forwarded headers with external TLS termination. Without this required setting applied, the external LB will continuously respond with redirect loops it receives from the ingress controller. (This can be created before or after rancher is installed, rke2 server agent will notice this addition and automatically apply it.)
-
-[,yaml]
-----
-apiVersion: helm.cattle.io/v1
-kind: HelmChartConfig
-metadata:
-  name: rke2-ingress-nginx
-  namespace: kube-system
-spec:
-  valuesContent: |-
-    controller:
-      config:
-        use-forwarded-headers: "true"
-----
-
 === Required Headers
 
 * `Host`
@@ -398,67 +373,3 @@ spec:
 === Health Checks
 
 Rancher will respond `200` to health checks on the `/healthz` endpoint.
-
-=== Example NGINX config
-
-This NGINX configuration is tested on NGINX 1.14.
-
-[CAUTION]
-====
-
-This NGINX configuration is only an example and may not suit your environment. For complete documentation, see https://docs.nginx.com/nginx/admin-guide/load-balancer/http-load-balancer/[NGINX Load Balancing - HTTP Load Balancing].
-====
-
-
-* Replace `IP_NODE1`, `IP_NODE2` and `IP_NODE3` with the IP addresses of the nodes in your cluster.
-* Replace both occurrences of `FQDN` to the DNS name for Rancher.
-* Replace `/certs/fullchain.pem` and `/certs/privkey.pem` to the location of the server certificate and the server certificate key respectively.
-
-----
-worker_processes 4;
-worker_rlimit_nofile 40000;
-
-events {
-    worker_connections 8192;
-}
-
-http {
-    upstream rancher {
-        server IP_NODE_1:80;
-        server IP_NODE_2:80;
-        server IP_NODE_3:80;
-    }
-
-    map $http_upgrade $connection_upgrade {
-        default Upgrade;
-        ''      close;
-    }
-
-    server {
-        listen 443 ssl http2;
-        server_name FQDN;
-        ssl_certificate /certs/fullchain.pem;
-        ssl_certificate_key /certs/privkey.pem;
-
-        location / {
-            proxy_set_header Host $host;
-            proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_set_header X-Forwarded-Port $server_port;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_pass http://rancher;
-            proxy_http_version 1.1;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection $connection_upgrade;
-            # This allows the ability for the execute shell window to remain open for up to 15 minutes. Without this parameter, the default is 1 minute and will automatically close.
-            proxy_read_timeout 900s;
-            proxy_buffering off;
-        }
-    }
-
-    server {
-        listen 80;
-        server_name FQDN;
-        return 301 https://$server_name$request_uri;
-    }
-}
-----

--- a/versions/v2.14/modules/en/pages/installation-and-upgrade/troubleshooting/troubleshooting.adoc
+++ b/versions/v2.14/modules/en/pages/installation-and-upgrade/troubleshooting/troubleshooting.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-25
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/troubleshooting.adoc 
 :product-path: installation-and-upgrade/troubleshooting/troubleshooting.adoc
@@ -20,7 +20,7 @@ This section describes how to troubleshoot an installation of Rancher on a Kuber
 Most of the troubleshooting will be done on objects in these 3 namespaces.
 
 * `cattle-system` - `rancher` deployment and pods.
-* `ingress-nginx` - Ingress controller pods and services.
+* `traefik` - Ingress controller pods and services.
 * `cert-manager` - `cert-manager` pods.
 
 == "default backend - 404"
@@ -134,7 +134,7 @@ If its ready and the SSL is still not working you may have a malformed cert or s
 Check the nginx-ingress-controller logs. Because the nginx-ingress-controller has multiple containers in its pod you will need to specify the name of the container.
 
 ----
-kubectl -n ingress-nginx logs -f nginx-ingress-controller-rfjrq nginx-ingress-controller
+kubectl logs -n traefik traefik-6b94b8b688-bngw2
 ...
 W0705 23:04:58.240571       7 backend_ssl.go:49] error obtaining PEM from secret cattle-system/tls-rancher-ingress: error retrieving secret cattle-system/tls-rancher-ingress: secret cattle-system/tls-rancher-ingress was not found
 ----
@@ -154,10 +154,6 @@ Install cert-manager and try installing Rancher again.
 The most common cause of this issue is port 8472/UDP is not open between the nodes. Check your local firewall, network routing or security groups.
 
 Once the network issue is resolved, the `canal` pods should timeout and restart to establish their connections.
-
-== nginx-ingress-controller Pods show RESTARTS
-
-The most common cause of this issue is the `canal` pods have failed to establish the overlay network. See <<_canal_pods_show_ready_23,canal Pods show READY `2/3`>> for troubleshooting.
 
 == Failed to dial to /var/run/docker.sock: ssh: rejected: administratively prohibited (open failed)
 

--- a/versions/v2.9/modules/en/pages/cluster-deployment/custom-clusters/custom-clusters.adoc
+++ b/versions/v2.9/modules/en/pages/cluster-deployment/custom-clusters/custom-clusters.adoc
@@ -1,6 +1,6 @@
 = Launching Kubernetes on Existing Custom Nodes
 :page-languages: [en, zh]
-:revdate: 2024-09-27
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: reference-guides/cluster-configuration/rancher-server-configuration/use-existing-nodes/index.adoc 
 :product-path: cluster-deployment/custom-clusters/custom-clusters.adoc
@@ -116,7 +116,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 === 3. Amazon Only: Tag Resources
 

--- a/versions/v2.9/modules/en/pages/cluster-deployment/hosted-kubernetes/eks/eks.adoc
+++ b/versions/v2.9/modules/en/pages/cluster-deployment/hosted-kubernetes/eks/eks.adoc
@@ -1,6 +1,6 @@
 = Creating an EKS Cluster
 :page-languages: [en, zh]
-:revdate: 2025-03-17
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/eks.adoc 
 :product-path: cluster-deployment/hosted-kubernetes/eks/eks.adoc
@@ -69,7 +69,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 == EKS Cluster Configuration Reference
 

--- a/versions/v2.9/modules/en/pages/cluster-deployment/hosted-kubernetes/gke/gke.adoc
+++ b/versions/v2.9/modules/en/pages/cluster-deployment/hosted-kubernetes/gke/gke.adoc
@@ -1,6 +1,6 @@
 = Creating a GKE Cluster
 :page-languages: [en, zh]
-:revdate: 2025-03-17
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-clusters-from-hosted-kubernetes-providers/gke.adoc 
 :product-path: cluster-deployment/hosted-kubernetes/gke/gke.adoc
@@ -85,7 +85,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 == Private Clusters
 

--- a/versions/v2.9/modules/en/pages/cluster-deployment/infra-providers/aws/aws.adoc
+++ b/versions/v2.9/modules/en/pages/cluster-deployment/infra-providers/aws/aws.adoc
@@ -1,6 +1,6 @@
 = Creating an Amazon EC2 Cluster
 :page-languages: [en, zh]
-:revdate: 2024-09-27
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-an-amazon-ec2-cluster.adoc 
 :product-path: cluster-deployment/infra-providers/aws/aws.adoc
@@ -150,7 +150,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 === Optional Next Steps
 

--- a/versions/v2.9/modules/en/pages/cluster-deployment/infra-providers/azure/azure.adoc
+++ b/versions/v2.9/modules/en/pages/cluster-deployment/infra-providers/azure/azure.adoc
@@ -1,6 +1,6 @@
 = Creating an Azure Cluster
 :page-languages: [en, zh]
-:revdate: 2025-03-17
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-an-azure-cluster.adoc 
 :product-path: cluster-deployment/infra-providers/azure/azure.adoc
@@ -160,7 +160,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 === Optional Next Steps
 

--- a/versions/v2.9/modules/en/pages/cluster-deployment/infra-providers/digitalocean/digitalocean.adoc
+++ b/versions/v2.9/modules/en/pages/cluster-deployment/infra-providers/digitalocean/digitalocean.adoc
@@ -1,6 +1,6 @@
 = Creating a DigitalOcean Cluster
 :page-languages: [en, zh]
-:revdate: 2024-09-27
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/create-a-digitalocean-cluster.adoc 
 :product-path: cluster-deployment/infra-providers/digitalocean/digitalocean.adoc
@@ -118,7 +118,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 == Optional Next Steps
 

--- a/versions/v2.9/modules/en/pages/cluster-deployment/infra-providers/nutanix/provision-kubernetes-clusters-in-aos.adoc
+++ b/versions/v2.9/modules/en/pages/cluster-deployment/infra-providers/nutanix/provision-kubernetes-clusters-in-aos.adoc
@@ -1,6 +1,6 @@
 = Provisioning Kubernetes Clusters in Nutanix AOS
 :page-languages: [en, zh]
-:revdate: 2024-09-27
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/nutanix/provision-kubernetes-clusters-in-aos.adoc 
 :product-path: cluster-deployment/infra-providers/nutanix/provision-kubernetes-clusters-in-aos.adoc
@@ -98,7 +98,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 == Optional Next Steps
 

--- a/versions/v2.9/modules/en/pages/cluster-deployment/infra-providers/vsphere/provision-kubernetes-clusters-in-vsphere.adoc
+++ b/versions/v2.9/modules/en/pages/cluster-deployment/infra-providers/vsphere/provision-kubernetes-clusters-in-vsphere.adoc
@@ -1,6 +1,6 @@
 = Provisioning Kubernetes Clusters in VMware vSphere
 :page-languages: [en, zh]
-:revdate: 2024-09-27
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/provision-kubernetes-clusters-in-vsphere.adoc 
 :product-path: cluster-deployment/infra-providers/vsphere/provision-kubernetes-clusters-in-vsphere.adoc
@@ -119,7 +119,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 == Optional Next Steps
 

--- a/versions/v2.9/modules/en/pages/cluster-deployment/register-existing-clusters.adoc
+++ b/versions/v2.9/modules/en/pages/cluster-deployment/register-existing-clusters.adoc
@@ -1,6 +1,6 @@
 = Registering Existing Clusters
 :page-languages: [en, zh]
-:revdate: 2025-08-25
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.adoc 
 :product-path: cluster-deployment/register-existing-clusters.adoc
@@ -86,7 +86,7 @@ Specifically, the value should be a comma-delimited string which only contains I
 
 * Your cluster is registered and assigned a state of *Pending*. Rancher is deploying resources to manage your cluster.
 * You can access your cluster after its state is updated to *Active*.
-* *Active* clusters are assigned two Projects: `Default` (containing the namespace `default`) and `System` (containing the namespaces `cattle-system`, `ingress-nginx`, `kube-public` and `kube-system`, if present).
+* *Active* clusters are assigned two Projects: `Default` (containing the namespace `default`) and `System` (containing the namespaces `cattle-system`, `traefik`, `kube-public` and `kube-system`, if present).
 
 [NOTE]
 ====

--- a/versions/v2.9/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
+++ b/versions/v2.9/modules/en/pages/installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
@@ -1,6 +1,6 @@
 = {rancher-product-name} Equinix Metal Quick Start
 :page-languages: [en, zh]
-:revdate: 2025-04-30
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal.adoc 
 :product-path: installation-and-upgrade/quick-start/deploy-rancher/equinix-metal.adoc
@@ -109,7 +109,7 @@ You can access your cluster after its state is updated to *Active*.
 *Active* clusters are assigned two Projects:
 
 * `Default`, containing the `default` namespace
-* `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+* `System`, containing the `cattle-system`, `traefik`, `kube-public`, and `kube-system` namespaces
 
 ==== Finished
 

--- a/versions/v2.9/modules/en/pages/installation-and-upgrade/references/helm-chart-options.adoc
+++ b/versions/v2.9/modules/en/pages/installation-and-upgrade/references/helm-chart-options.adoc
@@ -1,6 +1,6 @@
 = {rancher-product-name} Helm Chart Options
 :page-languages: [en, zh]
-:revdate: 2025-08-18
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/installation-references/helm-chart-options.adoc 
 :product-path: installation-and-upgrade/references/helm-chart-options.adoc
@@ -300,18 +300,13 @@ This option is only effective on the initial Rancher install. See https://github
 
 To customize or use a different ingress with Rancher server you can set your own Ingress annotations.
 
+Please refer to the Traefik documentation for the full list of Ingress NGINX annotations that are https://doc.traefik.io/traefik/reference/routing-configuration/kubernetes/ingress-nginx/#annotations-support[supported] and https://doc.traefik.io/traefik/reference/routing-configuration/kubernetes/ingress-nginx/#unsupported-annotations[unsupported] by Traefik's kubernetesIngressNginx provider.
+
 Example on setting a custom certificate issuer:
 
 [,plain]
 ----
 --set ingress.extraAnnotations.'cert-manager\.io/cluster-issuer'=issuer-name
-----
-
-Example on setting a static proxy header with `ingress.configurationSnippet`. This value is parsed like a template so variables can be used.
-
-[,plain]
-----
---set ingress.configurationSnippet='more_set_input_headers X-Forwarded-Host {{ .Values.hostname }};'
 ----
 
 === HTTP Proxy
@@ -395,36 +390,6 @@ If you are using a Private CA signed certificate (or if `agent-tls-mode` is set 
 
 Your load balancer must support long lived websocket connections and will need to insert proxy headers so Rancher can route links correctly.
 
-=== Configuring Ingress for External TLS when Using NGINX v0.22
-
-In NGINX v0.22, the behavior of NGINX has https://github.com/kubernetes/ingress-nginx/blob/06efac9f0b6f8f84b553f58ccecf79dc42c75cc6/Changelog.md[changed] regarding forwarding headers and external TLS termination. Therefore, in the scenario that you are using external TLS termination configuration with NGINX v0.22, you must enable the `use-forwarded-headers` option for ingress:
-
-For RKE installations, edit the `cluster.yml` to add the following settings.
-
-[,yaml]
-----
-ingress:
-  provider: nginx
-  options:
-    use-forwarded-headers: 'true'
-----
-
-For RKE2 installations, you can create a custom `rke2-ingress-nginx-config.yaml` file at `/var/lib/rancher/rke2/server/manifests/rke2-ingress-nginx-config.yaml` containing this required setting to enable using forwarded headers with external TLS termination. Without this required setting applied, the external LB will continuously respond with redirect loops it receives from the ingress controller. (This can be created before or after rancher is installed, rke2 server agent will notice this addition and automatically apply it.)
-
-[,yaml]
-----
-apiVersion: helm.cattle.io/v1
-kind: HelmChartConfig
-metadata:
-  name: rke2-ingress-nginx
-  namespace: kube-system
-spec:
-  valuesContent: |-
-    controller:
-      config:
-        use-forwarded-headers: "true"
-----
-
 === Required Headers
 
 * `Host`
@@ -441,67 +406,3 @@ spec:
 === Health Checks
 
 Rancher will respond `200` to health checks on the `/healthz` endpoint.
-
-=== Example NGINX config
-
-This NGINX configuration is tested on NGINX 1.14.
-
-[CAUTION]
-====
-
-This NGINX configuration is only an example and may not suit your environment. For complete documentation, see https://docs.nginx.com/nginx/admin-guide/load-balancer/http-load-balancer/[NGINX Load Balancing - HTTP Load Balancing].
-====
-
-
-* Replace `IP_NODE1`, `IP_NODE2` and `IP_NODE3` with the IP addresses of the nodes in your cluster.
-* Replace both occurrences of `FQDN` to the DNS name for Rancher.
-* Replace `/certs/fullchain.pem` and `/certs/privkey.pem` to the location of the server certificate and the server certificate key respectively.
-
-----
-worker_processes 4;
-worker_rlimit_nofile 40000;
-
-events {
-    worker_connections 8192;
-}
-
-http {
-    upstream rancher {
-        server IP_NODE_1:80;
-        server IP_NODE_2:80;
-        server IP_NODE_3:80;
-    }
-
-    map $http_upgrade $connection_upgrade {
-        default Upgrade;
-        ''      close;
-    }
-
-    server {
-        listen 443 ssl http2;
-        server_name FQDN;
-        ssl_certificate /certs/fullchain.pem;
-        ssl_certificate_key /certs/privkey.pem;
-
-        location / {
-            proxy_set_header Host $host;
-            proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_set_header X-Forwarded-Port $server_port;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_pass http://rancher;
-            proxy_http_version 1.1;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection $connection_upgrade;
-            # This allows the ability for the execute shell window to remain open for up to 15 minutes. Without this parameter, the default is 1 minute and will automatically close.
-            proxy_read_timeout 900s;
-            proxy_buffering off;
-        }
-    }
-
-    server {
-        listen 80;
-        server_name FQDN;
-        return 301 https://$server_name$request_uri;
-    }
-}
-----

--- a/versions/v2.9/modules/en/pages/installation-and-upgrade/troubleshooting/troubleshooting.adoc
+++ b/versions/v2.9/modules/en/pages/installation-and-upgrade/troubleshooting/troubleshooting.adoc
@@ -1,6 +1,6 @@
 = Troubleshooting the {rancher-product-name} Server Kubernetes Cluster
 :page-languages: [en, zh]
-:revdate: 2024-09-27
+:revdate: 2026-03-19
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/troubleshooting.adoc 
 :product-path: installation-and-upgrade/troubleshooting/troubleshooting.adoc
@@ -18,7 +18,7 @@ This section describes how to troubleshoot an installation of Rancher on a Kuber
 Most of the troubleshooting will be done on objects in these 3 namespaces.
 
 * `cattle-system` - `rancher` deployment and pods.
-* `ingress-nginx` - Ingress controller pods and services.
+* `traefik` - Ingress controller pods and services.
 * `cert-manager` - `cert-manager` pods.
 
 == "default backend - 404"
@@ -132,7 +132,7 @@ If its ready and the SSL is still not working you may have a malformed cert or s
 Check the nginx-ingress-controller logs. Because the nginx-ingress-controller has multiple containers in its pod you will need to specify the name of the container.
 
 ----
-kubectl -n ingress-nginx logs -f nginx-ingress-controller-rfjrq nginx-ingress-controller
+kubectl logs -n traefik traefik-6b94b8b688-bngw2
 ...
 W0705 23:04:58.240571       7 backend_ssl.go:49] error obtaining PEM from secret cattle-system/tls-rancher-ingress: error retrieving secret cattle-system/tls-rancher-ingress: secret cattle-system/tls-rancher-ingress was not found
 ----
@@ -152,10 +152,6 @@ Install cert-manager and try installing Rancher again.
 The most common cause of this issue is port 8472/UDP is not open between the nodes. Check your local firewall, network routing or security groups.
 
 Once the network issue is resolved, the `canal` pods should timeout and restart to establish their connections.
-
-== nginx-ingress-controller Pods show RESTARTS
-
-The most common cause of this issue is the `canal` pods have failed to establish the overlay network. See <<_canal_pods_show_ready_23,canal Pods show READY `2/3`>> for troubleshooting.
 
 == Failed to dial to /var/run/docker.sock: ssh: rejected: administratively prohibited (open failed)
 


### PR DESCRIPTION
Fixes #875

Note: the original [Community update](https://github.com/rancher/rancher-docs/pull/2237) backported changes to v2.10, but it's backported to v2.9 here as v2.9 has not been archived here yet.
