### PR TITLE
[v2.14.2] Logging - inotify troubleshooting

### DIFF
--- a/versions/v2.10/modules/en/pages/observability/logging/logging.adoc
+++ b/versions/v2.10/modules/en/pages/observability/logging/logging.adoc
@@ -1,6 +1,6 @@
 = {rancher-product-name} Integration with Logging Services
 :page-languages: [en, zh]
-:revdate: 2025-07-07
+:revdate: 2026-05-21
 :page-revdate: {revdate}
 :community-path: integrations-in-rancher/logging/index.adoc 
 :product-path: observability/logging/logging.adoc
@@ -125,6 +125,20 @@ For information on enabling the logging application for SELinux-enabled nodes, s
 By default, Rancher collects logs for control plane components and node components for all cluster types. In some cases additional logs can be collected. For details, see xref:./logging-helm-chart-options.adoc#_additional_logging_sources[this section.]
 
 == Troubleshooting
+
+=== Resource Exhaustion of `inotify` Watchers and File Descriptors
+
+When enabling the *Logging* app on Linux systems that heavily monitor the filesystem, you may encounter `Too many open files` or `CrashLoopBackOff` failures related to applications that leverage `inotify` to watch for file changes.
+
+This happens because the Linux kernel caps the number of files a user can open and the number of directory paths a subsystem can watch simultaneously. To resolve this, you must explicitly increase your `inotify` system limits.
+
+Below are example commands an admin user can run to increase system limits for `inotify` user instances and watches:
+
+[source,shell]
+----
+sysctl -w fs.inotify.max_user_instances=8192
+sysctl -w fs.inotify.max_user_watches=524288
+----
 
 === The Logging Buffer Overloads Pods
 

--- a/versions/v2.11/modules/en/pages/observability/logging/logging.adoc
+++ b/versions/v2.11/modules/en/pages/observability/logging/logging.adoc
@@ -1,6 +1,6 @@
 = {rancher-product-name} Integration with Logging Services
 :page-languages: [en, zh]
-:revdate: 2025-07-07
+:revdate: 2026-05-21
 :page-revdate: {revdate}
 :community-path: integrations-in-rancher/logging/index.adoc 
 :product-path: observability/logging/logging.adoc
@@ -125,6 +125,20 @@ For information on enabling the logging application for SELinux-enabled nodes, s
 By default, Rancher collects logs for control plane components and node components for all cluster types. In some cases additional logs can be collected. For details, see xref:./logging-helm-chart-options.adoc#_additional_logging_sources[this section.]
 
 == Troubleshooting
+
+=== Resource Exhaustion of `inotify` Watchers and File Descriptors
+
+When enabling the *Logging* app on Linux systems that heavily monitor the filesystem, you may encounter `Too many open files` or `CrashLoopBackOff` failures related to applications that leverage `inotify` to watch for file changes.
+
+This happens because the Linux kernel caps the number of files a user can open and the number of directory paths a subsystem can watch simultaneously. To resolve this, you must explicitly increase your `inotify` system limits.
+
+Below are example commands an admin user can run to increase system limits for `inotify` user instances and watches:
+
+[source,shell]
+----
+sysctl -w fs.inotify.max_user_instances=8192
+sysctl -w fs.inotify.max_user_watches=524288
+----
 
 === The Logging Buffer Overloads Pods
 

--- a/versions/v2.12/modules/en/pages/observability/logging/logging.adoc
+++ b/versions/v2.12/modules/en/pages/observability/logging/logging.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-05
+:revdate: 2026-05-21
 :page-revdate: {revdate}
 :community-path: integrations-in-rancher/logging/index.adoc 
 :product-path: observability/logging/logging.adoc
@@ -127,6 +127,20 @@ For information on enabling the logging application for SELinux-enabled nodes, s
 By default, Rancher collects logs for control plane components and node components for all cluster types. In some cases additional logs can be collected. For details, see xref:./logging-helm-chart-options.adoc#_additional_logging_sources[this section.]
 
 == Troubleshooting
+
+=== Resource Exhaustion of `inotify` Watchers and File Descriptors
+
+When enabling the *Logging* app on Linux systems that heavily monitor the filesystem, you may encounter `Too many open files` or `CrashLoopBackOff` failures related to applications that leverage `inotify` to watch for file changes.
+
+This happens because the Linux kernel caps the number of files a user can open and the number of directory paths a subsystem can watch simultaneously. To resolve this, you must explicitly increase your `inotify` system limits.
+
+Below are example commands an admin user can run to increase system limits for `inotify` user instances and watches:
+
+[source,shell]
+----
+sysctl -w fs.inotify.max_user_instances=8192
+sysctl -w fs.inotify.max_user_watches=524288
+----
 
 === The Logging Buffer Overloads Pods
 

--- a/versions/v2.13/modules/en/pages/observability/logging/logging.adoc
+++ b/versions/v2.13/modules/en/pages/observability/logging/logging.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-05
+:revdate: 2026-05-21
 :page-revdate: {revdate}
 :community-path: integrations-in-rancher/logging/index.adoc 
 :product-path: observability/logging/logging.adoc
@@ -127,6 +127,20 @@ For information on enabling the logging application for SELinux-enabled nodes, s
 By default, Rancher collects logs for control plane components and node components for all cluster types. In some cases additional logs can be collected. For details, see xref:./logging-helm-chart-options.adoc#_additional_logging_sources[this section.]
 
 == Troubleshooting
+
+=== Resource Exhaustion of `inotify` Watchers and File Descriptors
+
+When enabling the *Logging* app on Linux systems that heavily monitor the filesystem, you may encounter `Too many open files` or `CrashLoopBackOff` failures related to applications that leverage `inotify` to watch for file changes.
+
+This happens because the Linux kernel caps the number of files a user can open and the number of directory paths a subsystem can watch simultaneously. To resolve this, you must explicitly increase your `inotify` system limits.
+
+Below are example commands an admin user can run to increase system limits for `inotify` user instances and watches:
+
+[source,shell]
+----
+sysctl -w fs.inotify.max_user_instances=8192
+sysctl -w fs.inotify.max_user_watches=524288
+----
 
 === The Logging Buffer Overloads Pods
 

--- a/versions/v2.14/modules/en/pages/observability/logging/logging.adoc
+++ b/versions/v2.14/modules/en/pages/observability/logging/logging.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-05
+:revdate: 2026-05-21
 :page-revdate: {revdate}
 :community-path: integrations-in-rancher/logging/index.adoc 
 :product-path: observability/logging/logging.adoc
@@ -142,6 +142,21 @@ By default, Rancher collects logs for control plane components and node componen
 
 [#_troubleshooting]
 == Troubleshooting
+
+[#_resource_exhaustion_of_inotify_watchers_and_file_descriptors]
+=== Resource Exhaustion of `inotify` Watchers and File Descriptors
+
+When enabling the *Logging* app on Linux systems that heavily monitor the filesystem, you may encounter `Too many open files` or `CrashLoopBackOff` failures related to applications that leverage `inotify` to watch for file changes.
+
+This happens because the Linux kernel caps the number of files a user can open and the number of directory paths a subsystem can watch simultaneously. To resolve this, you must explicitly increase your `inotify` system limits.
+
+Below are example commands an admin user can run to increase system limits for `inotify` user instances and watches:
+
+[source,shell]
+----
+sysctl -w fs.inotify.max_user_instances=8192
+sysctl -w fs.inotify.max_user_watches=524288
+----
 
 [#_the_logging_buffer_overloads_pods]
 === The Logging Buffer Overloads Pods


### PR DESCRIPTION
Adding troubleshooting information to Logging page - `inotify` system limits update.

[Reference issue](https://github.com/rancher/rancher/issues/54216#issuecomment-4409722493)

Fixes #1060 