### PR TITLE
Use GH_TOKEN for git operations & trigger CI workflows

### DIFF
--- a/.github/workflows/draft-release-notes.yml
+++ b/.github/workflows/draft-release-notes.yml
@@ -85,6 +85,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+          # Use PR_TOKEN for initial push and PR creation
           git remote set-url origin "https://x-access-token:${PR_TOKEN}@github.com/${{ github.repository }}.git"
 
           git checkout -b "$BRANCH_NAME"
@@ -109,3 +110,9 @@ jobs:
               --head "$BRANCH_NAME" \
               --milestone "$VERSION"
           fi
+
+          # Trigger CI workflows by pushing an empty commit using the Vault token
+          # This triggers the 'synchronize' event which bypasses the GITHUB_TOKEN limitation
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          git commit --allow-empty -m "Trigger CI"
+          git push origin "$BRANCH_NAME"

--- a/.github/workflows/draft-release-notes.yml
+++ b/.github/workflows/draft-release-notes.yml
@@ -85,8 +85,8 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          # Use PR_TOKEN for initial push and PR creation
-          git remote set-url origin "https://x-access-token:${PR_TOKEN}@github.com/${{ github.repository }}.git"
+          # Use GH_TOKEN for git operations so commits are verified
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
 
           git checkout -b "$BRANCH_NAME"
           git add .
@@ -111,8 +111,7 @@ jobs:
               --milestone "$VERSION"
           fi
 
-          # Trigger CI workflows by pushing an empty commit using the Vault token
-          # This triggers the 'synchronize' event which bypasses the GITHUB_TOKEN limitation
-          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          # Trigger CI workflows by pushing an empty commit
+          # This triggers the 'synchronize' event which bypasses the PR_TOKEN limitation on the 'opened' event
           git commit --allow-empty -m "Trigger CI"
           git push origin "$BRANCH_NAME"

--- a/.github/workflows/generate-release-maintenance.yaml
+++ b/.github/workflows/generate-release-maintenance.yaml
@@ -68,6 +68,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+          # Use PR_TOKEN for initial push and PR creation
           git remote set-url origin "https://x-access-token:${PR_TOKEN}@github.com/${{ github.repository }}.git"
 
           git checkout -b "$BRANCH_NAME"
@@ -102,3 +103,9 @@ jobs:
               --milestone "$VERSION")
             PR_NUMBER=${PR_URL##*/}
           fi
+
+          # Trigger CI workflows by pushing an empty commit using the Vault token
+          # This triggers the 'synchronize' event which bypasses the GITHUB_TOKEN limitation
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          git commit --allow-empty -m "Trigger CI"
+          git push origin "$BRANCH_NAME"

--- a/.github/workflows/generate-release-maintenance.yaml
+++ b/.github/workflows/generate-release-maintenance.yaml
@@ -68,8 +68,8 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          # Use PR_TOKEN for initial push and PR creation
-          git remote set-url origin "https://x-access-token:${PR_TOKEN}@github.com/${{ github.repository }}.git"
+          # Use GH_TOKEN for git operations so commits are verified
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
 
           git checkout -b "$BRANCH_NAME"
           git add .
@@ -104,8 +104,7 @@ jobs:
             PR_NUMBER=${PR_URL##*/}
           fi
 
-          # Trigger CI workflows by pushing an empty commit using the Vault token
-          # This triggers the 'synchronize' event which bypasses the GITHUB_TOKEN limitation
-          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          # Trigger CI workflows by pushing an empty commit
+          # This triggers the 'synchronize' event which bypasses the PR_TOKEN limitation on the 'opened' event
           git commit --allow-empty -m "Trigger CI"
           git push origin "$BRANCH_NAME"


### PR DESCRIPTION
- [Trigger CI workflows by pushing an empty commit](https://github.com/rancher/rancher-product-docs/commit/79a30ef99dd003ae31d95b272a15009d7acbec23)
- [Use GH_TOKEN for git operations so commits are verified](https://github.com/rancher/rancher-product-docs/commit/b9d9038d8cbcd98a1d869631d1ca3ea971b55653)