### PR TITLE
Updating CAAPF release note - v2.14.1

### DIFF
--- a/versions/v2.14/modules/en/pages/release-notes/v2.14.1.adoc
+++ b/versions/v2.14/modules/en/pages/release-notes/v2.14.1.adoc
@@ -25,6 +25,7 @@ ifeval::["{build-type}" == "community"]
 :rn-capi-v1beta2: https://turtles.docs.rancher.com/turtles/v0.26/en/tutorials/capi-v1beta2.html
 :rn-imagescan: https://fleet.rancher.io/how-tos-for-users/imagescan
 :rn-caapf: https://turtles.docs.rancher.com/turtles/stable/en/user/caapf.html
+:rn-caapf-migration: https://turtles.docs.rancher.com/turtles/stable/en/user/caapf.html#_migrating_existing_caapf_managed_clusters_to_rancher
 :rn-capi-feature: https://turtles.docs.rancher.com/turtles/stable/en/overview/features.html#_how_to_set_feature_gates
 endif::[]
 ifeval::["{build-type}" != "community"]
@@ -41,6 +42,7 @@ ifeval::["{build-type}" != "community"]
 :rn-back-up-rancher: xref:rancher-admin/back-up-restore-and-disaster-recovery/back-up.adoc
 :rn-install-rancher: xref:installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
 :rn-caapf: https://documentation.suse.com/cloudnative/cluster-api/v0.26/en/user/caapf.html
+:rn-caapf-migration: https://documentation.suse.com/cloudnative/cluster-api/v0.26/en/user/caapf.html#_migrating_existing_caapf_managed_clusters_to_rancher
 :rn-capi-feature: https://documentation.suse.com/cloudnative/cluster-api/v0.26/en/overview/features.html#_how_to_set_feature_gates
 :rn-fleet-drift: https://documentation.suse.com/cloudnative/continuous-delivery/v0.15/en/changelogs/v0.15.0.html#_drift_correction_may_not_work_as_expected_with_helm_v4
 :rn-private-registry: https://documentation.suse.com/cloudnative/k3s/latest/en/installation/private-registry.html
@@ -216,7 +218,7 @@ endif::[]
 However, if you had previously disabled Rancher Turtles, you will need to manually re-enable it. Cluster provisioning will fail and a warning will display during Rancher startup if Turtles is disabled.
 +
 For more information on installing and using Rancher Turtles, refer to the {rn-capi-overview}[Cluster API integration documentation]. See https://github.com/rancher/rancher/issues/53291[#53291].
-* *Deprecation:* Starting from Rancher v2.14.1, Cluster API Addon Provider Fleet (CAAPF) is being disabled by default and will be removed in a future Rancher release per our https://www.suse.com/support/rancher-prime/#Rancher-Prime-Deprecation-Policy[deprecation policy]. While standard Fleet integration is still available through Rancher, additional steps are needed by users that upgrade to Rancher v2.14.1 and are running CAPI clusters that are provisioned using CAAPF. To enable the feature gate, you can set the `features.use-caapf.enabled` to `true` in the CAPI chart values, refer to {rn-capi-feature}[Features] and the {rn-caapf}[Cluster API Addon Provider Fleet] documentation for more information. 
+* *Deprecation:* Starting from Rancher v2.14.1, Cluster API Addon Provider Fleet (CAAPF) is being disabled by default and will be removed in a future Rancher release per our https://www.suse.com/support/rancher-prime/#Rancher-Prime-Deprecation-Policy[deprecation policy]. An automated migration script for CAAPF resources is available when upgrading to Rancher v2.14.1, refer to the {rn-caapf-migration}[CAPI documentation]. While standard Fleet integration is still available through Rancher, additional steps are needed by users that upgrade to Rancher v2.14.1 and are running CAPI clusters that are provisioned using CAAPF. To enable the feature gate, you can set the `features.use-caapf.enabled` to `true` in the CAPI chart values, refer to {rn-capi-feature}[Features] and the {rn-caapf}[Cluster API Addon Provider Fleet] documentation for more information. 
 +
 [IMPORTANT]
 ====
@@ -325,7 +327,7 @@ ifeval::["{build-type}" == "community"]
 [#_behavior_changes_7]
 === Behavior Changes
 
-* *Deprecation:* Starting from Rancher v2.14.1, Cluster API Addon Provider Fleet (CAAPF) is being disabled by default and will be removed in a future Rancher release per our https://www.suse.com/support/rancher-prime/#Rancher-Prime-Deprecation-Policy[deprecation policy]. While standard Fleet integration is still available through Rancher, additional steps are needed by users that upgrade to Rancher v2.14.1 and are running CAPI clusters that are provisioned using CAAPF. To enable the feature gate, you can set the `features.use-caapf.enabled` to `true` in the CAPI chart values, refer to {rn-capi-feature}[Features] and the {rn-caapf}[Cluster API Addon Provider Fleet] documentation for more information. 
+* *Deprecation:* Starting from Rancher v2.14.1, Cluster API Addon Provider Fleet (CAAPF) is being disabled by default and will be removed in a future Rancher release per our https://www.suse.com/support/rancher-prime/#Rancher-Prime-Deprecation-Policy[deprecation policy]. An automated migration script for CAAPF resources is available when upgrading to Rancher v2.14.1, refer to the {rn-caapf-migration}[CAPI documentation]. While standard Fleet integration is still available through Rancher, additional steps are needed by users that upgrade to Rancher v2.14.1 and are running CAPI clusters that are provisioned using CAAPF. To enable the feature gate, you can set the `features.use-caapf.enabled` to `true` in the CAPI chart values, refer to {rn-capi-feature}[Features] and the {rn-caapf}[Cluster API Addon Provider Fleet] documentation for more information. 
 +
 [IMPORTANT]
 ====


### PR DESCRIPTION
Updating CAAPF release note to include migration script information.

Will update community notes once merged.