### PR TITLE
Include cattle-scc-system namespace to allow  the rancher-ssc-operato…

### DIFF
--- a/versions/v2.12/modules/en/pages/security/psact.adoc
+++ b/versions/v2.12/modules/en/pages/security/psact.adoc
@@ -3,6 +3,7 @@ ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
 :revdate: 2026-01-15
+:revdate: 2026-04-14
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/psa-config-templates.adoc 
 :product-path: security/psact.adoc
@@ -131,6 +132,7 @@ When you run Rancher on a Kubernetes cluster that enforces a restrictive securit
 * `cattle-prometheus`
 * `cattle-provisioning-capi-system`
 * `cattle-resources-system`
+* `cattle-scc-system`
 * `cattle-sriov-system`
 * `cattle-system`
 * `cattle-ui-plugin-system`

--- a/versions/v2.13/modules/en/pages/security/psact.adoc
+++ b/versions/v2.13/modules/en/pages/security/psact.adoc
@@ -132,6 +132,7 @@ When you run Rancher on a Kubernetes cluster that enforces a restrictive securit
 * `cattle-prometheus`
 * `cattle-provisioning-capi-system`
 * `cattle-resources-system`
+* `cattle-scc-system`
 * `cattle-sriov-system`
 * `cattle-system`
 * `cattle-turtles-system`

--- a/versions/v2.14/modules/en/pages/security/psact.adoc
+++ b/versions/v2.14/modules/en/pages/security/psact.adoc
@@ -132,6 +132,7 @@ When you run Rancher on a Kubernetes cluster that enforces a restrictive securit
 * `cattle-prometheus`
 * `cattle-provisioning-capi-system`
 * `cattle-resources-system`
+* `cattle-scc-system`
 * `cattle-sriov-system`
 * `cattle-system`
 * `cattle-turtles-system`


### PR DESCRIPTION
The rancher-scc-operator fails to run if the namespace cattle-scc-system is not exempted
<img width="1095" height="233" alt="{A8B92A75-BE85-4E65-90AA-BDCF6451438F}" src="https://github.com/user-attachments/assets/4cb8c1fd-d7f7-4556-964e-acecc8075163" />
