### PR TITLE
Adding KB article reference - Migrating from Ingress NGINX to Traefik in a Rancher provisioned RKE2 Cluster

### DIFF
--- a/versions/v2.14/modules/en/pages/cluster-deployment/configuration/rke2.adoc
+++ b/versions/v2.14/modules/en/pages/cluster-deployment/configuration/rke2.adoc
@@ -196,7 +196,7 @@ By default, https://coredns.io/[CoreDNS] is installed as the default DNS provide
 *Ingress-NGINX EOL:* The community `ingress-nginx` controller reaches End-of-Life (EOL) in March 2026. Traefik is the recommended migration path for Rancher RKE2 environments. Refer to https://support.scc.suse.com/s/kb/Migrating-from-Ingress-NGINX-to-Traefik-in-a-Rancher-provisioned-RKE2-Cluster?language=en_US[Migrating from Ingress NGINX to Traefik in a Rancher provisioned RKE2 Cluster] for further details.
 ====
 
-If you want to publish your applications in a high-availability configuration, and you're hosting your nodes with a cloud-provider that doesn't have a native load-balancing feature, enable this option to use NGINX Ingress within the cluster. Refer to the https://documentation.suse.com/cloudnative/rke2/latest/en/networking/networking_services.html#_nginx_ingress_controller[RKE2 documentation] for additional configuration options.
+If you want to expose your applications in a high-availability configuration, and you're hosting your nodes with a cloud provider that doesn't have a native load-balancing feature, enable this option to use NGINX Ingress within the cluster. Refer to the https://documentation.suse.com/cloudnative/rke2/latest/en/networking/networking_services.html#_nginx_ingress_controller[RKE2 documentation] for additional configuration options.
 
 ===== Metrics Server
 

--- a/versions/v2.14/modules/en/pages/cluster-deployment/configuration/rke2.adoc
+++ b/versions/v2.14/modules/en/pages/cluster-deployment/configuration/rke2.adoc
@@ -189,14 +189,27 @@ Project network isolation is available if you are using any RKE2 network plugin 
 
 By default, https://coredns.io/[CoreDNS] is installed as the default DNS provider. If CoreDNS is not installed, an alternate DNS provider must be installed yourself. Refer to the https://documentation.suse.com/cloudnative/rke2/latest/en/networking/networking_services.html#_coredns[RKE2 documentation] for additional CoreDNS configurations.
 
-===== NGINX Ingress
+===== Ingress
 
+[tabs]
+======
+Ingress-NGINX::
++
+--
 [WARNING]
 ====
-*Ingress-NGINX EOL:* The community `ingress-nginx` controller reaches End-of-Life (EOL) in March 2026. Traefik is the recommended migration path for Rancher RKE2 environments. Refer to https://support.scc.suse.com/s/kb/Migrating-from-Ingress-NGINX-to-Traefik-in-a-Rancher-provisioned-RKE2-Cluster?language=en_US[Migrating from Ingress NGINX to Traefik in a Rancher provisioned RKE2 Cluster] for further details.
+*Ingress-NGINX EOL:* The community `ingress-nginx` controller reached End-of-Life (EOL) March 2026 and is deprecated in RKE2 v1.36. SUSE Rancher Prime provisioned RKE2 versions will continue to receive `ingress-nginx` support and CVE fixes (8+) for the entire lifecycle of RKE2 v1.32, v1.33, v1.34, v1.35 and v1.36. Traefik is the recommended migration path for SUSE Rancher RKE2 environments, it is recommended to migrate as soon as possible. Refer to https://support.scc.suse.com/s/kb/Migrating-from-Ingress-NGINX-to-Traefik-in-a-Rancher-provisioned-RKE2-Cluster?language=en_US[Migrating from Ingress NGINX to Traefik in a Rancher provisioned RKE2 Cluster] for further details.
 ====
 
-If you want to expose your applications in a high-availability configuration, and you're hosting your nodes with a cloud provider that doesn't have a native load-balancing feature, enable this option to use NGINX Ingress within the cluster. Refer to the https://documentation.suse.com/cloudnative/rke2/latest/en/networking/networking_services.html#_nginx_ingress_controller[RKE2 documentation] for additional configuration options.
+This is the legacy ingress option to enable Ingress-NGINX within the cluster. Refer to the https://documentation.suse.com/cloudnative/rke2/latest/en/networking/networking_services.html#_ingress_controller[RKE2 documentation] for additional configuration options.
+--
+
+Traefik::
++
+--
+If you want to expose your applications in a high-availability configuration, and you're hosting your nodes with a cloud provider that doesn't have a native load-balancing feature, enable this option to use Traefik Ingress within the cluster. Refer to the https://documentation.suse.com/cloudnative/rke2/latest/en/networking/networking_services.html#_ingress_controller[RKE2 documentation] for additional configuration options.
+--
+======
 
 ===== Metrics Server
 

--- a/versions/v2.14/modules/en/pages/cluster-deployment/configuration/rke2.adoc
+++ b/versions/v2.14/modules/en/pages/cluster-deployment/configuration/rke2.adoc
@@ -191,9 +191,12 @@ By default, https://coredns.io/[CoreDNS] is installed as the default DNS provide
 
 ===== NGINX Ingress
 
-If you want to publish your applications in a high-availability configuration, and you're hosting your nodes with a cloud-provider that doesn't have a native load-balancing feature, enable this option to use NGINX Ingress within the cluster. Refer to the https://documentation.suse.com/cloudnative/rke2/latest/en/networking/networking_services.html#_nginx_ingress_controller[RKE2 documentation] for additional configuration options.
+[WARNING]
+====
+*Ingress-NGINX EOL:* The community `ingress-nginx` controller reaches End-of-Life (EOL) in March 2026. Traefik is the recommended migration path for Rancher RKE2 environments. Refer to https://support.scc.suse.com/s/kb/Migrating-from-Ingress-NGINX-to-Traefik-in-a-Rancher-provisioned-RKE2-Cluster?language=en_US[Migrating from Ingress NGINX to Traefik in a Rancher provisioned RKE2 Cluster] for further details.
+====
 
-Refer to the https://documentation.suse.com/cloudnative/rke2/latest/en/networking/networking_services.html#_nginx_ingress_controller[RKE2 documentation] for additional configuration options.
+If you want to publish your applications in a high-availability configuration, and you're hosting your nodes with a cloud-provider that doesn't have a native load-balancing feature, enable this option to use NGINX Ingress within the cluster. Refer to the https://documentation.suse.com/cloudnative/rke2/latest/en/networking/networking_services.html#_nginx_ingress_controller[RKE2 documentation] for additional configuration options.
 
 ===== Metrics Server
 

--- a/versions/v2.14/modules/en/pages/cluster-deployment/configuration/rke2.adoc
+++ b/versions/v2.14/modules/en/pages/cluster-deployment/configuration/rke2.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-12-10
+:revdate: 2026-03-30
 :page-revdate: {revdate}
 :community-path: reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration.adoc 
 :product-path: cluster-deployment/configuration/rke2.adoc

--- a/versions/v2.14/modules/en/pages/installation-and-upgrade/infrastructure-setup/ha-rke2-kubernetes-cluster.adoc
+++ b/versions/v2.14/modules/en/pages/installation-and-upgrade/infrastructure-setup/ha-rke2-kubernetes-cluster.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-05
+:revdate: 2026-03-30
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/infrastructure-setup/ha-rke2-kubernetes-cluster.adoc 
 :product-path: installation-and-upgrade/infrastructure-setup/ha-rke2-kubernetes-cluster.adoc

--- a/versions/v2.14/modules/en/pages/installation-and-upgrade/infrastructure-setup/ha-rke2-kubernetes-cluster.adoc
+++ b/versions/v2.14/modules/en/pages/installation-and-upgrade/infrastructure-setup/ha-rke2-kubernetes-cluster.adoc
@@ -52,7 +52,7 @@ You will also need to set up a load balancer to direct traffic to the Rancher re
 
 [WARNING]
 ====
-*Ingress-NGINX EOL:* The community `ingress-nginx` controller reaches End-of-Life (EOL) in March 2026. Traefik is the recommended migration path for Rancher RKE2 environments. Refer to https://support.scc.suse.com/s/kb/Migrating-from-Ingress-NGINX-to-Traefik-in-a-Rancher-provisioned-RKE2-Cluster?language=en_US[Migrating from Ingress NGINX to Traefik in a Rancher provisioned RKE2 Cluster] for further details.
+*Ingress-NGINX EOL:* The community `ingress-nginx` controller reached End-of-Life (EOL) March 2026 and is deprecated in RKE2 v1.36. SUSE Rancher Prime provisioned RKE2 versions will continue to receive `ingress-nginx` support and CVE fixes (8+) for the entire lifecycle of RKE2 v1.32, v1.33, v1.34, v1.35 and v1.36. Traefik is the recommended migration path for SUSE Rancher RKE2 environments, it is recommended to migrate as soon as possible. Refer to https://support.scc.suse.com/s/kb/Migrating-from-Ingress-NGINX-to-Traefik-in-a-Rancher-provisioned-RKE2-Cluster?language=en_US[Migrating from Ingress NGINX to Traefik in a Rancher provisioned RKE2 Cluster] for further details.
 ====
 
 When Kubernetes gets set up in a later step, the RKE2 tool will deploy an Nginx Ingress controller. This controller will listen on ports 80 and 443 of the worker nodes, answering traffic destined for specific hostnames.

--- a/versions/v2.14/modules/en/pages/installation-and-upgrade/infrastructure-setup/ha-rke2-kubernetes-cluster.adoc
+++ b/versions/v2.14/modules/en/pages/installation-and-upgrade/infrastructure-setup/ha-rke2-kubernetes-cluster.adoc
@@ -50,6 +50,11 @@ For an example of one way to set up Linux nodes, refer to this {xref-setup-ec2-n
 
 You will also need to set up a load balancer to direct traffic to the Rancher replica on all nodes. That will prevent an outage of any single node from taking down communications to the Rancher management server.
 
+[WARNING]
+====
+*Ingress-NGINX EOL:* The community `ingress-nginx` controller reaches End-of-Life (EOL) in March 2026. Traefik is the recommended migration path for Rancher RKE2 environments. Refer to https://support.scc.suse.com/s/kb/Migrating-from-Ingress-NGINX-to-Traefik-in-a-Rancher-provisioned-RKE2-Cluster?language=en_US[Migrating from Ingress NGINX to Traefik in a Rancher provisioned RKE2 Cluster] for further details.
+====
+
 When Kubernetes gets set up in a later step, the RKE2 tool will deploy an Nginx Ingress controller. This controller will listen on ports 80 and 443 of the worker nodes, answering traffic destined for specific hostnames.
 
 When Rancher is installed (also in a later step), the Rancher system creates an Ingress resource. That Ingress tells the Nginx Ingress controller to listen for traffic destined for the Rancher hostname. The Nginx Ingress controller, when receiving traffic destined for the Rancher hostname, will forward that traffic to the running Rancher pods in the cluster.

--- a/versions/v2.14/modules/en/pages/installation-and-upgrade/install-kubernetes/rke2-for-rancher.adoc
+++ b/versions/v2.14/modules/en/pages/installation-and-upgrade/install-kubernetes/rke2-for-rancher.adoc
@@ -105,7 +105,7 @@ To use this `kubeconfig` file,
 
 . Install https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl[kubectl,] a Kubernetes command-line tool.
 . Copy the file at `/etc/rancher/rke2/rke2.yaml` and save it to the directory `~/.kube/config` on your local machine.
-. In the kubeconfig file, the `server` directive is defined as localhost. Configure the server as the DNS of your control-plane load balancer, on port 6443. (The RKE2 Kubernetes API Server uses port 6443, while the Rancher server will be served via the Traefik Ingress on ports 80 and 443.) Here is an example `rke2.yaml`:
+. In the kubeconfig file, the `server` directive is defined as localhost. Configure the server as the DNS of your control-plane load balancer, on port 6443. (The RKE2 Kubernetes API Server uses port 6443, while the Rancher server will be served via the Traefik Ingress on ports 80 and 443. Refer to https://support.scc.suse.com/s/kb/Migrating-from-Ingress-NGINX-to-Traefik-in-a-Rancher-provisioned-RKE2-Cluster?language=en_US[Migrating from Ingress NGINX to Traefik in a Rancher provisioned RKE2 Cluster] for further details.) Here is an example `rke2.yaml`:
 
 [,yml]
 ----

--- a/versions/v2.14/modules/en/pages/installation-and-upgrade/install-kubernetes/rke2-for-rancher.adoc
+++ b/versions/v2.14/modules/en/pages/installation-and-upgrade/install-kubernetes/rke2-for-rancher.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2026-03-20
+:revdate: 2026-03-30
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/kubernetes-cluster-setup/rke2-for-rancher.adoc 
 :product-path: installation-and-upgrade/install-kubernetes/rke2-for-rancher.adoc


### PR DESCRIPTION
Adding [KB article reference](https://support.scc.suse.com/s/kb/Migrating-from-Ingress-NGINX-to-Traefik-in-a-Rancher-provisioned-RKE2-Cluster?language=en_US) for content related to Rancher provisioned RKE2 clusters - ingress.

CC @manuelbuil 