### PR TITLE
CAAPF note - v2.14.1 release note

### DIFF
--- a/versions/v2.14/modules/en/pages/release-notes/v2.14.1.adoc
+++ b/versions/v2.14/modules/en/pages/release-notes/v2.14.1.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2026-05-11
+:revdate: 2026-05-18
 :page-revdate: {revdate}
 :release-version: v2.14.1
 :rn-component-version: v2.14
@@ -216,7 +216,14 @@ endif::[]
 However, if you had previously disabled Rancher Turtles, you will need to manually re-enable it. Cluster provisioning will fail and a warning will display during Rancher startup if Turtles is disabled.
 +
 For more information on installing and using Rancher Turtles, refer to the {rn-capi-overview}[Cluster API integration documentation]. See https://github.com/rancher/rancher/issues/53291[#53291].
-* *Deprecation:* Starting from Rancher v2.14.1, Cluster API Addon Provider Fleet (CAAPF) is being disabled by default and will be removed in a future Rancher release per our https://www.suse.com/support/rancher-prime/#Rancher-Prime-Deprecation-Policy[deprecation policy]. While standard Fleet integration is still available through Rancher, additional steps are needed by users that upgrade to Rancher v2.14.1 and are running CAPI clusters that are provisioned using CAAPF. To enable the feature gate, you can set the `features.use-caapf.enabled` to `true` in the CAPI chart values, refer to {rn-capi-feature}[Features] and the {rn-caapf}[Cluster API Addon Provider Fleet] documentation for more information. See https://github.com/rancher/turtles/pull/2176[#2176].
+* *Deprecation:* Starting from Rancher v2.14.1, Cluster API Addon Provider Fleet (CAAPF) is being disabled by default and will be removed in a future Rancher release per our https://www.suse.com/support/rancher-prime/#Rancher-Prime-Deprecation-Policy[deprecation policy]. While standard Fleet integration is still available through Rancher, additional steps are needed by users that upgrade to Rancher v2.14.1 and are running CAPI clusters that are provisioned using CAAPF. To enable the feature gate, you can set the `features.use-caapf.enabled` to `true` in the CAPI chart values, refer to {rn-capi-feature}[Features] and the {rn-caapf}[Cluster API Addon Provider Fleet] documentation for more information. 
++
+[IMPORTANT]
+====
+The `features.use-caapf.enabled: true` flag must be set *before* upgrading to Rancher v2.14.1. If the upgrade completes with the flag at its default (`false`), the {turtles-product-name} controller will reconcile imported clusters without the `provisioning.cattle.io/externally-managed` annotation, handing Fleet agent management to Rancher. Enabling the flag afterward causes {turtles-product-name} to re-add the annotation and hand management back to CAAPF, resulting in the Fleet agent being re-installed on workload clusters.
+====
++
+See https://github.com/rancher/turtles/pull/2176[#2176].
 
 
 [#_major_bug_fixes_3]
@@ -318,7 +325,14 @@ ifeval::["{build-type}" == "community"]
 [#_behavior_changes_7]
 === Behavior Changes
 
-* *Deprecation:* Starting from Rancher v2.14.1, Cluster API Addon Provider Fleet (CAAPF) is being disabled by default and will be removed in a future Rancher release per our https://www.suse.com/support/rancher-prime/#Rancher-Prime-Deprecation-Policy[deprecation policy]. While standard Fleet integration is still available through Rancher, additional steps are needed by users that upgrade to Rancher v2.14.1 and are running CAPI clusters that are provisioned using CAAPF. To enable the feature gate, you can set the `features.use-caapf.enabled` to `true` in the CAPI chart values, refer to {rn-capi-feature}[Features] and the {rn-caapf}[Cluster API Addon Provider Fleet] documentation for more information. See https://github.com/rancher/turtles/pull/2176[#2176].
+* *Deprecation:* Starting from Rancher v2.14.1, Cluster API Addon Provider Fleet (CAAPF) is being disabled by default and will be removed in a future Rancher release per our https://www.suse.com/support/rancher-prime/#Rancher-Prime-Deprecation-Policy[deprecation policy]. While standard Fleet integration is still available through Rancher, additional steps are needed by users that upgrade to Rancher v2.14.1 and are running CAPI clusters that are provisioned using CAAPF. To enable the feature gate, you can set the `features.use-caapf.enabled` to `true` in the CAPI chart values, refer to {rn-capi-feature}[Features] and the {rn-caapf}[Cluster API Addon Provider Fleet] documentation for more information. 
++
+[IMPORTANT]
+====
+The `features.use-caapf.enabled: true` flag must be set *before* upgrading to Rancher v2.14.1. If the upgrade completes with the flag at its default (`false`), the {turtles-product-name} controller will reconcile imported clusters without the `provisioning.cattle.io/externally-managed` annotation, handing Fleet agent management to Rancher. Enabling the flag afterward causes {turtles-product-name} to re-add the annotation and hand management back to CAAPF, resulting in the Fleet agent being re-installed on workload clusters.
+====
++
+See https://github.com/rancher/turtles/pull/2176[#2176].
 
 [#_k3s_and_rke2_provisioning_1]
 == K3s and RKE2 Provisioning

--- a/versions/v2.14/modules/zh/pages/release-notes/v2.14.1.adoc
+++ b/versions/v2.14/modules/zh/pages/release-notes/v2.14.1.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2026-05-11
+:revdate: 2026-05-18
 :page-revdate: {revdate}
 :release-version: v2.14.1
 :rn-component-version: v2.14
@@ -194,7 +194,14 @@ endif::[]
 However, if you had previously disabled Rancher Turtles, you will need to manually re-enable it. Cluster provisioning will fail and a warning will display during Rancher startup if Turtles is disabled.
 +
 For more information on installing and using Rancher Turtles, refer to the {rn-capi-overview}[Cluster API integration documentation]. See https://github.com/rancher/rancher/issues/53291[#53291].
-* *Deprecation:* Starting from Rancher v2.14.1, Cluster API Addon Provider Fleet (CAAPF) is being disabled by default and will be removed in a future Rancher release per our https://www.suse.com/support/rancher-prime/#Rancher-Prime-Deprecation-Policy[deprecation policy]. While standard Fleet integration is still available through Rancher, additional steps are needed by users that upgrade to Rancher v2.14.1 and are running CAPI clusters that are provisioned using CAAPF. To enable the feature gate, you can set the `features.use-caapf.enabled` to `true` in the CAPI chart values, refer to {rn-capi-feature}[Features] and the {rn-caapf}[Cluster API Addon Provider Fleet] documentation for more information. See https://github.com/rancher/turtles/pull/2176[#2176].
+* *Deprecation:* Starting from Rancher v2.14.1, Cluster API Addon Provider Fleet (CAAPF) is being disabled by default and will be removed in a future Rancher release per our https://www.suse.com/support/rancher-prime/#Rancher-Prime-Deprecation-Policy[deprecation policy]. While standard Fleet integration is still available through Rancher, additional steps are needed by users that upgrade to Rancher v2.14.1 and are running CAPI clusters that are provisioned using CAAPF. To enable the feature gate, you can set the `features.use-caapf.enabled` to `true` in the CAPI chart values, refer to {rn-capi-feature}[Features] and the {rn-caapf}[Cluster API Addon Provider Fleet] documentation for more information. 
++
+[IMPORTANT]
+====
+The `features.use-caapf.enabled: true` flag must be set *before* upgrading to Rancher v2.14.1. If the upgrade completes with the flag at its default (`false`), the {turtles-product-name} controller will reconcile imported clusters without the `provisioning.cattle.io/externally-managed` annotation, handing Fleet agent management to Rancher. Enabling the flag afterward causes {turtles-product-name} to re-add the annotation and hand management back to CAAPF, resulting in the Fleet agent being re-installed on workload clusters.
+====
++
+See https://github.com/rancher/turtles/pull/2176[#2176].
 
 
 === Major Bug Fixes
@@ -279,7 +286,14 @@ ifeval::["{build-type}" == "community"]
 
 === Behavior Changes
 
-* *Deprecation:* Starting from Rancher v2.14.1, Cluster API Addon Provider Fleet (CAAPF) is being disabled by default and will be removed in a future Rancher release per our https://www.suse.com/support/rancher-prime/#Rancher-Prime-Deprecation-Policy[deprecation policy]. While standard Fleet integration is still available through Rancher, additional steps are needed by users that upgrade to Rancher v2.14.1 and are running CAPI clusters that are provisioned using CAAPF. To enable the feature gate, you can set the `features.use-caapf.enabled` to `true` in the CAPI chart values, refer to {rn-capi-feature}[Features] and the {rn-caapf}[Cluster API Addon Provider Fleet] documentation for more information. See https://github.com/rancher/turtles/pull/2176[#2176].
+* *Deprecation:* Starting from Rancher v2.14.1, Cluster API Addon Provider Fleet (CAAPF) is being disabled by default and will be removed in a future Rancher release per our https://www.suse.com/support/rancher-prime/#Rancher-Prime-Deprecation-Policy[deprecation policy]. While standard Fleet integration is still available through Rancher, additional steps are needed by users that upgrade to Rancher v2.14.1 and are running CAPI clusters that are provisioned using CAAPF. To enable the feature gate, you can set the `features.use-caapf.enabled` to `true` in the CAPI chart values, refer to {rn-capi-feature}[Features] and the {rn-caapf}[Cluster API Addon Provider Fleet] documentation for more information. 
++
+[IMPORTANT]
+====
+The `features.use-caapf.enabled: true` flag must be set *before* upgrading to Rancher v2.14.1. If the upgrade completes with the flag at its default (`false`), the {turtles-product-name} controller will reconcile imported clusters without the `provisioning.cattle.io/externally-managed` annotation, handing Fleet agent management to Rancher. Enabling the flag afterward causes {turtles-product-name} to re-add the annotation and hand management back to CAAPF, resulting in the Fleet agent being re-installed on workload clusters.
+====
++
+See https://github.com/rancher/turtles/pull/2176[#2176].
 
 == K3s and RKE2 Provisioning
 


### PR DESCRIPTION
Adding CAAPF note to v2.14.1 release note.

Based on https://github.com/rancher/turtles-product-docs/pull/210

Updating the community notes post merge.