### PR TITLE
Run test-deploy on generated branches, use a new token to also create PRs

### DIFF
--- a/.github/workflows/draft-release-notes.yml
+++ b/.github/workflows/draft-release-notes.yml
@@ -26,12 +26,11 @@ jobs:
         uses: rancher-eio/read-vault-secrets@7282bf97898cd1c16c89f837e0bb442e6d384c89 # main
         with:
           secrets: |
-            github/token/rancher--rancher-product-docs--contents--write token | GH_TOKEN
+            github/token/rancher--rancher-product-docs--pull_requests--write token | GH_TOKEN
 
       - name: Create Pull Request
         env:
           GH_TOKEN: ${{ env.GH_TOKEN }}
-          PR_TOKEN: ${{ github.token }}
           VERSION: ${{ inputs.version }}
           PR_BODY_TEMPLATE: |
             - [ ] Remove the old info, issues listed as Bug Fixes and Features, move previous 'Known Issues' and 'Behavior Changes' to 'Long-standing Known Issues' and 'Previous Rancher Behavior Changes' section.
@@ -94,16 +93,16 @@ jobs:
 
           git push -f origin "$BRANCH_NAME"
 
-          PR_NUMBER=$(GH_TOKEN="$PR_TOKEN" gh pr list --head "$BRANCH_NAME" --base "$BASE_BRANCH" --json number --jq '.[0].number')
+          PR_NUMBER=$(gh pr list --head "$BRANCH_NAME" --base "$BASE_BRANCH" --json number --jq '.[0].number')
           PR_BODY="${PR_BODY_TEMPLATE//__VERSION__/$VERSION}"
           PR_BODY="${PR_BODY//__MINOR_VERSION__/$MINOR_VERSION}"
 
           if [[ -n "$PR_NUMBER" && "$PR_NUMBER" != "null" ]]; then
-            GH_TOKEN="$PR_TOKEN" gh pr edit "$PR_NUMBER" \
+            gh pr edit "$PR_NUMBER" \
               --title "Add Release Notes for $VERSION" \
               --body "$PR_BODY"
           else
-            GH_TOKEN="$PR_TOKEN" gh pr create \
+            gh pr create \
               --title "Add Release Notes for $VERSION" \
               --body "$PR_BODY" \
               --base "$BASE_BRANCH" \
@@ -111,7 +110,6 @@ jobs:
               --milestone "$VERSION"
           fi
 
-          # Trigger CI workflows by pushing an empty commit
-          # This triggers the 'synchronize' event which bypasses the PR_TOKEN limitation on the 'opened' event
+          # Attempt to trigger CI workflows by pushing an empty commit, also allows for squashing commits to get them verified
           git commit --allow-empty -m "Trigger CI"
           git push origin "$BRANCH_NAME"

--- a/.github/workflows/generate-release-maintenance.yaml
+++ b/.github/workflows/generate-release-maintenance.yaml
@@ -56,12 +56,11 @@ jobs:
         uses: rancher-eio/read-vault-secrets@7282bf97898cd1c16c89f837e0bb442e6d384c89 # main
         with:
           secrets: |
-            github/token/rancher--rancher-product-docs--contents--write token | GH_TOKEN
+            github/token/rancher--rancher-product-docs--pull_requests--write token | GH_TOKEN
 
       - name: Create Pull Request
         env:
           GH_TOKEN: ${{ env.GH_TOKEN }}
-          PR_TOKEN: ${{ github.token }}
         run: |
           BRANCH_NAME="${VERSION}-maintenance"
 
@@ -77,25 +76,25 @@ jobs:
 
           git push -f origin "$BRANCH_NAME"
 
-          PR_NUMBER=$(GH_TOKEN="$PR_TOKEN" gh pr list --head "$BRANCH_NAME" --base "$BASE_BRANCH" --json number --jq '.[0].number')
+          PR_NUMBER=$(gh pr list --head "$BRANCH_NAME" --base "$BASE_BRANCH" --json number --jq '.[0].number')
 
           PR_BODY="Automated release maintenance updates for version $VERSION."$'\n'"Command executed: \`./scripts/release-maintenance.sh -t \"$TAG\" -d \"$DATE\" --prime \"$PRIME\" --community \"$COMMUNITY\"\`"
 
           # Search for the release maintenance issue
-          IS_FORK=$(GH_TOKEN="$PR_TOKEN" gh repo view "${{ github.repository }}" --json isFork --jq '.isFork')
+          IS_FORK=$(gh repo view "${{ github.repository }}" --json isFork --jq '.isFork')
           if [[ "$IS_FORK" == "false" ]]; then
-            ISSUE_NUMBER=$(GH_TOKEN="$PR_TOKEN" gh issue list --repo "${{ github.repository }}" --search "\"$VERSION\" \"Rancher Manager Release Maintenance Task Checklist\" in:title is:open" --json number --jq '.[0].number')
+            ISSUE_NUMBER=$(gh issue list --repo "${{ github.repository }}" --search "\"$VERSION\" \"Rancher Manager Release Maintenance Task Checklist\" in:title is:open" --json number --jq '.[0].number')
             if [[ -n "$ISSUE_NUMBER" && "$ISSUE_NUMBER" != "null" ]]; then
               PR_BODY="$PR_BODY"$'\n\n'"Relates to #$ISSUE_NUMBER"
             fi
           fi
 
           if [[ -n "$PR_NUMBER" && "$PR_NUMBER" != "null" ]]; then
-            GH_TOKEN="$PR_TOKEN" gh pr edit "$PR_NUMBER" \
+            gh pr edit "$PR_NUMBER" \
               --title "$VERSION - Release Maintenance" \
               --body "$PR_BODY"
           else
-            PR_URL=$(GH_TOKEN="$PR_TOKEN" gh pr create \
+            PR_URL=$(gh pr create \
               --title "$VERSION - Release Maintenance" \
               --body "$PR_BODY" \
               --base "$BASE_BRANCH" \
@@ -104,7 +103,6 @@ jobs:
             PR_NUMBER=${PR_URL##*/}
           fi
 
-          # Trigger CI workflows by pushing an empty commit
-          # This triggers the 'synchronize' event which bypasses the PR_TOKEN limitation on the 'opened' event
+          # Attempt to trigger CI workflows by pushing an empty commit, also allows for squashing commits to get them verified
           git commit --allow-empty -m "Trigger CI"
           git push origin "$BRANCH_NAME"

--- a/.github/workflows/test-deploy-community.yml
+++ b/.github/workflows/test-deploy-community.yml
@@ -6,6 +6,12 @@ on:
     paths-ignore:
       - '**/README.md'
     types: [opened, edited, synchronize, reopened]
+  push:
+    branches:
+      - '*-maintenance'
+      - 'release-notes-*'
+    paths-ignore:
+      - '**/README.md'
 
 permissions:
   pull-requests: write

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -6,6 +6,12 @@ on:
     paths-ignore:
       - '**/README.md'
     types: [opened, edited, synchronize, reopened]
+  push:
+    branches:
+      - '*-maintenance'
+      - 'release-notes-*'
+    paths-ignore:
+      - '**/README.md'
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
* Triggering CI workflows by pushing an empty commit did not seem to work, instead, run CI on branch pushes.
* The new github/token/rancher--rancher-product-docs--pull_requests--write should have perms for both branch push and PR creation.