### PR TITLE
Remove Community files/symlinks for files removed in PR #895

### DIFF
--- a/community-docs/v2.12/modules/ROOT/pages/reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration.adoc
+++ b/community-docs/v2.12/modules/ROOT/pages/reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration.adoc
@@ -1,1 +1,0 @@
-../../../../../../../../versions/v2.12/modules/en/pages/cluster-deployment/configuration/rke1.adoc

--- a/community-docs/v2.13/modules/ROOT/pages/reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration.adoc
+++ b/community-docs/v2.13/modules/ROOT/pages/reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration.adoc
@@ -1,1 +1,0 @@
-../../../../../../../../versions/v2.13/modules/en/pages/cluster-deployment/configuration/rke1.adoc

--- a/community-docs/v2.14/modules/ROOT/pages/reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration.adoc
+++ b/community-docs/v2.14/modules/ROOT/pages/reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration.adoc
@@ -1,1 +1,0 @@
-../../../../../../../../versions/v2.14/modules/en/pages/cluster-deployment/configuration/rke1.adoc


### PR DESCRIPTION
The Product files were removed in https://github.com/rancher/rancher-product-docs/pull/895, but we missed removing the corresponding Community symlinks to them.