### PR TITLE
Branch off of release branch when available

### DIFF
--- a/.github/workflows/generate-release-maintenance.yaml
+++ b/.github/workflows/generate-release-maintenance.yaml
@@ -25,31 +25,37 @@ jobs:
       contents: write
       pull-requests: write
       issues: read
-
+    env:
+      BASE_BRANCH: 'main'
+      DATE: ${{ inputs.release_date }}
+      PRIME: ${{ inputs.prime }}
+      COMMUNITY: ${{ inputs.community }}
+      TAG: ${{ inputs.release_tag }}
+      VERSION: ''
     steps:
+      - name: Determine base branch
+        run: |
+          # Extract version from tag (e.g., v2.11.10-alpha1 -> v2.11.10)
+          VERSION=${TAG%%-*}
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+          if git ls-remote https://github.com/rancher/rancher-product-docs "$VERSION" | grep -q "$VERSION"; then
+            echo "BASE_BRANCH=$VERSION" >> $GITHUB_ENV
+          fi
+
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ env.BASE_BRANCH }}
 
       - name: Generate Release Maintenance
-        run: ./scripts/release-maintenance.sh -t "${{ inputs.release_tag }}" -d "${{ inputs.release_date }}" --prime "${{ inputs.prime }}" --community "${{ inputs.community }}"
+        run: ./scripts/release-maintenance.sh -t "$TAG" -d "$DATE" --prime "$PRIME" --community "$COMMUNITY"
 
       - name: Create Pull Request
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ inputs.release_tag }}
-          DATE: ${{ inputs.release_date }}
-          PRIME: ${{ inputs.prime }}
-          COMMUNITY: ${{ inputs.community }}
         run: |
-          # Extract version from tag (e.g., v2.11.10-alpha1 -> v2.11.10)
-          VERSION=${TAG%%-*}
           BRANCH_NAME="${VERSION}-maintenance"
-
-          if git ls-remote --heads origin "$VERSION" | grep -q "$VERSION"; then
-            BASE_BRANCH="$VERSION"
-          else
-            BASE_BRANCH="main"
-          fi
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
This PR refactors the release maintenance workflow so that it checks out the corresponding release branch (if available) that matches the version inputted and uses that to branch off of to create the *-maintenance branch.

In the existing iteration, things work correctly if the correct branch (release branch) is selected for the `Use workflow from` field when triggering the workflow. However, when the `Use workflow from` field uses a branch that doesn't match the version targeted (e.g. left as the default main) then the resulting branch/PR contains unexpected commits as seen in https://github.com/rancher/rancher-product-docs/pull/991.