### PR TITLE
v2.10.12 - Release Maintenance

### DIFF
--- a/versions/v2.10/antora.yml
+++ b/versions/v2.10/antora.yml
@@ -8,7 +8,7 @@ nav:
 asciidoc:
   attributes:
     rancher-helm-repo: "rancher-prime"
-    current-patch-version: "2.10.11"
+    current-patch-version: "2.10.12"
     # docs links
     harvester-docs-version: v1.5
     longhorn-docs-version: 1.8

--- a/versions/v2.10/modules/en/pages/faq/deprecated-features.adoc
+++ b/versions/v2.10/modules/en/pages/faq/deprecated-features.adoc
@@ -1,6 +1,6 @@
 = Deprecated Features in {rancher-product-name}
 :page-languages: [en, zh]
-:revdate: 2026-01-29
+:revdate: 2026-05-27
 :page-revdate: {revdate}
 :community-path: faq/deprecated-features.adoc 
 :product-path: faq/deprecated-features.adoc
@@ -15,6 +15,10 @@ Rancher will publish deprecated features as part of the https://github.com/ranch
 
 |===
 | Patch Version | Release Date
+
+// DO NOT EDIT THIS LINE, REQUIRED BY RELEASE SCRIPT.
+| https://github.com/rancher/rancher/releases/tag/v2.10.12[2.10.12]
+| May 27, 2026
 
 | https://github.com/rancher/rancher/releases/tag/v2.10.11[2.10.11]
 | January 29, 2026

--- a/versions/v2.10/modules/en/pages/installation-and-upgrade/hosted-kubernetes/cloud-marketplace/aws/install-adapter.adoc
+++ b/versions/v2.10/modules/en/pages/installation-and-upgrade/hosted-kubernetes/cloud-marketplace/aws/install-adapter.adoc
@@ -1,6 +1,6 @@
 = Installing the Adapter
 :page-languages: [en, zh]
-:revdate: 2026-01-27
+:revdate: 2026-05-27
 :page-revdate: {revdate}
 :community-path: integrations-in-rancher/cloud-marketplace/aws-cloud-marketplace/install-adapter.adoc 
 :product-path: installation-and-upgrade/hosted-kubernetes/cloud-marketplace/aws/install-adapter.adoc
@@ -27,6 +27,10 @@ In order to deploy and run the adapter successfully, you need to ensure its vers
 
 |===
 | Rancher Version | Adapter Version
+
+// DO NOT EDIT THIS LINE, REQUIRED BY RELEASE SCRIPT.
+| v2.10.12
+| v105.0.0+up5.0.1
 
 | v2.10.11
 | v105.0.0+up5.0.1

--- a/versions/v2.10/modules/en/pages/release-notes.adoc
+++ b/versions/v2.10/modules/en/pages/release-notes.adoc
@@ -1,6 +1,6 @@
 = Release Notes
 :page-languages: [en, zh]
-:revdate: 2026-02-02
+:revdate: 2026-05-27
 :page-revdate: {revdate}
 
 == Current Version
@@ -8,17 +8,27 @@
 |===
 | Version | Release Notes | Support Matrix | Prime | Community
 
-| v2.10.11
-| xref:release-notes/v2.10.11.adoc[View]
+// DO NOT EDIT THIS LINE, REQUIRED BY RELEASE SCRIPT. CURRENT VERSION.
+| v2.10.12
+| xref:release-notes/v2.10.12.adoc[View]
 | N/A
 | &#10003;
 | N/A
+// DO NOT EDIT THIS LINE, REQUIRED BY RELEASE SCRIPT. CURRENT VERSION END.
+
 |===
 
 == Past Versions
 
 |===
 | Version | Release Notes | Support Matrix | Prime | Community
+
+// DO NOT EDIT THIS LINE, REQUIRED BY RELEASE SCRIPT. PAST VERSIONS.
+| v2.10.11
+| https://github.com/rancher/rancher/releases/tag/v2.10.11[View]
+| https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/rancher-v2-10-11/[View]
+| &#10003;
+| N/A
 
 | v2.10.10
 | https://github.com/rancher/rancher/releases/tag/v2.10.10[View]

--- a/versions/v2.10/modules/en/pages/security/rancher-webhook/rancher-webhook.adoc
+++ b/versions/v2.10/modules/en/pages/security/rancher-webhook/rancher-webhook.adoc
@@ -1,6 +1,6 @@
 = {rancher-product-name} Webhook
 :page-languages: [en, zh]
-:revdate: 2026-01-27
+:revdate: 2026-05-27
 :page-revdate: {revdate}
 :community-path: reference-guides/rancher-webhook.adoc 
 :product-path: security/rancher-webhook/rancher-webhook.adoc
@@ -25,6 +25,12 @@ NOTE: Rancher manages deployment and upgrade of the webhook. Under most circumst
 
 |===
 | Rancher Version | Webhook Version | Availability in Prime | Availability in Community
+
+// DO NOT EDIT THIS LINE, REQUIRED BY RELEASE SCRIPT.
+| v2.10.12
+| v0.6.12
+| &#10003;
+| &cross;
 
 | v2.10.11
 | v0.6.12

--- a/versions/v2.10/modules/zh/pages/faq/deprecated-features.adoc
+++ b/versions/v2.10/modules/zh/pages/faq/deprecated-features.adoc
@@ -1,6 +1,6 @@
 = {rancher-product-name} 中已弃用的功能
 :page-languages: [en, zh]
-:revdate: 2026-01-29
+:revdate: 2026-05-27
 :page-revdate: {revdate}
 
 == Rancher 的弃用策略是什么？
@@ -13,6 +13,10 @@ Rancher 将在 GitHub 上发布的 Rancher 的link:https://github.com/rancher/ra
 
 |===
 | Patch 版本 | 发布时间
+
+// DO NOT EDIT THIS LINE, REQUIRED BY RELEASE SCRIPT.
+| https://github.com/rancher/rancher/releases/tag/v2.10.12[2.10.12]
+| 2026 年 5 月 27 日
 
 | https://github.com/rancher/rancher/releases/tag/v2.10.11[2.10.11]
 | 2026 年 01 月 29 日

--- a/versions/v2.10/modules/zh/pages/installation-and-upgrade/hosted-kubernetes/cloud-marketplace/aws/install-adapter.adoc
+++ b/versions/v2.10/modules/zh/pages/installation-and-upgrade/hosted-kubernetes/cloud-marketplace/aws/install-adapter.adoc
@@ -1,6 +1,6 @@
 = 安装 Adapter
 :page-languages: [en, zh]
-:revdate: 2026-01-27
+:revdate: 2026-05-27
 :page-revdate: {revdate}
 
 ____
@@ -19,6 +19,10 @@ ____
 
 |===
 | Rancher 版本 | Adapter 版本
+
+// DO NOT EDIT THIS LINE, REQUIRED BY RELEASE SCRIPT.
+| v2.10.12
+| v105.0.0+up5.0.1
 
 | v2.10.11
 | v105.0.0+up5.0.1

--- a/versions/v2.10/modules/zh/pages/release-notes.adoc
+++ b/versions/v2.10/modules/zh/pages/release-notes.adoc
@@ -1,6 +1,6 @@
 = 发版说明
 :page-languages: [en, zh]
-:revdate: 2026-02-02
+:revdate: 2026-05-27
 :page-revdate: {revdate}
 
 == 当前版本
@@ -8,17 +8,27 @@
 |===
 | 版本 | 发版说明 | 支持矩阵 | Prime | Community
 
-| v2.10.11
-| xref:release-notes/v2.10.11.adoc[View]
+// DO NOT EDIT THIS LINE, REQUIRED BY RELEASE SCRIPT. CURRENT VERSION.
+| v2.10.12
+| xref:release-notes/v2.10.12.adoc[View]
 | N/A
 | &#10003;
 | N/A
+// DO NOT EDIT THIS LINE, REQUIRED BY RELEASE SCRIPT. CURRENT VERSION END.
+
 |===
 
 == 旧版本
 
 |===
 | 版本 | 发版说明 | 支持矩阵 | Prime | Community
+
+// DO NOT EDIT THIS LINE, REQUIRED BY RELEASE SCRIPT. PAST VERSIONS.
+| v2.10.11
+| https://github.com/rancher/rancher/releases/tag/v2.10.11[View]
+| https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/rancher-v2-10-11/[View]
+| &#10003;
+| N/A
 
 | v2.10.10
 | https://github.com/rancher/rancher/releases/tag/v2.10.10[View]

--- a/versions/v2.10/modules/zh/pages/security/rancher-webhook/rancher-webhook.adoc
+++ b/versions/v2.10/modules/zh/pages/security/rancher-webhook/rancher-webhook.adoc
@@ -1,6 +1,6 @@
 = {rancher-product-name} Webhook
 :page-languages: [en, zh]
-:revdate: 2026-01-27
+:revdate: 2026-05-27
 :page-revdate: {revdate}
 
 Rancher-Webhook 是 Rancher 的重要组件，它与 Kubernetes 结合使用，用于增强安全性并为 Rancher 管理的集群启用关键功能。
@@ -17,6 +17,12 @@ Rancher 将 Rancher-Webhook 作为单独的 deployment 和服务部署在 local 
 
 |===
 | Rancher Version | Webhook Version | Availability in Prime | Availability in Community
+
+// DO NOT EDIT THIS LINE, REQUIRED BY RELEASE SCRIPT.
+| v2.10.12
+| v0.6.12
+| &#10003;
+| &cross;
 
 | v2.10.11
 | v0.6.12


### PR DESCRIPTION
Based on https://github.com/rancher/rancher/blob/v2.10.12-alpha1/build.yaml

Also fixes missing release task attributes in the version which I believe led to the CI failure [here](https://github.com/rancher/rancher-product-docs/actions/runs/26240993348/job/77226980965).