### PR TITLE
Update Ingress NGINX retirement guide 

### DIFF
--- a/versions/v2.13/modules/en/pages/cluster-admin/kubernetes-resources/load-balancer-and-ingress-controller/guide-to-ingress-retirement.adoc
+++ b/versions/v2.13/modules/en/pages/cluster-admin/kubernetes-resources/load-balancer-and-ingress-controller/guide-to-ingress-retirement.adoc
@@ -82,33 +82,21 @@ The migration process involves a four-phase strategy:
 
 When migrating a Rancher local cluster, the Rancher Ingress resource requires specific handling to prevent lockouts. Follow the specific https://support.scc.suse.com/s/kb/How-to-migrate-the-Rancher-Ingress-to-Traefik-in-an-RKE2-cluster?language=en_US[guide for migrating the Rancher Ingress to Traefik in an RKE2 cluster]. This guide builds upon the standalone migration phases but includes steps tailored to the Rancher management server.
 
-////
-// Add this section in v2.14.1. 
-
 === Downstream RKE2 Clusters (Provisioned by Rancher)
 
 For RKE2 clusters provisioned and managed by {rancher-product-name}, migration options are integrated directly into the user interface.
 
 [NOTE]
 ====
-This migration option is only possible in Rancher v2.13.5+ and v2.14.0+.
+ifeval::["{build-type}" != "community"]
+This migration option is only possible in Rancher v2.13.5+ and v2.14.
+endif::[]
+ifeval::["{build-type}" == "community"]
+This migration option is only possible in Rancher v2.14.0+.
+endif::[]
 ====
 
 The cluster configuration interface provides a Dual Mode migration option. This allows you to safely test and migrate traffic from Ingress NGINX to Traefik directly from the cluster management screen.
-////
-
-ifeval::["{build-type}" == "community"]
-=== Downstream RKE2 clusters (provisioned by Rancher)
-
-For RKE2 clusters provisioned and managed by Rancher, migration options are integrated directly into the user interface.
-
-[NOTE]
-====
-This migration option is only possible in Rancher v2.13.5+ and v2.14.0+.
-====
-
-The cluster configuration interface provides a Dual Mode migration option. This allows you to safely test and migrate traffic from Ingress NGINX to Traefik directly from the cluster management page. For more information, refer to the documentation.
-endif::[]
 
 === Rancher on Managed Kubernetes (Amazon EKS, Azure AKS, Google GKE)
 

--- a/versions/v2.13/modules/zh/pages/cluster-admin/kubernetes-resources/load-balancer-and-ingress-controller/guide-to-ingress-retirement.adoc
+++ b/versions/v2.13/modules/zh/pages/cluster-admin/kubernetes-resources/load-balancer-and-ingress-controller/guide-to-ingress-retirement.adoc
@@ -82,38 +82,21 @@ The migration process involves a four-phase strategy:
 
 When migrating a Rancher local cluster, the Rancher Ingress resource requires specific handling to prevent lockouts. Follow the specific https://support.scc.suse.com/s/kb/How-to-migrate-the-Rancher-Ingress-to-Traefik-in-an-RKE2-cluster?language=en_US[guide for migrating the Rancher Ingress to Traefik in an RKE2 cluster]. This guide builds upon the standalone migration phases but includes steps tailored to the Rancher management server.
 
-////
-// Add this section in v2.14.1. 
-
 === Downstream RKE2 Clusters (Provisioned by Rancher)
 
 For RKE2 clusters provisioned and managed by {rancher-product-name}, migration options are integrated directly into the user interface.
 
 [NOTE]
 ====
-// ifeval::["{build-type}" != "community"]
+ifeval::["{build-type}" != "community"]
 This migration option is only possible in Rancher v2.13.5+ and v2.14.
-// endif::[]
-// ifeval::["{build-type}" == "community"]
+endif::[]
+ifeval::["{build-type}" == "community"]
 This migration option is only possible in Rancher v2.14.0+.
-// endif::[]
+endif::[]
 ====
 
 The cluster configuration interface provides a Dual Mode migration option. This allows you to safely test and migrate traffic from Ingress NGINX to Traefik directly from the cluster management screen.
-////
-
-ifeval::["{build-type}" == "community"]
-=== Downstream RKE2 clusters (provisioned by Rancher)
-
-For RKE2 clusters provisioned and managed by Rancher, migration options are integrated directly into the user interface.
-
-[NOTE]
-====
-This migration option is only possible in Rancher v2.14.0+.
-====
-
-The cluster configuration interface provides a Dual Mode migration option. This allows you to safely test and migrate traffic from Ingress NGINX to Traefik directly from the cluster management page. For more information, refer to the documentation.
-endif::[]
 
 === Rancher on Managed Kubernetes (Amazon EKS, Azure AKS, Google GKE)
 

--- a/versions/v2.14/modules/en/pages/cluster-admin/kubernetes-resources/load-balancer-and-ingress-controller/guide-to-ingress-retirement.adoc
+++ b/versions/v2.14/modules/en/pages/cluster-admin/kubernetes-resources/load-balancer-and-ingress-controller/guide-to-ingress-retirement.adoc
@@ -82,33 +82,21 @@ The migration process involves a four-phase strategy:
 
 When migrating a Rancher local cluster, the Rancher Ingress resource requires specific handling to prevent lockouts. Follow the specific https://support.scc.suse.com/s/kb/How-to-migrate-the-Rancher-Ingress-to-Traefik-in-an-RKE2-cluster?language=en_US[guide for migrating the Rancher Ingress to Traefik in an RKE2 cluster]. This guide builds upon the standalone migration phases but includes steps tailored to the Rancher management server.
 
-////
-// Add this section in v2.14.1. 
-
 === Downstream RKE2 Clusters (Provisioned by Rancher)
 
 For RKE2 clusters provisioned and managed by {rancher-product-name}, migration options are integrated directly into the user interface.
 
 [NOTE]
 ====
-This migration option is only possible in Rancher v2.13.5+ and v2.14.0+.
+ifeval::["{build-type}" != "community"]
+This migration option is only possible in Rancher v2.13.5+ and v2.14.
+endif::[]
+ifeval::["{build-type}" == "community"]
+This migration option is only possible in Rancher v2.14.0+.
+endif::[]
 ====
 
 The cluster configuration interface provides a Dual Mode migration option. This allows you to safely test and migrate traffic from Ingress NGINX to Traefik directly from the cluster management screen.
-////
-
-ifeval::["{build-type}" == "community"]
-=== Downstream RKE2 clusters (provisioned by Rancher)
-
-For RKE2 clusters provisioned and managed by Rancher, migration options are integrated directly into the user interface.
-
-[NOTE]
-====
-This migration option is only possible in Rancher v2.13.5+ and v2.14.0+.
-====
-
-The cluster configuration interface provides a Dual Mode migration option. This allows you to safely test and migrate traffic from Ingress NGINX to Traefik directly from the cluster management page. For more information, refer to the documentation.
-endif::[]
 
 === Rancher on Managed Kubernetes (Amazon EKS, Azure AKS, Google GKE)
 

--- a/versions/v2.14/modules/zh/pages/cluster-admin/kubernetes-resources/load-balancer-and-ingress-controller/guide-to-ingress-retirement.adoc
+++ b/versions/v2.14/modules/zh/pages/cluster-admin/kubernetes-resources/load-balancer-and-ingress-controller/guide-to-ingress-retirement.adoc
@@ -82,38 +82,21 @@ The migration process involves a four-phase strategy:
 
 When migrating a Rancher local cluster, the Rancher Ingress resource requires specific handling to prevent lockouts. Follow the specific https://support.scc.suse.com/s/kb/How-to-migrate-the-Rancher-Ingress-to-Traefik-in-an-RKE2-cluster?language=en_US[guide for migrating the Rancher Ingress to Traefik in an RKE2 cluster]. This guide builds upon the standalone migration phases but includes steps tailored to the Rancher management server.
 
-////
-// Add this section in v2.14.1. 
-
 === Downstream RKE2 Clusters (Provisioned by Rancher)
 
 For RKE2 clusters provisioned and managed by {rancher-product-name}, migration options are integrated directly into the user interface.
 
 [NOTE]
 ====
-// ifeval::["{build-type}" != "community"]
+ifeval::["{build-type}" != "community"]
 This migration option is only possible in Rancher v2.13.5+ and v2.14.
-// endif::[]
-// ifeval::["{build-type}" == "community"]
+endif::[]
+ifeval::["{build-type}" == "community"]
 This migration option is only possible in Rancher v2.14.0+.
-// endif::[]
+endif::[]
 ====
 
 The cluster configuration interface provides a Dual Mode migration option. This allows you to safely test and migrate traffic from Ingress NGINX to Traefik directly from the cluster management screen.
-////
-
-ifeval::["{build-type}" == "community"]
-=== Downstream RKE2 clusters (provisioned by Rancher)
-
-For RKE2 clusters provisioned and managed by Rancher, migration options are integrated directly into the user interface.
-
-[NOTE]
-====
-This migration option is only possible in Rancher v2.14.0+.
-====
-
-The cluster configuration interface provides a Dual Mode migration option. This allows you to safely test and migrate traffic from Ingress NGINX to Traefik directly from the cluster management page. For more information, refer to the documentation.
-endif::[]
 
 === Rancher on Managed Kubernetes (Amazon EKS, Azure AKS, Google GKE)
 


### PR DESCRIPTION
- Update/single source "Downstream RKE2 clusters (provisioned by Rancher)" section in Ingress NGINX retirement guide 