### PR TITLE
Sync Community PR #2262 (Docs: Migrate controlplane troubleshooting guide from RKE/Docker to RKE2/K3s/containerd)

### DIFF
--- a/versions/v2.12/modules/en/pages/troubleshooting/kubernetes-components/troubleshooting-controlplane-nodes.adoc
+++ b/versions/v2.12/modules/en/pages/troubleshooting/kubernetes-components/troubleshooting-controlplane-nodes.adoc
@@ -2,57 +2,104 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-05
+:revdate: 2026-05-12
 :page-revdate: {revdate}
 :community-path: troubleshooting/kubernetes-components/troubleshooting-controlplane-nodes.adoc 
 :product-path: troubleshooting/kubernetes-components/troubleshooting-controlplane-nodes.adoc
 
-This section applies to nodes with the `controlplane` role.
+== Prerequisites
 
-== Check if the Controlplane Containers are Running
+As RKE2 and K3s rely on `containerd` as the container runtime, `crictl` replaces Docker for container management. Before proceeding with the troubleshooting commands, configure your environment by exporting the following variables:
 
-There are three specific containers launched on nodes with the `controlplane` role:
+=== RKE2
+
+[source,console]
+----
+export PATH=$PATH:/var/lib/rancher/rke2/bin/
+export CRI_CONFIG_FILE=/var/lib/rancher/rke2/agent/etc/crictl.yaml
+----
+
+=== K3s
+
+[source,console]
+----
+export PATH=$PATH:/usr/local/bin
+export CRI_CONFIG_FILE=/var/lib/rancher/k3s/agent/etc/crictl.yaml
+----
+
+== Check if the Controlplane Components are Running
+
+*RKE2*: There are three specific containers launched on nodes with the `controlplane` role:
 
 * `kube-apiserver`
 * `kube-controller-manager`
 * `kube-scheduler`
 
-The containers should have status *Up*. The duration shown after *Up* is the time the container has been running.
+The containers should have state *Running*. You can check this using `crictl`:
 
+[source,console]
 ----
-docker ps -a -f=name='kube-apiserver|kube-controller-manager|kube-scheduler'
+crictl ps | grep -E 'kube-apiserver|kube-controller-manager|kube-scheduler'
 ----
 
 Example output:
 
+[source,console]
 ----
-CONTAINER ID        IMAGE                                COMMAND                  CREATED             STATUS              PORTS               NAMES
-26c7159abbcc        rancher/hyperkube:v1.11.5-rancher1   "/opt/rke-tools/en..."   3 hours ago         Up 3 hours                              kube-apiserver
-f3d287ca4549        rancher/hyperkube:v1.11.5-rancher1   "/opt/rke-tools/en..."   3 hours ago         Up 3 hours                              kube-scheduler
-bdf3898b8063        rancher/hyperkube:v1.11.5-rancher1   "/opt/rke-tools/en..."   3 hours ago         Up 3 hours                              kube-controller-manager
+CONTAINER           IMAGE               CREATED             STATE               NAME                            ATTEMPT             POD ID              POD                                     NAMESPACE
+deb8a96948594       138b1e685e151       11 days ago         Running             kube-controller-manager         0                   0996426295dc5       kube-controller-manager                 kube-system
+f5abb4c7846e4       138b1e685e151       11 days ago         Running             kube-scheduler                  0                   80cd9f30af0be       kube-scheduler                          kube-system
+ecd8a6991c22a       138b1e685e151       11 days ago         Running             kube-apiserver                  0                   58e042fabe78c       kube-apiserver                          kube-system
 ----
 
-== Controlplane Container Logging
+*K3s*: These components run as embedded processes within the K3s service. They do not run as separate containers, so their status is tied to the `k3s` systemd service:
+
+[source,console]
+----
+systemctl status k3s
+----
+
+== Controlplane Logging
 
 [NOTE]
 ====
-
 If you added multiple nodes with the `controlplane` role, both `kube-controller-manager` and `kube-scheduler` use a leader election process to determine the leader. Only the current leader will log the performed actions. See xref:troubleshooting/other-troubleshooting-tips/kubernetes-resources.adoc#_kubernetes_leader_election[Kubernetes leader election] how to retrieve the current leader.
 ====
 
+The logs can contain information on what the problem could be.
 
-The logging of the containers can contain information on what the problem could be.
+*RKE2*:
 
+[source,console]
 ----
-docker logs kube-apiserver
-docker logs kube-controller-manager
-docker logs kube-scheduler
+crictl logs $(crictl ps --name kube-apiserver -q)
+crictl logs $(crictl ps --name kube-controller-manager -q)
+crictl logs $(crictl ps --name kube-scheduler -q)
 ----
 
-== {rke2-product-name} Server Logging
+*K3s*:
 
-If Rancher provisions an RKE2 cluster that can't communicate with Rancher, you can run this command on a server node in the downstream cluster to get the RKE2 server logs:
+[source,console]
+----
+journalctl -u k3s | grep -i "kube-apiserver"
+journalctl -u k3s | grep -i "kube-controller-manager"
+journalctl -u k3s | grep -i "kube-scheduler"
+----
 
+== RKE2/K3s Server Logging
+
+If Rancher provisions an RKE2 or K3s cluster that can't communicate with Rancher, you can run this command on a server node in the downstream cluster to get the server logs:
+
+*RKE2*:
+
+[source,console]
 ----
 journalctl -u rke2-server -f
+----
+
+*K3s*:
+
+[source,console]
+----
+journalctl -u k3s -f
 ----

--- a/versions/v2.13/modules/en/pages/troubleshooting/kubernetes-components/troubleshooting-controlplane-nodes.adoc
+++ b/versions/v2.13/modules/en/pages/troubleshooting/kubernetes-components/troubleshooting-controlplane-nodes.adoc
@@ -2,57 +2,104 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-05
+:revdate: 2026-05-12
 :page-revdate: {revdate}
 :community-path: troubleshooting/kubernetes-components/troubleshooting-controlplane-nodes.adoc 
 :product-path: troubleshooting/kubernetes-components/troubleshooting-controlplane-nodes.adoc
 
-This section applies to nodes with the `controlplane` role.
+== Prerequisites
 
-== Check if the Controlplane Containers are Running
+As RKE2 and K3s rely on `containerd` as the container runtime, `crictl` replaces Docker for container management. Before proceeding with the troubleshooting commands, configure your environment by exporting the following variables:
 
-There are three specific containers launched on nodes with the `controlplane` role:
+=== RKE2
+
+[source,console]
+----
+export PATH=$PATH:/var/lib/rancher/rke2/bin/
+export CRI_CONFIG_FILE=/var/lib/rancher/rke2/agent/etc/crictl.yaml
+----
+
+=== K3s
+
+[source,console]
+----
+export PATH=$PATH:/usr/local/bin
+export CRI_CONFIG_FILE=/var/lib/rancher/k3s/agent/etc/crictl.yaml
+----
+
+== Check if the Controlplane Components are Running
+
+*RKE2*: There are three specific containers launched on nodes with the `controlplane` role:
 
 * `kube-apiserver`
 * `kube-controller-manager`
 * `kube-scheduler`
 
-The containers should have status *Up*. The duration shown after *Up* is the time the container has been running.
+The containers should have state *Running*. You can check this using `crictl`:
 
+[source,console]
 ----
-docker ps -a -f=name='kube-apiserver|kube-controller-manager|kube-scheduler'
+crictl ps | grep -E 'kube-apiserver|kube-controller-manager|kube-scheduler'
 ----
 
 Example output:
 
+[source,console]
 ----
-CONTAINER ID        IMAGE                                COMMAND                  CREATED             STATUS              PORTS               NAMES
-26c7159abbcc        rancher/hyperkube:v1.11.5-rancher1   "/opt/rke-tools/en..."   3 hours ago         Up 3 hours                              kube-apiserver
-f3d287ca4549        rancher/hyperkube:v1.11.5-rancher1   "/opt/rke-tools/en..."   3 hours ago         Up 3 hours                              kube-scheduler
-bdf3898b8063        rancher/hyperkube:v1.11.5-rancher1   "/opt/rke-tools/en..."   3 hours ago         Up 3 hours                              kube-controller-manager
+CONTAINER           IMAGE               CREATED             STATE               NAME                            ATTEMPT             POD ID              POD                                     NAMESPACE
+deb8a96948594       138b1e685e151       11 days ago         Running             kube-controller-manager         0                   0996426295dc5       kube-controller-manager                 kube-system
+f5abb4c7846e4       138b1e685e151       11 days ago         Running             kube-scheduler                  0                   80cd9f30af0be       kube-scheduler                          kube-system
+ecd8a6991c22a       138b1e685e151       11 days ago         Running             kube-apiserver                  0                   58e042fabe78c       kube-apiserver                          kube-system
 ----
 
-== Controlplane Container Logging
+*K3s*: These components run as embedded processes within the K3s service. They do not run as separate containers, so their status is tied to the `k3s` systemd service:
+
+[source,console]
+----
+systemctl status k3s
+----
+
+== Controlplane Logging
 
 [NOTE]
 ====
-
 If you added multiple nodes with the `controlplane` role, both `kube-controller-manager` and `kube-scheduler` use a leader election process to determine the leader. Only the current leader will log the performed actions. See xref:troubleshooting/other-troubleshooting-tips/kubernetes-resources.adoc#_kubernetes_leader_election[Kubernetes leader election] how to retrieve the current leader.
 ====
 
+The logs can contain information on what the problem could be.
 
-The logging of the containers can contain information on what the problem could be.
+*RKE2*:
 
+[source,console]
 ----
-docker logs kube-apiserver
-docker logs kube-controller-manager
-docker logs kube-scheduler
+crictl logs $(crictl ps --name kube-apiserver -q)
+crictl logs $(crictl ps --name kube-controller-manager -q)
+crictl logs $(crictl ps --name kube-scheduler -q)
 ----
 
-== {rke2-product-name} Server Logging
+*K3s*:
 
-If Rancher provisions an RKE2 cluster that can't communicate with Rancher, you can run this command on a server node in the downstream cluster to get the RKE2 server logs:
+[source,console]
+----
+journalctl -u k3s | grep -i "kube-apiserver"
+journalctl -u k3s | grep -i "kube-controller-manager"
+journalctl -u k3s | grep -i "kube-scheduler"
+----
 
+== RKE2/K3s Server Logging
+
+If Rancher provisions an RKE2 or K3s cluster that can't communicate with Rancher, you can run this command on a server node in the downstream cluster to get the server logs:
+
+*RKE2*:
+
+[source,console]
 ----
 journalctl -u rke2-server -f
+----
+
+*K3s*:
+
+[source,console]
+----
+journalctl -u k3s -f
 ----

--- a/versions/v2.14/modules/en/pages/troubleshooting/kubernetes-components/troubleshooting-controlplane-nodes.adoc
+++ b/versions/v2.14/modules/en/pages/troubleshooting/kubernetes-components/troubleshooting-controlplane-nodes.adoc
@@ -2,60 +2,104 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-05
+:revdate: 2026-05-12
 :page-revdate: {revdate}
 :community-path: troubleshooting/kubernetes-components/troubleshooting-controlplane-nodes.adoc 
 :product-path: troubleshooting/kubernetes-components/troubleshooting-controlplane-nodes.adoc
 
-This section applies to nodes with the `controlplane` role.
+== Prerequisites
 
-[#_check_if_the_controlplane_containers_are_running]
-== Check if the Controlplane Containers are Running
+As RKE2 and K3s rely on `containerd` as the container runtime, `crictl` replaces Docker for container management. Before proceeding with the troubleshooting commands, configure your environment by exporting the following variables:
 
-There are three specific containers launched on nodes with the `controlplane` role:
+=== RKE2
+
+[source,console]
+----
+export PATH=$PATH:/var/lib/rancher/rke2/bin/
+export CRI_CONFIG_FILE=/var/lib/rancher/rke2/agent/etc/crictl.yaml
+----
+
+=== K3s
+
+[source,console]
+----
+export PATH=$PATH:/usr/local/bin
+export CRI_CONFIG_FILE=/var/lib/rancher/k3s/agent/etc/crictl.yaml
+----
+
+== Check if the Controlplane Components are Running
+
+*RKE2*: There are three specific containers launched on nodes with the `controlplane` role:
 
 * `kube-apiserver`
 * `kube-controller-manager`
 * `kube-scheduler`
 
-The containers should have status *Up*. The duration shown after *Up* is the time the container has been running.
+The containers should have state *Running*. You can check this using `crictl`:
 
+[source,console]
 ----
-docker ps -a -f=name='kube-apiserver|kube-controller-manager|kube-scheduler'
+crictl ps | grep -E 'kube-apiserver|kube-controller-manager|kube-scheduler'
 ----
 
 Example output:
 
+[source,console]
 ----
-CONTAINER ID        IMAGE                                COMMAND                  CREATED             STATUS              PORTS               NAMES
-26c7159abbcc        rancher/hyperkube:v1.11.5-rancher1   "/opt/rke-tools/en..."   3 hours ago         Up 3 hours                              kube-apiserver
-f3d287ca4549        rancher/hyperkube:v1.11.5-rancher1   "/opt/rke-tools/en..."   3 hours ago         Up 3 hours                              kube-scheduler
-bdf3898b8063        rancher/hyperkube:v1.11.5-rancher1   "/opt/rke-tools/en..."   3 hours ago         Up 3 hours                              kube-controller-manager
+CONTAINER           IMAGE               CREATED             STATE               NAME                            ATTEMPT             POD ID              POD                                     NAMESPACE
+deb8a96948594       138b1e685e151       11 days ago         Running             kube-controller-manager         0                   0996426295dc5       kube-controller-manager                 kube-system
+f5abb4c7846e4       138b1e685e151       11 days ago         Running             kube-scheduler                  0                   80cd9f30af0be       kube-scheduler                          kube-system
+ecd8a6991c22a       138b1e685e151       11 days ago         Running             kube-apiserver                  0                   58e042fabe78c       kube-apiserver                          kube-system
 ----
 
-[#_controlplane_container_logging]
-== Controlplane Container Logging
+*K3s*: These components run as embedded processes within the K3s service. They do not run as separate containers, so their status is tied to the `k3s` systemd service:
+
+[source,console]
+----
+systemctl status k3s
+----
+
+== Controlplane Logging
 
 [NOTE]
 ====
-
 If you added multiple nodes with the `controlplane` role, both `kube-controller-manager` and `kube-scheduler` use a leader election process to determine the leader. Only the current leader will log the performed actions. See xref:troubleshooting/other-troubleshooting-tips/kubernetes-resources.adoc#_kubernetes_leader_election[Kubernetes leader election] how to retrieve the current leader.
 ====
 
+The logs can contain information on what the problem could be.
 
-The logging of the containers can contain information on what the problem could be.
+*RKE2*:
 
+[source,console]
 ----
-docker logs kube-apiserver
-docker logs kube-controller-manager
-docker logs kube-scheduler
+crictl logs $(crictl ps --name kube-apiserver -q)
+crictl logs $(crictl ps --name kube-controller-manager -q)
+crictl logs $(crictl ps --name kube-scheduler -q)
 ----
 
-[#__rke2_product_name_server_logging]
-== {rke2-product-name} Server Logging
+*K3s*:
 
-If Rancher provisions an RKE2 cluster that can't communicate with Rancher, you can run this command on a server node in the downstream cluster to get the RKE2 server logs:
+[source,console]
+----
+journalctl -u k3s | grep -i "kube-apiserver"
+journalctl -u k3s | grep -i "kube-controller-manager"
+journalctl -u k3s | grep -i "kube-scheduler"
+----
 
+== RKE2/K3s Server Logging
+
+If Rancher provisions an RKE2 or K3s cluster that can't communicate with Rancher, you can run this command on a server node in the downstream cluster to get the server logs:
+
+*RKE2*:
+
+[source,console]
 ----
 journalctl -u rke2-server -f
+----
+
+*K3s*:
+
+[source,console]
+----
+journalctl -u k3s -f
 ----

--- a/versions/v2.14/modules/en/pages/troubleshooting/kubernetes-components/troubleshooting-controlplane-nodes.adoc
+++ b/versions/v2.14/modules/en/pages/troubleshooting/kubernetes-components/troubleshooting-controlplane-nodes.adoc
@@ -7,10 +7,12 @@ endif::[]
 :community-path: troubleshooting/kubernetes-components/troubleshooting-controlplane-nodes.adoc 
 :product-path: troubleshooting/kubernetes-components/troubleshooting-controlplane-nodes.adoc
 
+[#_prerequisites]
 == Prerequisites
 
 As RKE2 and K3s rely on `containerd` as the container runtime, `crictl` replaces Docker for container management. Before proceeding with the troubleshooting commands, configure your environment by exporting the following variables:
 
+[#_rke2]
 === RKE2
 
 [source,console]
@@ -19,6 +21,7 @@ export PATH=$PATH:/var/lib/rancher/rke2/bin/
 export CRI_CONFIG_FILE=/var/lib/rancher/rke2/agent/etc/crictl.yaml
 ----
 
+[#_k3s]
 === K3s
 
 [source,console]
@@ -27,6 +30,7 @@ export PATH=$PATH:/usr/local/bin
 export CRI_CONFIG_FILE=/var/lib/rancher/k3s/agent/etc/crictl.yaml
 ----
 
+[#_check_if_the_controlplane_components_are_running]
 == Check if the Controlplane Components are Running
 
 *RKE2*: There are three specific containers launched on nodes with the `controlplane` role:
@@ -59,6 +63,7 @@ ecd8a6991c22a       138b1e685e151       11 days ago         Running             
 systemctl status k3s
 ----
 
+[#_controlplane_logging]
 == Controlplane Logging
 
 [NOTE]
@@ -86,6 +91,7 @@ journalctl -u k3s | grep -i "kube-controller-manager"
 journalctl -u k3s | grep -i "kube-scheduler"
 ----
 
+[#_rke2k3s_server_logging]
 == RKE2/K3s Server Logging
 
 If Rancher provisions an RKE2 or K3s cluster that can't communicate with Rancher, you can run this command on a server node in the downstream cluster to get the server logs:


### PR DESCRIPTION
Updating the troubleshooting-controlplane-node.adoc page tied to https://github.com/rancher/rancher-docs/pull/2262

The publish-image.adoc page was updated already in this PR https://github.com/rancher/rancher-product-docs/pull/1024