### PR TITLE
Update the Rancher version example to a newer Prime version

### DIFF
--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/upgrades.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/upgrades.adoc
@@ -3,6 +3,7 @@ ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
 :revdate: 2025-08-25
+:revdate: 2026-04-17
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/upgrades.adoc 
 :product-path: installation-and-upgrade/upgrades.adoc
@@ -93,7 +94,7 @@ You can fetch the chart for the specific version you are upgrading to by adding 
 +
 [,plain]
 ----
- helm fetch rancher-prime/rancher --version=2.6.8
+ helm fetch rancher-prime/rancher --version=2.12.7
 ----
 
 === 3. Review Rancher Feature Chart Versions Before Upgrade
@@ -200,7 +201,7 @@ Alternatively, it's possible to export the current values to a file and referenc
  helm upgrade rancher rancher-prime/rancher \
    --namespace cattle-system \
    -f values.yaml \
-   --version=2.6.8
+   --version=2.12.7
 ----
 
 === 5. Verify the Upgrade


### PR DESCRIPTION
Hi team,
The Rancher version in the example is old and not Prime version. I created this PR to update the value to 2.12.7, for instance. See https://ranchermanager.docs.rancher.com/versions
<img width="444" height="96" alt="{128F2044-FFD4-4096-A452-F0B4F4E03470}" src="https://github.com/user-attachments/assets/af8a3c67-3b68-4399-9c53-d221a5e30c4c" />

<img width="469" height="132" alt="{DAA54A3A-8550-4D41-88C3-98F76B384D0F}" src="https://github.com/user-attachments/assets/be4bcfb9-46d7-4b92-b99d-9122ff800288" />
