### PR TITLE
Remove cross reference to EOL version

### DIFF
--- a/versions/v2.10/modules/en/pages/installation-and-upgrade/upgrades.adoc
+++ b/versions/v2.10/modules/en/pages/installation-and-upgrade/upgrades.adoc
@@ -211,15 +211,6 @@ Alternatively, it's possible to export the current values to a file and referenc
 
 Log into Rancher to confirm that the upgrade succeeded.
 
-[TIP]
-====
-
-Having network issues following upgrade?
-
-See xref:[Restoring Cluster Networking].
-====
-
-
 == Known Upgrade Issues
 
 A list of known issues for each Rancher version can be found in the release notes on https://github.com/rancher/rancher/releases[GitHub] and on the https://forums.rancher.com/c/announcements/12[Rancher forums.]

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/upgrades.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/upgrades.adoc
@@ -211,15 +211,6 @@ Alternatively, it's possible to export the current values to a file and referenc
 
 Log into Rancher to confirm that the upgrade succeeded.
 
-[TIP]
-====
-
-Having network issues following upgrade?
-
-See xref:[Restoring Cluster Networking].
-====
-
-
 == Known Upgrade Issues
 
 A list of known issues for each Rancher version can be found in the release notes on https://github.com/rancher/rancher/releases[GitHub] and on the https://forums.rancher.com/c/announcements/12[Rancher forums.]

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/upgrades.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/upgrades.adoc
@@ -212,15 +212,6 @@ Alternatively, it's possible to export the current values to a file and referenc
 
 Log into Rancher to confirm that the upgrade succeeded.
 
-[TIP]
-====
-
-Having network issues following upgrade?
-
-See xref:[Restoring Cluster Networking].
-====
-
-
 == Known Upgrade Issues
 
 A list of known issues for each Rancher version can be found in the release notes on https://github.com/rancher/rancher/releases[GitHub] and on the https://forums.rancher.com/c/announcements/12[Rancher forums.]

--- a/versions/v2.13/modules/en/pages/installation-and-upgrade/upgrades.adoc
+++ b/versions/v2.13/modules/en/pages/installation-and-upgrade/upgrades.adoc
@@ -219,15 +219,6 @@ include::shared:ROOT:partial$en/rancher-chart-rename.adoc[]
 
 Log into Rancher to confirm that the upgrade succeeded.
 
-[TIP]
-====
-
-Having network issues following upgrade?
-
-See xref:[Restoring Cluster Networking].
-====
-
-
 == Known Upgrade Issues
 
 A list of known issues for each Rancher version can be found in the release notes on https://github.com/rancher/rancher/releases[GitHub] and on the https://forums.rancher.com/c/announcements/12[Rancher forums.]

--- a/versions/v2.14/modules/en/pages/installation-and-upgrade/upgrades.adoc
+++ b/versions/v2.14/modules/en/pages/installation-and-upgrade/upgrades.adoc
@@ -218,15 +218,6 @@ include::shared:ROOT:partial$en/rancher-chart-rename.adoc[]
 
 Log into Rancher to confirm that the upgrade succeeded.
 
-[TIP]
-====
-
-Having network issues following upgrade?
-
-See xref:[Restoring Cluster Networking].
-====
-
-
 == Known Upgrade Issues
 
 A list of known issues for each Rancher version can be found in the release notes on https://github.com/rancher/rancher/releases[GitHub] and on the https://forums.rancher.com/c/announcements/12[Rancher forums.]

--- a/versions/v2.9/modules/en/pages/installation-and-upgrade/upgrades.adoc
+++ b/versions/v2.9/modules/en/pages/installation-and-upgrade/upgrades.adoc
@@ -195,15 +195,6 @@ Alternatively, it's possible to export the current values to a file and referenc
 
 Log into Rancher to confirm that the upgrade succeeded.
 
-[TIP]
-====
-
-Having network issues following upgrade?
-
-See xref:[Restoring Cluster Networking].
-====
-
-
 == Known Upgrade Issues
 
 A list of known issues for each Rancher version can be found in the release notes on https://github.com/rancher/rancher/releases[GitHub] and on the https://forums.rancher.com/c/announcements/12[Rancher forums.]


### PR DESCRIPTION
Fixes #950 

The cross reference [links to a page](https://github.com/rancher/rancher-docs/blame/9c5b4fa91444340c2bef5656e25255ab1ec1119f/docs/getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/upgrades.md#L246) from a version of Rancher that's EOL.