### PR TITLE
SUSE Application Collection -cert-manager install/upgrade

### DIFF
--- a/versions/v2.10/modules/en/pages/installation-and-upgrade/install-rancher.adoc
+++ b/versions/v2.10/modules/en/pages/installation-and-upgrade/install-rancher.adoc
@@ -192,11 +192,9 @@ There are three recommended options for the source of the certificate used for T
 
 === 4. Install cert-manager
 
-[tabs]
-=======
-Using SUSE Application Collection::
-+
---
+ifeval::["{build-type}" != "community"]
+==== Using SUSE Application Collection
+
 https://docs.apps.rancher.io/[SUSE Application Collection] provides a cert-manager chart that is compatible with Rancher. If you are using SUSE Application Collection, we recommend installing cert-manager using this option. 
 
 . Log in to the secure SUSE Application Collection registry:
@@ -261,12 +259,10 @@ cert-manager-56cc584bd4-nhjx7              1/1     Running   0          3m
 cert-manager-cainjector-7cfc74b84b-kg7m2   1/1     Running   0          3m
 cert-manager-webhook-784f6dd68-69dvn       1/1     Running   0          3m
 ----
+endif::[]
 
---
+==== Using Upstream Jetstack Helm Repository
 
-Using Upstream Jetstack Helm Repository::
-+
---
 ____
 You should skip this step if you are bringing your own certificate files (option `ingress.tls.source=secret`), or if you use {xref-helm-chart-options}#_external_tls_termination[TLS termination on an external load balancer].
 ____
@@ -323,9 +319,6 @@ cert-manager-webhook-787858fcdb-nlzsq      1/1     Running   0          2m
 ----
 
 ======
-
---
-=======
 
 === 5. Install Rancher with Helm and Your Chosen Certificate Option
 

--- a/versions/v2.10/modules/en/pages/installation-and-upgrade/install-rancher.adoc
+++ b/versions/v2.10/modules/en/pages/installation-and-upgrade/install-rancher.adoc
@@ -243,7 +243,7 @@ helm install <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert
 If you are deploying in a cluster that requires FIPS cryptography compliance, you can substitute the chart path with `oci://dp.apps.rancher.io/charts/cert-manager-fips`.
 ====
 
-. Verify the Installation
+. Verify the Installation.
 +
 Once you've installed cert-manager, you can verify it is deployed correctly by checking the `cert-manager` namespace for running pods:
 +

--- a/versions/v2.10/modules/en/pages/installation-and-upgrade/install-rancher.adoc
+++ b/versions/v2.10/modules/en/pages/installation-and-upgrade/install-rancher.adoc
@@ -1,6 +1,6 @@
 = Install/Upgrade {rancher-product-name} on a Kubernetes Cluster
 :page-languages: [en, zh]
-:revdate: 2025-08-18
+:revdate: 2026-06-10
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/index.adoc 
 :product-path: installation-and-upgrade/install-rancher.adoc
@@ -192,6 +192,81 @@ There are three recommended options for the source of the certificate used for T
 
 === 4. Install cert-manager
 
+[tabs]
+=======
+Using SUSE Application Collection::
++
+--
+https://docs.apps.rancher.io/[SUSE Application Collection] provides a cert-manager chart that is compatible with Rancher. If you are using SUSE Application Collection, we recommend installing cert-manager using this option. 
+
+. Log in to the secure SUSE Application Collection registry:
++
+Before installing, https://docs.apps.rancher.io/get-started/authentication[authenticate your Helm CLI] against the Application Collection OCI registry using your enterprise credentials:
++
+[source,shell]
+----
+helm registry login dp.apps.rancher.io -u <username-or-service-account-username> -p <access-token-or-service-account-token>
+----
+
+. Create the target namespace `cert-manager`:
++
+[source,shell]
+----
+kubectl create namespace cert-manager
+----
+
+. Create the Image Pull Secret:
++
+Because the Application Collection is a private registry, your cluster's nodes need a secret to pull the images. Generate this secret in the `cert-manager` namespace:
++
+[source,shell]
+----
+kubectl create secret docker-registry application-collection \
+  --namespace cert-manager \
+  --docker-server=dp.apps.rancher.io \
+  --docker-username=<YOUR_APPCO_USERNAME> \
+  --docker-password=<YOUR_APPCO_TOKEN>
+----
+
+. Install cert-manager via the OCI chart path:
++
+Deploy the chart directly from the OCI registry path. Ensure you pass the `global.imagePullSecrets` flag so the pods can authenticate:
++
+[source,shell]
+----
+helm install <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert-manager \
+    --namespace cert-manager \
+    --set global.imagePullSecrets={application-collection} \
+    --set crds.enabled=true
+----
++
+[NOTE]
+====
+If you are deploying in a cluster that requires FIPS cryptography compliance, you can substitute the chart path with `oci://dp.apps.rancher.io/charts/cert-manager-fips`.
+====
+
+. Verify the Installation
++
+Once you've installed cert-manager, you can verify it is deployed correctly by checking the `cert-manager` namespace for running pods:
++
+[source,shell]
+----
+kubectl get pods --namespace cert-manager
+----
++
+[source,shell]
+----
+NAME                                       READY   STATUS    RESTARTS   AGE
+cert-manager-56cc584bd4-nhjx7              1/1     Running   0          3m
+cert-manager-cainjector-7cfc74b84b-kg7m2   1/1     Running   0          3m
+cert-manager-webhook-784f6dd68-69dvn       1/1     Running   0          3m
+----
+
+--
+
+Using Upstream Jetstack Helm Repository::
++
+--
 ____
 You should skip this step if you are bringing your own certificate files (option `ingress.tls.source=secret`), or if you use {xref-helm-chart-options}#_external_tls_termination[TLS termination on an external load balancer].
 ____
@@ -248,6 +323,9 @@ cert-manager-webhook-787858fcdb-nlzsq      1/1     Running   0          2m
 ----
 
 ======
+
+--
+=======
 
 === 5. Install Rancher with Helm and Your Chosen Certificate Option
 

--- a/versions/v2.10/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
+++ b/versions/v2.10/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -179,7 +179,7 @@ Based on the choice your made in <<_2_choose_your_ssl_configuration,2. Choose yo
 ifeval::["{build-type}" != "community"]
 ===== Fetch from SUSE Application Collection
 
-Use this option to pull the security-hardened cert-manager chart listed in the https://apps.rancher.io/applications/cert-manager[SUSE Application Collection] available to Prime users.
+Use this option to pull the security-hardened cert-manager chart listed in the https://apps.rancher.io/applications/cert-manager[SUSE Application Collection] (AppCo) available to Prime users.
 
 . Log in to AppCo registry on an internet-connected machine:
 +

--- a/versions/v2.10/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
+++ b/versions/v2.10/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -181,41 +181,41 @@ ifeval::["{build-type}" != "community"]
 
 Use this option to pull the security-hardened cert-manager chart listed in the https://apps.rancher.io/applications/cert-manager[SUSE Application Collection] available to Prime users.
 
-====== 1. Log in to AppCo registry on an internet-connected machine:
-
+. Log in to AppCo registry on an internet-connected machine:
++
 Use your https://docs.apps.rancher.io/get-started/authentication[enterprise credentials] to log in to the secure SUSE Application Collection registry:
-
++
 [source,shell]
 ----
 helm registry login dp.apps.rancher.io -u <username-or-service-account-username> -p <access-token-or-service-account-token>
 ----
 
-====== 2. Export and download the OCI chart archive:
-
+. Export and download the OCI chart archive:
++
 Use `helm pull` to download the chart directly from the OCI registry as a local tarball:
-
++
 [source,shell]
 ----
 helm pull oci://dp.apps.rancher.io/charts/cert-manager --version <cert-manager-version>
 ----
-
++
 This saves `cert-manager-<cert-manager-version>.tgz` to your current working directory.
 
-====== 3. Populate the Private Registry with AppCo Images
-
+. Populate the Private Registry with AppCo Images.
++
 Before installing cert-manager inside the air-gapped cluster, you must pull the secure container images from SUSE on your internet-connected machine, save them, transfer them via secure media (like a USB drive), and push them to your local registry.
-
++
 The below command pulls the secure container images from SUSE:
-
++
 [source,shell]
 ----
 docker pull dp.apps.rancher.io/cert-manager-controller:<cert-manager-version>
 docker pull dp.apps.rancher.io/cert-manager-cainjector:<cert-manager-version>
 docker pull dp.apps.rancher.io/cert-manager-webhook:<cert-manager-version>
 ----
-
++
 The below command saves, transfers, and retags the images for your internal air-gapped registry:
-
++
 [source,shell]
 ----
 # Save to tarball
@@ -254,29 +254,29 @@ Recent changes to cert-manager require an upgrade. If you are upgrading Rancher 
 ====
 
 
-====== 1. Add the cert-manager Repo
-
+. Add the cert-manager Repo.
++
 From a system connected to the internet, add the cert-manager repo to Helm:
-
++
 [,plain]
 ----
 helm repo add jetstack https://charts.jetstack.io
 helm repo update
 ----
 
-====== 2. Fetch the cert-manager Chart
-
+. Fetch the cert-manager Chart.
++
 Fetch the latest cert-manager chart available from the https://artifacthub.io/packages/helm/cert-manager/cert-manager[Helm chart repository].
-
++
 [,plain]
 ----
 helm fetch jetstack/cert-manager --version v1.11.0
 ----
 
-====== 3. Retrieve the cert-manager CRDs
-
+. Retrieve the cert-manager CRDs.
++
 Download the required CRD file for cert-manager:
-
++
 [,plain]
 ----
    curl -L -o cert-manager-crd.yaml https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cert-manager.crds.yaml

--- a/versions/v2.10/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
+++ b/versions/v2.10/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -176,6 +176,7 @@ Based on the choice your made in <<_2_choose_your_ssl_configuration,2. Choose yo
 
 ==== Option A: Default Self-Signed Certificate
 
+ifeval::["{build-type}" != "community"]
 ===== Fetch from SUSE Application Collection
 
 Use this option to pull the security-hardened cert-manager chart listed in the https://apps.rancher.io/applications/cert-manager[SUSE Application Collection] available to Prime users.
@@ -238,6 +239,7 @@ docker push <registry.internal.corp>/cert-manager-controller:<cert-manager-versi
 docker push <registry.internal.corp>/cert-manager-cainjector:<cert-manager-version>
 docker push <registry.internal.corp>/cert-manager-webhook:<cert-manager-version>
 ----
+endif::[]
 
 ===== Fetch from Upstream Helm Jetstack Repository
 
@@ -294,6 +296,7 @@ Install cert-manager with the same options you would use to install the chart. R
 To see options on how to customize the cert-manager install (including for cases where your cluster uses PodSecurityPolicies), see the https://artifacthub.io/packages/helm/cert-manager/cert-manager#configuration[cert-manager docs].
 ====
 
+ifeval::["{build-type}" != "community"]
 .Click to expand - SUSE Application Collection cert-manager Installation Instructions
 [%collapsible]
 ======
@@ -316,6 +319,7 @@ helm install cert-manager ./<cert-manager-version>.tgz \
   --set cainjector.image.repository=<registry.internal.corp>/cert-manager-cainjector
 ----
 ======
+endif::[]
 
 .Click to expand - Helm Jetstack cert-manager Installation Instructions
 [%collapsible]

--- a/versions/v2.10/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
+++ b/versions/v2.10/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -1,6 +1,6 @@
 = 4. Install {rancher-product-name}
 :page-languages: [en, zh]
-:revdate: 2026-02-18
+:revdate: 2026-06-10
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/install-rancher-ha.adoc 
 :product-path: installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -176,6 +176,73 @@ Based on the choice your made in <<_2_choose_your_ssl_configuration,2. Choose yo
 
 ==== Option A: Default Self-Signed Certificate
 
+===== Fetch from SUSE Application Collection
+
+Use this option to pull the security-hardened cert-manager chart listed in the https://apps.rancher.io/applications/cert-manager[SUSE Application Collection] available to Prime users.
+
+====== 1. Log in to AppCo registry on an internet-connected machine:
+
+Use your https://docs.apps.rancher.io/get-started/authentication[enterprise credentials] to log in to the secure SUSE Application Collection registry:
+
+[source,shell]
+----
+helm registry login dp.apps.rancher.io -u <username-or-service-account-username> -p <access-token-or-service-account-token>
+----
+
+====== 2. Export and download the OCI chart archive:
+
+Use `helm pull` to download the chart directly from the OCI registry as a local tarball:
+
+[source,shell]
+----
+helm pull oci://dp.apps.rancher.io/charts/cert-manager --version <cert-manager-version>
+----
+
+This saves `cert-manager-<cert-manager-version>.tgz` to your current working directory.
+
+====== 3. Populate the Private Registry with AppCo Images
+
+Before installing cert-manager inside the air-gapped cluster, you must pull the secure container images from SUSE on your internet-connected machine, save them, transfer them via secure media (like a USB drive), and push them to your local registry.
+
+The below command pulls the secure container images from SUSE:
+
+[source,shell]
+----
+docker pull dp.apps.rancher.io/cert-manager-controller:<cert-manager-version>
+docker pull dp.apps.rancher.io/cert-manager-cainjector:<cert-manager-version>
+docker pull dp.apps.rancher.io/cert-manager-webhook:<cert-manager-version>
+----
+
+The below command saves, transfers, and retags the images for your internal air-gapped registry:
+
+[source,shell]
+----
+# Save to tarball
+docker save -o cert-manager-appco.tar \
+   dp.apps.rancher.io/cert-manager-controller:<cert-manager-version> \
+   dp.apps.rancher.io/cert-manager-cainjector:<cert-manager-version> \
+   dp.apps.rancher.io/cert-manager-webhook:<cert-manager-version>
+
+# Transfer the tar file and chart .tgz file into the air-gapped network
+
+# Load on air-gapped machine
+docker load -i cert-manager-appco.tar
+
+# Retag for your internal registry (e.g., registry.internal.corp)
+docker tag dp.apps.rancher.io/cert-manager-controller:<cert-manager-version> <registry.internal.corp>/cert-manager-controller:<cert-manager-version>
+docker tag dp.apps.rancher.io/cert-manager-cainjector:<cert-manager-version> <registry.internal.corp>/cert-manager-cainjector:<cert-manager-version>
+docker tag dp.apps.rancher.io/cert-manager-webhook:<cert-manager-version> <registry.internal.corp>/cert-manager-webhook:<cert-manager-version>
+
+# Push to internal registry
+docker push <registry.internal.corp>/cert-manager-controller:<cert-manager-version>
+docker push <registry.internal.corp>/cert-manager-cainjector:<cert-manager-version>
+docker push <registry.internal.corp>/cert-manager-webhook:<cert-manager-version>
+----
+
+===== Fetch from Upstream Helm Jetstack Repository
+
+Use this option to pull the community open-source chart.
+
 By default, Rancher generates a CA and uses cert-manager to issue the certificate for access to the Rancher server interface.
 
 [NOTE]
@@ -185,7 +252,7 @@ Recent changes to cert-manager require an upgrade. If you are upgrading Rancher 
 ====
 
 
-===== 1. Add the cert-manager Repo
+====== 1. Add the cert-manager Repo
 
 From a system connected to the internet, add the cert-manager repo to Helm:
 
@@ -195,7 +262,7 @@ helm repo add jetstack https://charts.jetstack.io
 helm repo update
 ----
 
-===== 2. Fetch the cert-manager Chart
+====== 2. Fetch the cert-manager Chart
 
 Fetch the latest cert-manager chart available from the https://artifacthub.io/packages/helm/cert-manager/cert-manager[Helm chart repository].
 
@@ -204,7 +271,7 @@ Fetch the latest cert-manager chart available from the https://artifacthub.io/pa
 helm fetch jetstack/cert-manager --version v1.11.0
 ----
 
-===== 3. Retrieve the cert-manager CRDs
+====== 3. Retrieve the cert-manager CRDs
 
 Download the required CRD file for cert-manager:
 
@@ -227,8 +294,30 @@ Install cert-manager with the same options you would use to install the chart. R
 To see options on how to customize the cert-manager install (including for cases where your cluster uses PodSecurityPolicies), see the https://artifacthub.io/packages/helm/cert-manager/cert-manager#configuration[cert-manager docs].
 ====
 
+.Click to expand - SUSE Application Collection cert-manager Installation Instructions
+[%collapsible]
+======
+. Create the namespace.
++
+[source,shell]
+----
+kubectl create namespace cert-manager
+----
 
-.Click to expand
+. Install using the local chart tarball file.
++
+[source,shell]
+----
+helm install cert-manager ./<cert-manager-version>.tgz \
+  --namespace cert-manager \
+  --set installCRDs=true \
+  --set image.repository=<registry.internal.corp>/cert-manager-controller \
+  --set webhook.image.repository=<registry.internal.corp>/cert-manager-webhook \
+  --set cainjector.image.repository=<registry.internal.corp>/cert-manager-cainjector
+----
+======
+
+.Click to expand - Helm Jetstack cert-manager Installation Instructions
 [%collapsible]
 ======
 If you are using self-signed certificates, install cert-manager:

--- a/versions/v2.10/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
+++ b/versions/v2.10/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
@@ -81,7 +81,7 @@ helm install <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert
 If you are deploying in a cluster that requires FIPS cryptography compliance, you can substitute the chart path with `oci://dp.apps.rancher.io/charts/cert-manager-fips`.
 ====
 
-. Verify the Installation
+. Verify the Installation.
 +
 Once you've installed cert-manager, you can verify it is deployed correctly by checking the `cert-manager` namespace for running pods:
 +

--- a/versions/v2.10/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
+++ b/versions/v2.10/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
@@ -1,6 +1,6 @@
 = 3. Install {rancher-product-name}
 :page-languages: [en, zh] 
-:revdate: 2026-04-21
+:revdate: 2026-06-10
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/install-rancher.adoc 
 :product-path: installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
@@ -30,6 +30,81 @@ sudo ./get_helm.sh
 
 == Install cert-manager
 
+[tabs]
+======
+Using SUSE Application Collection::
++
+--
+https://docs.apps.rancher.io/[SUSE Application Collection] provides a cert-manager chart that is compatible with Rancher. If you are using SUSE Application Collection, we recommend installing cert-manager using this option. 
+
+. Log in to the secure SUSE Application Collection registry:
++
+Before installing, https://docs.apps.rancher.io/get-started/authentication[authenticate your Helm CLI] against the Application Collection OCI registry using your enterprise credentials:
++
+[source,shell]
+----
+helm registry login dp.apps.rancher.io -u <username-or-service-account-username> -p <access-token-or-service-account-token>
+----
+
+. Create the target namespace `cert-manager`:
++
+[source,shell]
+----
+kubectl create namespace cert-manager
+----
+
+. Create the Image Pull Secret:
++
+Because the Application Collection is a private registry, your cluster's nodes need a secret to pull the images. Generate this secret in the `cert-manager` namespace:
++
+[source,shell]
+----
+kubectl create secret docker-registry application-collection \
+  --namespace cert-manager \
+  --docker-server=dp.apps.rancher.io \
+  --docker-username=<YOUR_APPCO_USERNAME> \
+  --docker-password=<YOUR_APPCO_TOKEN>
+----
+
+. Install cert-manager via the OCI chart path:
++
+Deploy the chart directly from the OCI registry path. Ensure you pass the `global.imagePullSecrets` flag so the pods can authenticate:
++
+[source,shell]
+----
+helm install <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert-manager \
+    --namespace cert-manager \
+    --set global.imagePullSecrets={application-collection} \
+    --set crds.enabled=true
+----
++
+[NOTE]
+====
+If you are deploying in a cluster that requires FIPS cryptography compliance, you can substitute the chart path with `oci://dp.apps.rancher.io/charts/cert-manager-fips`.
+====
+
+. Verify the Installation
++
+Once you've installed cert-manager, you can verify it is deployed correctly by checking the `cert-manager` namespace for running pods:
++
+[source,shell]
+----
+kubectl get pods --namespace cert-manager
+----
++
+[source,shell]
+----
+NAME                                       READY   STATUS    RESTARTS   AGE
+cert-manager-56cc584bd4-nhjx7              1/1     Running   0          3m
+cert-manager-cainjector-7cfc74b84b-kg7m2   1/1     Running   0          3m
+cert-manager-webhook-784f6dd68-69dvn       1/1     Running   0          3m
+----
+
+--
+
+Using Upstream Jetstack Helm Repository::
++
+--
 Add the cert-manager Helm repository:
 
 ----
@@ -71,6 +146,8 @@ Now you should wait until cert-manager is finished starting up:
 kubectl rollout status deployment -n cert-manager cert-manager
 kubectl rollout status deployment -n cert-manager cert-manager-webhook
 ----
+--
+======
 
 == Install {rancher-product-name}
 

--- a/versions/v2.10/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
+++ b/versions/v2.10/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
@@ -30,11 +30,9 @@ sudo ./get_helm.sh
 
 == Install cert-manager
 
-[tabs]
-======
-Using SUSE Application Collection::
-+
---
+ifeval::["{build-type}" != "community"]
+=== Using SUSE Application Collection
+
 https://docs.apps.rancher.io/[SUSE Application Collection] provides a cert-manager chart that is compatible with Rancher. If you are using SUSE Application Collection, we recommend installing cert-manager using this option. 
 
 . Log in to the secure SUSE Application Collection registry:
@@ -99,12 +97,10 @@ cert-manager-56cc584bd4-nhjx7              1/1     Running   0          3m
 cert-manager-cainjector-7cfc74b84b-kg7m2   1/1     Running   0          3m
 cert-manager-webhook-784f6dd68-69dvn       1/1     Running   0          3m
 ----
+endif::[]
 
---
+=== Using Upstream Jetstack Helm Repository
 
-Using Upstream Jetstack Helm Repository::
-+
---
 Add the cert-manager Helm repository:
 
 ----
@@ -146,8 +142,6 @@ Now you should wait until cert-manager is finished starting up:
 kubectl rollout status deployment -n cert-manager cert-manager
 kubectl rollout status deployment -n cert-manager cert-manager-webhook
 ----
---
-======
 
 == Install {rancher-product-name}
 

--- a/versions/v2.10/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
+++ b/versions/v2.10/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
@@ -269,6 +269,7 @@ Refer to the https://cert-manager.io/docs/usage/cmctl/#migrate-api-version[API v
 . Upgrade Rancher normally with `helm upgrade`.
 ======
 
+ifeval::["{build-type}" != "community"]
 === Option D: Upgrade cert-manager Using SUSE Application Collection
 
 .Click to expand
@@ -292,6 +293,7 @@ helm upgrade <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert
 ----
 
 ======
+endif::[]
 
 === Verify the Deployment
 

--- a/versions/v2.10/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
+++ b/versions/v2.10/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
@@ -40,7 +40,38 @@ The namespace used in these instructions depends on the namespace cert-manager i
 
 In order to upgrade cert-manager, follow these instructions:
 
+ifeval::["{build-type}" != "community"]
+=== Option A: Upgrade cert-manager Using SUSE Application Collection
+
+.Click to expand
+[%collapsible]
+======
+
+The cert-manager chart can be upgraded in-place using the Helm `upgrade` workflow to a https://apps.rancher.io/applications/cert-manager[specific version] listed in the SUSE Application Collection, below is an example command:
+
+[source,shell]
+----
+helm upgrade <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert-manager \
+  --set global.imagePullSecrets={application-collection}
+----
+
+To reuse the existing values and only upgrade the chart version:
+
+[source,shell]
+----
+helm upgrade <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert-manager \
+  --reuse-values
+----
+
+======
+endif::[]
+
+ifeval::["{build-type}" != "community"]
+=== Option B: Upgrade cert-manager with Internet Access
+endif::[]
+ifeval::["{build-type}" == "community"]
 === Option A: Upgrade cert-manager with Internet Access
+endif::[]
 
 .Click to expand
 [%collapsible]
@@ -129,13 +160,20 @@ helm repo update
 +
 ======
 
+ifeval::["{build-type}" != "community"]
+=== Option C: Upgrade cert-manager in an Air-Gapped Environment
+endif::[]
+ifeval::["{build-type}" == "community"]
 === Option B: Upgrade cert-manager in an Air-Gapped Environment
+endif::[]
 
 .Click to expand
 [%collapsible]
 ======
 
-=== Prerequisites
+[#_prerequisites]
+[pass]
+<h3><a id="_prerequisites"></a>Prerequisites</h3>
 
 Before you can perform the upgrade, you must prepare your air gapped environment by adding the necessary container images to your private registry and downloading or rendering the required Kubernetes manifest files.
 
@@ -247,7 +285,12 @@ If you are running Kubernetes v1.15 or below, you will need to add the `--valida
 ----
 ======
 
+ifeval::["{build-type}" != "community"]
+=== Option D: Upgrade cert-manager from Versions 1.5 and Below
+endif::[]
+ifeval::["{build-type}" == "community"]
 === Option C: Upgrade cert-manager from Versions 1.5 and Below
+endif::[]
 
 .Click to expand
 [%collapsible]
@@ -268,32 +311,6 @@ Refer to the https://cert-manager.io/docs/usage/cmctl/#migrate-api-version[API v
 . In the decoded file, search for `cert-manager.io/v1beta1` and *replace it* with `cert-manager.io/v1`.
 . Upgrade Rancher normally with `helm upgrade`.
 ======
-
-ifeval::["{build-type}" != "community"]
-=== Option D: Upgrade cert-manager Using SUSE Application Collection
-
-.Click to expand
-[%collapsible]
-======
-
-The cert-manager chart can be upgraded in-place using the Helm `upgrade` workflow to a https://apps.rancher.io/applications/cert-manager[specific version] listed in the SUSE Application Collection, below is an example command:
-
-[source,shell]
-----
-helm upgrade <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert-manager \
-  --set global.imagePullSecrets={application-collection}
-----
-
-To reuse the existing values and only upgrade the chart version:
-
-[source,shell]
-----
-helm upgrade <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert-manager \
-  --reuse-values
-----
-
-======
-endif::[]
 
 === Verify the Deployment
 

--- a/versions/v2.10/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
+++ b/versions/v2.10/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
@@ -29,19 +29,18 @@ To address these changes, this guide will do two things:
 [NOTE]
 .Important:
 ====
-
-If you are upgrading cert-manager to the latest version from a version older than 1.5, follow the steps in <<_option_c_upgrade_cert_manager_from_versions_1_5_and_below,Option C>> below to do so. Note that you do not need to reinstall Rancher to perform this upgrade.
+If you are upgrading cert-manager to the latest version from a version older than 1.5, follow the steps via the method <<_upgrade_cert_manager_from_versions_1_5_and_below,Upgrade cert-manager from Versions 1.5 and Below>>. Note that you do not need to reinstall Rancher to perform this upgrade.
 ====
 
 
-== Upgrade Cert-Manager
+== cert-manager Upgrade Methods
 
 The namespace used in these instructions depends on the namespace cert-manager is currently installed in. If it is in kube-system use that in the instructions below. You can verify by running `kubectl get pods --all-namespaces` and checking which namespace the cert-manager-* pods are listed in. Do not change the namespace cert-manager is running in or this can cause issues.
 
 In order to upgrade cert-manager, follow these instructions:
 
 ifeval::["{build-type}" != "community"]
-=== Option A: Upgrade cert-manager Using SUSE Application Collection
+=== Upgrade cert-manager Using SUSE Application Collection
 
 .Click to expand
 [%collapsible]
@@ -66,12 +65,7 @@ helm upgrade <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert
 ======
 endif::[]
 
-ifeval::["{build-type}" != "community"]
-=== Option B: Upgrade cert-manager with Internet Access
-endif::[]
-ifeval::["{build-type}" == "community"]
-=== Option A: Upgrade cert-manager with Internet Access
-endif::[]
+=== Upgrade cert-manager with Internet Access
 
 .Click to expand
 [%collapsible]
@@ -160,12 +154,7 @@ helm repo update
 +
 ======
 
-ifeval::["{build-type}" != "community"]
-=== Option C: Upgrade cert-manager in an Air-Gapped Environment
-endif::[]
-ifeval::["{build-type}" == "community"]
-=== Option B: Upgrade cert-manager in an Air-Gapped Environment
-endif::[]
+=== Upgrade cert-manager in an Air-Gapped Environment
 
 .Click to expand
 [%collapsible]
@@ -285,12 +274,7 @@ If you are running Kubernetes v1.15 or below, you will need to add the `--valida
 ----
 ======
 
-ifeval::["{build-type}" != "community"]
-=== Option D: Upgrade cert-manager from Versions 1.5 and Below
-endif::[]
-ifeval::["{build-type}" == "community"]
-=== Option C: Upgrade cert-manager from Versions 1.5 and Below
-endif::[]
+=== Upgrade cert-manager from Versions 1.5 and Below
 
 .Click to expand
 [%collapsible]

--- a/versions/v2.10/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
+++ b/versions/v2.10/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
@@ -1,6 +1,6 @@
 = Upgrading Cert-Manager
 :page-languages: [en, zh]
-:revdate: 2026-04-21
+:revdate: 2026-06-10
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/resources/upgrade-cert-manager.adoc 
 :product-path: installation-and-upgrade/resources/upgrade-cert-manager.adoc
@@ -267,6 +267,30 @@ Refer to the https://cert-manager.io/docs/usage/cmctl/#migrate-api-version[API v
 . Follow the Helm tutorial to https://helm.sh/docs/topics/kubernetes_apis/#updating-api-versions-of-a-release-manifest[update the API version of a release manifest]. The chart release name is `release_name=rancher` and the release namespace is `release_namespace=cattle-system`.
 . In the decoded file, search for `cert-manager.io/v1beta1` and *replace it* with `cert-manager.io/v1`.
 . Upgrade Rancher normally with `helm upgrade`.
+======
+
+=== Option D: Upgrade cert-manager Using SUSE Application Collection
+
+.Click to expand
+[%collapsible]
+======
+
+The cert-manager chart can be upgraded in-place using the Helm `upgrade` workflow to a https://apps.rancher.io/applications/cert-manager[specific version] listed in the SUSE Application Collection, below is an example command:
+
+[source,shell]
+----
+helm upgrade <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert-manager \
+  --set global.imagePullSecrets={application-collection}
+----
+
+To reuse the existing values and only upgrade the chart version:
+
+[source,shell]
+----
+helm upgrade <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert-manager \
+  --reuse-values
+----
+
 ======
 
 === Verify the Deployment

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/install-rancher.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/install-rancher.adoc
@@ -192,11 +192,9 @@ There are three recommended options for the source of the certificate used for T
 
 === 4. Install cert-manager
 
-[tabs]
-=======
-Using SUSE Application Collection::
-+
---
+ifeval::["{build-type}" != "community"]
+==== Using SUSE Application Collection
+
 https://docs.apps.rancher.io/[SUSE Application Collection] provides a cert-manager chart that is compatible with Rancher. If you are using SUSE Application Collection, we recommend installing cert-manager using this option. 
 
 . Log in to the secure SUSE Application Collection registry:
@@ -261,12 +259,10 @@ cert-manager-56cc584bd4-nhjx7              1/1     Running   0          3m
 cert-manager-cainjector-7cfc74b84b-kg7m2   1/1     Running   0          3m
 cert-manager-webhook-784f6dd68-69dvn       1/1     Running   0          3m
 ----
+endif::[]
 
---
+==== Using Upstream Jetstack Helm Repository
 
-Using Upstream Jetstack Helm Repository::
-+
---
 ____
 You should skip this step if you are bringing your own certificate files (option `ingress.tls.source=secret`), or if you use {xref-helm-chart-options}#_external_tls_termination[TLS termination on an external load balancer].
 ____
@@ -323,9 +319,6 @@ cert-manager-webhook-787858fcdb-nlzsq      1/1     Running   0          2m
 ----
 
 ======
-
---
-=======
 
 === 5. Install Rancher with Helm and Your Chosen Certificate Option
 

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/install-rancher.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/install-rancher.adoc
@@ -243,7 +243,7 @@ helm install <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert
 If you are deploying in a cluster that requires FIPS cryptography compliance, you can substitute the chart path with `oci://dp.apps.rancher.io/charts/cert-manager-fips`.
 ====
 
-. Verify the Installation
+. Verify the Installation.
 +
 Once you've installed cert-manager, you can verify it is deployed correctly by checking the `cert-manager` namespace for running pods:
 +

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/install-rancher.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/install-rancher.adoc
@@ -1,6 +1,6 @@
 = Install/Upgrade {rancher-product-name} on a Kubernetes Cluster
 :page-languages: [en, zh]
-:revdate: 2025-08-18
+:revdate: 2026-06-10
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/index.adoc 
 :product-path: installation-and-upgrade/install-rancher.adoc
@@ -192,6 +192,81 @@ There are three recommended options for the source of the certificate used for T
 
 === 4. Install cert-manager
 
+[tabs]
+=======
+Using SUSE Application Collection::
++
+--
+https://docs.apps.rancher.io/[SUSE Application Collection] provides a cert-manager chart that is compatible with Rancher. If you are using SUSE Application Collection, we recommend installing cert-manager using this option. 
+
+. Log in to the secure SUSE Application Collection registry:
++
+Before installing, https://docs.apps.rancher.io/get-started/authentication[authenticate your Helm CLI] against the Application Collection OCI registry using your enterprise credentials:
++
+[source,shell]
+----
+helm registry login dp.apps.rancher.io -u <username-or-service-account-username> -p <access-token-or-service-account-token>
+----
+
+. Create the target namespace `cert-manager`:
++
+[source,shell]
+----
+kubectl create namespace cert-manager
+----
+
+. Create the Image Pull Secret:
++
+Because the Application Collection is a private registry, your cluster's nodes need a secret to pull the images. Generate this secret in the `cert-manager` namespace:
++
+[source,shell]
+----
+kubectl create secret docker-registry application-collection \
+  --namespace cert-manager \
+  --docker-server=dp.apps.rancher.io \
+  --docker-username=<YOUR_APPCO_USERNAME> \
+  --docker-password=<YOUR_APPCO_TOKEN>
+----
+
+. Install cert-manager via the OCI chart path:
++
+Deploy the chart directly from the OCI registry path. Ensure you pass the `global.imagePullSecrets` flag so the pods can authenticate:
++
+[source,shell]
+----
+helm install <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert-manager \
+    --namespace cert-manager \
+    --set global.imagePullSecrets={application-collection} \
+    --set crds.enabled=true
+----
++
+[NOTE]
+====
+If you are deploying in a cluster that requires FIPS cryptography compliance, you can substitute the chart path with `oci://dp.apps.rancher.io/charts/cert-manager-fips`.
+====
+
+. Verify the Installation
++
+Once you've installed cert-manager, you can verify it is deployed correctly by checking the `cert-manager` namespace for running pods:
++
+[source,shell]
+----
+kubectl get pods --namespace cert-manager
+----
++
+[source,shell]
+----
+NAME                                       READY   STATUS    RESTARTS   AGE
+cert-manager-56cc584bd4-nhjx7              1/1     Running   0          3m
+cert-manager-cainjector-7cfc74b84b-kg7m2   1/1     Running   0          3m
+cert-manager-webhook-784f6dd68-69dvn       1/1     Running   0          3m
+----
+
+--
+
+Using Upstream Jetstack Helm Repository::
++
+--
 ____
 You should skip this step if you are bringing your own certificate files (option `ingress.tls.source=secret`), or if you use {xref-helm-chart-options}#_external_tls_termination[TLS termination on an external load balancer].
 ____
@@ -248,6 +323,9 @@ cert-manager-webhook-787858fcdb-nlzsq      1/1     Running   0          2m
 ----
 
 ======
+
+--
+=======
 
 === 5. Install Rancher with Helm and Your Chosen Certificate Option
 

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -179,7 +179,7 @@ Based on the choice your made in <<_2_choose_your_ssl_configuration,2. Choose yo
 ifeval::["{build-type}" != "community"]
 ===== Fetch from SUSE Application Collection
 
-Use this option to pull the security-hardened cert-manager chart listed in the https://apps.rancher.io/applications/cert-manager[SUSE Application Collection] available to Prime users.
+Use this option to pull the security-hardened cert-manager chart listed in the https://apps.rancher.io/applications/cert-manager[SUSE Application Collection] (AppCo) available to Prime users.
 
 . Log in to AppCo registry on an internet-connected machine:
 +

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -181,41 +181,41 @@ ifeval::["{build-type}" != "community"]
 
 Use this option to pull the security-hardened cert-manager chart listed in the https://apps.rancher.io/applications/cert-manager[SUSE Application Collection] available to Prime users.
 
-====== 1. Log in to AppCo registry on an internet-connected machine:
-
+. Log in to AppCo registry on an internet-connected machine:
++
 Use your https://docs.apps.rancher.io/get-started/authentication[enterprise credentials] to log in to the secure SUSE Application Collection registry:
-
++
 [source,shell]
 ----
 helm registry login dp.apps.rancher.io -u <username-or-service-account-username> -p <access-token-or-service-account-token>
 ----
 
-====== 2. Export and download the OCI chart archive:
-
+. Export and download the OCI chart archive:
++
 Use `helm pull` to download the chart directly from the OCI registry as a local tarball:
-
++
 [source,shell]
 ----
 helm pull oci://dp.apps.rancher.io/charts/cert-manager --version <cert-manager-version>
 ----
-
++
 This saves `cert-manager-<cert-manager-version>.tgz` to your current working directory.
 
-====== 3. Populate the Private Registry with AppCo Images
-
+. Populate the Private Registry with AppCo Images.
++
 Before installing cert-manager inside the air-gapped cluster, you must pull the secure container images from SUSE on your internet-connected machine, save them, transfer them via secure media (like a USB drive), and push them to your local registry.
-
++
 The below command pulls the secure container images from SUSE:
-
++
 [source,shell]
 ----
 docker pull dp.apps.rancher.io/cert-manager-controller:<cert-manager-version>
 docker pull dp.apps.rancher.io/cert-manager-cainjector:<cert-manager-version>
 docker pull dp.apps.rancher.io/cert-manager-webhook:<cert-manager-version>
 ----
-
++
 The below command saves, transfers, and retags the images for your internal air-gapped registry:
-
++
 [source,shell]
 ----
 # Save to tarball
@@ -254,29 +254,29 @@ Recent changes to cert-manager require an upgrade. If you are upgrading Rancher 
 ====
 
 
-====== 1. Add the cert-manager Repo
-
+. Add the cert-manager Repo.
++
 From a system connected to the internet, add the cert-manager repo to Helm:
-
++
 [,plain]
 ----
 helm repo add jetstack https://charts.jetstack.io
 helm repo update
 ----
 
-====== 2. Fetch the cert-manager Chart
-
+. Fetch the cert-manager Chart.
++
 Fetch the latest cert-manager chart available from the https://artifacthub.io/packages/helm/cert-manager/cert-manager[Helm chart repository].
-
++
 [,plain]
 ----
 helm fetch jetstack/cert-manager --version v1.11.0
 ----
 
-====== 3. Retrieve the cert-manager CRDs
-
+. Retrieve the cert-manager CRDs.
++
 Download the required CRD file for cert-manager:
-
++
 [,plain]
 ----
    curl -L -o cert-manager-crd.yaml https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cert-manager.crds.yaml

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -176,6 +176,7 @@ Based on the choice your made in <<_2_choose_your_ssl_configuration,2. Choose yo
 
 ==== Option A: Default Self-Signed Certificate
 
+ifeval::["{build-type}" != "community"]
 ===== Fetch from SUSE Application Collection
 
 Use this option to pull the security-hardened cert-manager chart listed in the https://apps.rancher.io/applications/cert-manager[SUSE Application Collection] available to Prime users.
@@ -238,6 +239,7 @@ docker push <registry.internal.corp>/cert-manager-controller:<cert-manager-versi
 docker push <registry.internal.corp>/cert-manager-cainjector:<cert-manager-version>
 docker push <registry.internal.corp>/cert-manager-webhook:<cert-manager-version>
 ----
+endif::[]
 
 ===== Fetch from Upstream Helm Jetstack Repository
 
@@ -294,6 +296,7 @@ Install cert-manager with the same options you would use to install the chart. R
 To see options on how to customize the cert-manager install (including for cases where your cluster uses PodSecurityPolicies), see the https://artifacthub.io/packages/helm/cert-manager/cert-manager#configuration[cert-manager docs].
 ====
 
+ifeval::["{build-type}" != "community"]
 .Click to expand - SUSE Application Collection cert-manager Installation Instructions
 [%collapsible]
 ======
@@ -316,6 +319,7 @@ helm install cert-manager ./<cert-manager-version>.tgz \
   --set cainjector.image.repository=<registry.internal.corp>/cert-manager-cainjector
 ----
 ======
+endif::[]
 
 .Click to expand - Helm Jetstack cert-manager Installation Instructions
 [%collapsible]

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -1,6 +1,6 @@
 = 4. Install {rancher-product-name}
 :page-languages: [en, zh]
-:revdate: 2026-02-18
+:revdate: 2026-06-10
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/install-rancher-ha.adoc 
 :product-path: installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -176,6 +176,73 @@ Based on the choice your made in <<_2_choose_your_ssl_configuration,2. Choose yo
 
 ==== Option A: Default Self-Signed Certificate
 
+===== Fetch from SUSE Application Collection
+
+Use this option to pull the security-hardened cert-manager chart listed in the https://apps.rancher.io/applications/cert-manager[SUSE Application Collection] available to Prime users.
+
+====== 1. Log in to AppCo registry on an internet-connected machine:
+
+Use your https://docs.apps.rancher.io/get-started/authentication[enterprise credentials] to log in to the secure SUSE Application Collection registry:
+
+[source,shell]
+----
+helm registry login dp.apps.rancher.io -u <username-or-service-account-username> -p <access-token-or-service-account-token>
+----
+
+====== 2. Export and download the OCI chart archive:
+
+Use `helm pull` to download the chart directly from the OCI registry as a local tarball:
+
+[source,shell]
+----
+helm pull oci://dp.apps.rancher.io/charts/cert-manager --version <cert-manager-version>
+----
+
+This saves `cert-manager-<cert-manager-version>.tgz` to your current working directory.
+
+====== 3. Populate the Private Registry with AppCo Images
+
+Before installing cert-manager inside the air-gapped cluster, you must pull the secure container images from SUSE on your internet-connected machine, save them, transfer them via secure media (like a USB drive), and push them to your local registry.
+
+The below command pulls the secure container images from SUSE:
+
+[source,shell]
+----
+docker pull dp.apps.rancher.io/cert-manager-controller:<cert-manager-version>
+docker pull dp.apps.rancher.io/cert-manager-cainjector:<cert-manager-version>
+docker pull dp.apps.rancher.io/cert-manager-webhook:<cert-manager-version>
+----
+
+The below command saves, transfers, and retags the images for your internal air-gapped registry:
+
+[source,shell]
+----
+# Save to tarball
+docker save -o cert-manager-appco.tar \
+   dp.apps.rancher.io/cert-manager-controller:<cert-manager-version> \
+   dp.apps.rancher.io/cert-manager-cainjector:<cert-manager-version> \
+   dp.apps.rancher.io/cert-manager-webhook:<cert-manager-version>
+
+# Transfer the tar file and chart .tgz file into the air-gapped network
+
+# Load on air-gapped machine
+docker load -i cert-manager-appco.tar
+
+# Retag for your internal registry (e.g., registry.internal.corp)
+docker tag dp.apps.rancher.io/cert-manager-controller:<cert-manager-version> <registry.internal.corp>/cert-manager-controller:<cert-manager-version>
+docker tag dp.apps.rancher.io/cert-manager-cainjector:<cert-manager-version> <registry.internal.corp>/cert-manager-cainjector:<cert-manager-version>
+docker tag dp.apps.rancher.io/cert-manager-webhook:<cert-manager-version> <registry.internal.corp>/cert-manager-webhook:<cert-manager-version>
+
+# Push to internal registry
+docker push <registry.internal.corp>/cert-manager-controller:<cert-manager-version>
+docker push <registry.internal.corp>/cert-manager-cainjector:<cert-manager-version>
+docker push <registry.internal.corp>/cert-manager-webhook:<cert-manager-version>
+----
+
+===== Fetch from Upstream Helm Jetstack Repository
+
+Use this option to pull the community open-source chart.
+
 By default, Rancher generates a CA and uses cert-manager to issue the certificate for access to the Rancher server interface.
 
 [NOTE]
@@ -185,7 +252,7 @@ Recent changes to cert-manager require an upgrade. If you are upgrading Rancher 
 ====
 
 
-===== 1. Add the cert-manager Repo
+====== 1. Add the cert-manager Repo
 
 From a system connected to the internet, add the cert-manager repo to Helm:
 
@@ -195,7 +262,7 @@ helm repo add jetstack https://charts.jetstack.io
 helm repo update
 ----
 
-===== 2. Fetch the cert-manager Chart
+====== 2. Fetch the cert-manager Chart
 
 Fetch the latest cert-manager chart available from the https://artifacthub.io/packages/helm/cert-manager/cert-manager[Helm chart repository].
 
@@ -204,7 +271,7 @@ Fetch the latest cert-manager chart available from the https://artifacthub.io/pa
 helm fetch jetstack/cert-manager --version v1.11.0
 ----
 
-===== 3. Retrieve the cert-manager CRDs
+====== 3. Retrieve the cert-manager CRDs
 
 Download the required CRD file for cert-manager:
 
@@ -227,8 +294,30 @@ Install cert-manager with the same options you would use to install the chart. R
 To see options on how to customize the cert-manager install (including for cases where your cluster uses PodSecurityPolicies), see the https://artifacthub.io/packages/helm/cert-manager/cert-manager#configuration[cert-manager docs].
 ====
 
+.Click to expand - SUSE Application Collection cert-manager Installation Instructions
+[%collapsible]
+======
+. Create the namespace.
++
+[source,shell]
+----
+kubectl create namespace cert-manager
+----
 
-.Click to expand
+. Install using the local chart tarball file.
++
+[source,shell]
+----
+helm install cert-manager ./<cert-manager-version>.tgz \
+  --namespace cert-manager \
+  --set installCRDs=true \
+  --set image.repository=<registry.internal.corp>/cert-manager-controller \
+  --set webhook.image.repository=<registry.internal.corp>/cert-manager-webhook \
+  --set cainjector.image.repository=<registry.internal.corp>/cert-manager-cainjector
+----
+======
+
+.Click to expand - Helm Jetstack cert-manager Installation Instructions
 [%collapsible]
 ======
 If you are using self-signed certificates, install cert-manager:

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
@@ -81,7 +81,7 @@ helm install <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert
 If you are deploying in a cluster that requires FIPS cryptography compliance, you can substitute the chart path with `oci://dp.apps.rancher.io/charts/cert-manager-fips`.
 ====
 
-. Verify the Installation
+. Verify the Installation.
 +
 Once you've installed cert-manager, you can verify it is deployed correctly by checking the `cert-manager` namespace for running pods:
 +

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
@@ -1,6 +1,6 @@
 = 3. Install {rancher-product-name}
 :page-languages: [en, zh]
-:revdate: 2026-04-21
+:revdate: 2026-06-10
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/install-rancher.adoc 
 :product-path: installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
@@ -30,6 +30,81 @@ sudo ./get_helm.sh
 
 == Install cert-manager
 
+[tabs]
+======
+Using SUSE Application Collection::
++
+--
+https://docs.apps.rancher.io/[SUSE Application Collection] provides a cert-manager chart that is compatible with Rancher. If you are using SUSE Application Collection, we recommend installing cert-manager using this option. 
+
+. Log in to the secure SUSE Application Collection registry:
++
+Before installing, https://docs.apps.rancher.io/get-started/authentication[authenticate your Helm CLI] against the Application Collection OCI registry using your enterprise credentials:
++
+[source,shell]
+----
+helm registry login dp.apps.rancher.io -u <username-or-service-account-username> -p <access-token-or-service-account-token>
+----
+
+. Create the target namespace `cert-manager`:
++
+[source,shell]
+----
+kubectl create namespace cert-manager
+----
+
+. Create the Image Pull Secret:
++
+Because the Application Collection is a private registry, your cluster's nodes need a secret to pull the images. Generate this secret in the `cert-manager` namespace:
++
+[source,shell]
+----
+kubectl create secret docker-registry application-collection \
+  --namespace cert-manager \
+  --docker-server=dp.apps.rancher.io \
+  --docker-username=<YOUR_APPCO_USERNAME> \
+  --docker-password=<YOUR_APPCO_TOKEN>
+----
+
+. Install cert-manager via the OCI chart path:
++
+Deploy the chart directly from the OCI registry path. Ensure you pass the `global.imagePullSecrets` flag so the pods can authenticate:
++
+[source,shell]
+----
+helm install <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert-manager \
+    --namespace cert-manager \
+    --set global.imagePullSecrets={application-collection} \
+    --set crds.enabled=true
+----
++
+[NOTE]
+====
+If you are deploying in a cluster that requires FIPS cryptography compliance, you can substitute the chart path with `oci://dp.apps.rancher.io/charts/cert-manager-fips`.
+====
+
+. Verify the Installation
++
+Once you've installed cert-manager, you can verify it is deployed correctly by checking the `cert-manager` namespace for running pods:
++
+[source,shell]
+----
+kubectl get pods --namespace cert-manager
+----
++
+[source,shell]
+----
+NAME                                       READY   STATUS    RESTARTS   AGE
+cert-manager-56cc584bd4-nhjx7              1/1     Running   0          3m
+cert-manager-cainjector-7cfc74b84b-kg7m2   1/1     Running   0          3m
+cert-manager-webhook-784f6dd68-69dvn       1/1     Running   0          3m
+----
+
+--
+
+Using Upstream Jetstack Helm Repository::
++
+--
 Add the cert-manager Helm repository:
 
 ----
@@ -71,6 +146,8 @@ Now you should wait until cert-manager is finished starting up:
 kubectl rollout status deployment -n cert-manager cert-manager
 kubectl rollout status deployment -n cert-manager cert-manager-webhook
 ----
+--
+======
 
 == Install {rancher-product-name}
 

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
@@ -30,11 +30,9 @@ sudo ./get_helm.sh
 
 == Install cert-manager
 
-[tabs]
-======
-Using SUSE Application Collection::
-+
---
+ifeval::["{build-type}" != "community"]
+=== Using SUSE Application Collection
+
 https://docs.apps.rancher.io/[SUSE Application Collection] provides a cert-manager chart that is compatible with Rancher. If you are using SUSE Application Collection, we recommend installing cert-manager using this option. 
 
 . Log in to the secure SUSE Application Collection registry:
@@ -99,12 +97,10 @@ cert-manager-56cc584bd4-nhjx7              1/1     Running   0          3m
 cert-manager-cainjector-7cfc74b84b-kg7m2   1/1     Running   0          3m
 cert-manager-webhook-784f6dd68-69dvn       1/1     Running   0          3m
 ----
+endif::[]
 
---
+=== Using Upstream Jetstack Helm Repository
 
-Using Upstream Jetstack Helm Repository::
-+
---
 Add the cert-manager Helm repository:
 
 ----
@@ -146,8 +142,6 @@ Now you should wait until cert-manager is finished starting up:
 kubectl rollout status deployment -n cert-manager cert-manager
 kubectl rollout status deployment -n cert-manager cert-manager-webhook
 ----
---
-======
 
 == Install {rancher-product-name}
 

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
@@ -269,6 +269,7 @@ Refer to the https://cert-manager.io/docs/usage/cmctl/#migrate-api-version[API v
 . Upgrade Rancher normally with `helm upgrade`.
 ======
 
+ifeval::["{build-type}" != "community"]
 === Option D: Upgrade cert-manager Using SUSE Application Collection
 
 .Click to expand
@@ -292,6 +293,7 @@ helm upgrade <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert
 ----
 
 ======
+endif::[]
 
 === Verify the Deployment
 

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
@@ -40,7 +40,38 @@ The namespace used in these instructions depends on the namespace cert-manager i
 
 In order to upgrade cert-manager, follow these instructions:
 
+ifeval::["{build-type}" != "community"]
+=== Option A: Upgrade cert-manager Using SUSE Application Collection
+
+.Click to expand
+[%collapsible]
+======
+
+The cert-manager chart can be upgraded in-place using the Helm `upgrade` workflow to a https://apps.rancher.io/applications/cert-manager[specific version] listed in the SUSE Application Collection, below is an example command:
+
+[source,shell]
+----
+helm upgrade <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert-manager \
+  --set global.imagePullSecrets={application-collection}
+----
+
+To reuse the existing values and only upgrade the chart version:
+
+[source,shell]
+----
+helm upgrade <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert-manager \
+  --reuse-values
+----
+
+======
+endif::[]
+
+ifeval::["{build-type}" != "community"]
+=== Option B: Upgrade cert-manager with Internet Access
+endif::[]
+ifeval::["{build-type}" == "community"]
 === Option A: Upgrade cert-manager with Internet Access
+endif::[]
 
 .Click to expand
 [%collapsible]
@@ -129,13 +160,20 @@ helm repo update
 +
 ======
 
+ifeval::["{build-type}" != "community"]
+=== Option C: Upgrade cert-manager in an Air-Gapped Environment
+endif::[]
+ifeval::["{build-type}" == "community"]
 === Option B: Upgrade cert-manager in an Air-Gapped Environment
+endif::[]
 
 .Click to expand
 [%collapsible]
 ======
 
-=== Prerequisites
+[#_prerequisites]
+[pass]
+<h3><a id="_prerequisites"></a>Prerequisites</h3>
 
 Before you can perform the upgrade, you must prepare your air gapped environment by adding the necessary container images to your private registry and downloading or rendering the required Kubernetes manifest files.
 
@@ -247,7 +285,12 @@ If you are running Kubernetes v1.15 or below, you will need to add the `--valida
 ----
 ======
 
+ifeval::["{build-type}" != "community"]
+=== Option D: Upgrade cert-manager from Versions 1.5 and Below
+endif::[]
+ifeval::["{build-type}" == "community"]
 === Option C: Upgrade cert-manager from Versions 1.5 and Below
+endif::[]
 
 .Click to expand
 [%collapsible]
@@ -268,32 +311,6 @@ Refer to the https://cert-manager.io/docs/usage/cmctl/#migrate-api-version[API v
 . In the decoded file, search for `cert-manager.io/v1beta1` and *replace it* with `cert-manager.io/v1`.
 . Upgrade Rancher normally with `helm upgrade`.
 ======
-
-ifeval::["{build-type}" != "community"]
-=== Option D: Upgrade cert-manager Using SUSE Application Collection
-
-.Click to expand
-[%collapsible]
-======
-
-The cert-manager chart can be upgraded in-place using the Helm `upgrade` workflow to a https://apps.rancher.io/applications/cert-manager[specific version] listed in the SUSE Application Collection, below is an example command:
-
-[source,shell]
-----
-helm upgrade <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert-manager \
-  --set global.imagePullSecrets={application-collection}
-----
-
-To reuse the existing values and only upgrade the chart version:
-
-[source,shell]
-----
-helm upgrade <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert-manager \
-  --reuse-values
-----
-
-======
-endif::[]
 
 === Verify the Deployment
 

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
@@ -29,19 +29,18 @@ To address these changes, this guide will do two things:
 [NOTE]
 .Important:
 ====
-
-If you are upgrading cert-manager to the latest version from a version older than 1.5, follow the steps in <<_option_c_upgrade_cert_manager_from_versions_1_5_and_below,Option C>> below to do so. Note that you do not need to reinstall Rancher to perform this upgrade.
+If you are upgrading cert-manager to the latest version from a version older than 1.5, follow the steps via the method <<_upgrade_cert_manager_from_versions_1_5_and_below,Upgrade cert-manager from Versions 1.5 and Below>>. Note that you do not need to reinstall Rancher to perform this upgrade.
 ====
 
 
-== Upgrade Cert-Manager
+== cert-manager Upgrade Methods
 
 The namespace used in these instructions depends on the namespace cert-manager is currently installed in. If it is in kube-system use that in the instructions below. You can verify by running `kubectl get pods --all-namespaces` and checking which namespace the cert-manager-* pods are listed in. Do not change the namespace cert-manager is running in or this can cause issues.
 
 In order to upgrade cert-manager, follow these instructions:
 
 ifeval::["{build-type}" != "community"]
-=== Option A: Upgrade cert-manager Using SUSE Application Collection
+=== Upgrade cert-manager Using SUSE Application Collection
 
 .Click to expand
 [%collapsible]
@@ -66,12 +65,7 @@ helm upgrade <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert
 ======
 endif::[]
 
-ifeval::["{build-type}" != "community"]
-=== Option B: Upgrade cert-manager with Internet Access
-endif::[]
-ifeval::["{build-type}" == "community"]
-=== Option A: Upgrade cert-manager with Internet Access
-endif::[]
+=== Upgrade cert-manager with Internet Access
 
 .Click to expand
 [%collapsible]
@@ -160,12 +154,7 @@ helm repo update
 +
 ======
 
-ifeval::["{build-type}" != "community"]
-=== Option C: Upgrade cert-manager in an Air-Gapped Environment
-endif::[]
-ifeval::["{build-type}" == "community"]
-=== Option B: Upgrade cert-manager in an Air-Gapped Environment
-endif::[]
+=== Upgrade cert-manager in an Air-Gapped Environment
 
 .Click to expand
 [%collapsible]
@@ -285,12 +274,7 @@ If you are running Kubernetes v1.15 or below, you will need to add the `--valida
 ----
 ======
 
-ifeval::["{build-type}" != "community"]
-=== Option D: Upgrade cert-manager from Versions 1.5 and Below
-endif::[]
-ifeval::["{build-type}" == "community"]
-=== Option C: Upgrade cert-manager from Versions 1.5 and Below
-endif::[]
+=== Upgrade cert-manager from Versions 1.5 and Below
 
 .Click to expand
 [%collapsible]

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
@@ -1,6 +1,6 @@
 = Upgrading Cert-Manager
 :page-languages: [en, zh]
-:revdate: 2026-04-21
+:revdate: 2026-06-10
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/resources/upgrade-cert-manager.adoc 
 :product-path: installation-and-upgrade/resources/upgrade-cert-manager.adoc
@@ -267,6 +267,30 @@ Refer to the https://cert-manager.io/docs/usage/cmctl/#migrate-api-version[API v
 . Follow the Helm tutorial to https://helm.sh/docs/topics/kubernetes_apis/#updating-api-versions-of-a-release-manifest[update the API version of a release manifest]. The chart release name is `release_name=rancher` and the release namespace is `release_namespace=cattle-system`.
 . In the decoded file, search for `cert-manager.io/v1beta1` and *replace it* with `cert-manager.io/v1`.
 . Upgrade Rancher normally with `helm upgrade`.
+======
+
+=== Option D: Upgrade cert-manager Using SUSE Application Collection
+
+.Click to expand
+[%collapsible]
+======
+
+The cert-manager chart can be upgraded in-place using the Helm `upgrade` workflow to a https://apps.rancher.io/applications/cert-manager[specific version] listed in the SUSE Application Collection, below is an example command:
+
+[source,shell]
+----
+helm upgrade <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert-manager \
+  --set global.imagePullSecrets={application-collection}
+----
+
+To reuse the existing values and only upgrade the chart version:
+
+[source,shell]
+----
+helm upgrade <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert-manager \
+  --reuse-values
+----
+
 ======
 
 === Verify the Deployment

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/install-rancher.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/install-rancher.adoc
@@ -240,7 +240,7 @@ helm install <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert
 If you are deploying in a cluster that requires FIPS cryptography compliance, you can substitute the chart path with `oci://dp.apps.rancher.io/charts/cert-manager-fips`.
 ====
 
-. Verify the Installation
+. Verify the Installation.
 +
 Once you've installed cert-manager, you can verify it is deployed correctly by checking the `cert-manager` namespace for running pods:
 +

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/install-rancher.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/install-rancher.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-25
+:revdate: 2026-06-10
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/index.adoc 
 :product-path: installation-and-upgrade/install-rancher.adoc
@@ -189,6 +189,81 @@ There are three recommended options for the source of the certificate used for T
 
 === 4. Install cert-manager
 
+[tabs]
+=======
+Using SUSE Application Collection::
++
+--
+https://docs.apps.rancher.io/[SUSE Application Collection] provides a cert-manager chart that is compatible with Rancher. If you are using SUSE Application Collection, we recommend installing cert-manager using this option. 
+
+. Log in to the secure SUSE Application Collection registry:
++
+Before installing, https://docs.apps.rancher.io/get-started/authentication[authenticate your Helm CLI] against the Application Collection OCI registry using your enterprise credentials:
++
+[source,shell]
+----
+helm registry login dp.apps.rancher.io -u <username-or-service-account-username> -p <access-token-or-service-account-token>
+----
+
+. Create the target namespace `cert-manager`:
++
+[source,shell]
+----
+kubectl create namespace cert-manager
+----
+
+. Create the Image Pull Secret:
++
+Because the Application Collection is a private registry, your cluster's nodes need a secret to pull the images. Generate this secret in the `cert-manager` namespace:
++
+[source,shell]
+----
+kubectl create secret docker-registry application-collection \
+  --namespace cert-manager \
+  --docker-server=dp.apps.rancher.io \
+  --docker-username=<YOUR_APPCO_USERNAME> \
+  --docker-password=<YOUR_APPCO_TOKEN>
+----
+
+. Install cert-manager via the OCI chart path:
++
+Deploy the chart directly from the OCI registry path. Ensure you pass the `global.imagePullSecrets` flag so the pods can authenticate:
++
+[source,shell]
+----
+helm install <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert-manager \
+    --namespace cert-manager \
+    --set global.imagePullSecrets={application-collection} \
+    --set crds.enabled=true
+----
++
+[NOTE]
+====
+If you are deploying in a cluster that requires FIPS cryptography compliance, you can substitute the chart path with `oci://dp.apps.rancher.io/charts/cert-manager-fips`.
+====
+
+. Verify the Installation
++
+Once you've installed cert-manager, you can verify it is deployed correctly by checking the `cert-manager` namespace for running pods:
++
+[source,shell]
+----
+kubectl get pods --namespace cert-manager
+----
++
+[source,shell]
+----
+NAME                                       READY   STATUS    RESTARTS   AGE
+cert-manager-56cc584bd4-nhjx7              1/1     Running   0          3m
+cert-manager-cainjector-7cfc74b84b-kg7m2   1/1     Running   0          3m
+cert-manager-webhook-784f6dd68-69dvn       1/1     Running   0          3m
+----
+
+--
+
+Using Upstream Jetstack Helm Repository::
++
+--
 ____
 You should skip this step if you are bringing your own certificate files (option `ingress.tls.source=secret`), or if you use {xref-helm-chart-options}#_external_tls_termination[TLS termination on an external load balancer].
 ____
@@ -245,6 +320,9 @@ cert-manager-webhook-787858fcdb-nlzsq      1/1     Running   0          2m
 ----
 
 ======
+
+--
+=======
 
 === 5. Install Rancher with Helm and Your Chosen Certificate Option
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/install-rancher.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/install-rancher.adoc
@@ -189,11 +189,9 @@ There are three recommended options for the source of the certificate used for T
 
 === 4. Install cert-manager
 
-[tabs]
-=======
-Using SUSE Application Collection::
-+
---
+ifeval::["{build-type}" != "community"]
+==== Using SUSE Application Collection
+
 https://docs.apps.rancher.io/[SUSE Application Collection] provides a cert-manager chart that is compatible with Rancher. If you are using SUSE Application Collection, we recommend installing cert-manager using this option. 
 
 . Log in to the secure SUSE Application Collection registry:
@@ -258,12 +256,10 @@ cert-manager-56cc584bd4-nhjx7              1/1     Running   0          3m
 cert-manager-cainjector-7cfc74b84b-kg7m2   1/1     Running   0          3m
 cert-manager-webhook-784f6dd68-69dvn       1/1     Running   0          3m
 ----
+endif::[]
 
---
+==== Using Upstream Jetstack Helm Repository
 
-Using Upstream Jetstack Helm Repository::
-+
---
 ____
 You should skip this step if you are bringing your own certificate files (option `ingress.tls.source=secret`), or if you use {xref-helm-chart-options}#_external_tls_termination[TLS termination on an external load balancer].
 ____
@@ -320,9 +316,6 @@ cert-manager-webhook-787858fcdb-nlzsq      1/1     Running   0          2m
 ----
 
 ======
-
---
-=======
 
 === 5. Install Rancher with Helm and Your Chosen Certificate Option
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2026-04-22
+:revdate: 2026-06-10
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/install-rancher-ha.adoc 
 :product-path: installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -178,6 +178,73 @@ Based on the choice your made in <<_2_choose_your_ssl_configuration,2. Choose yo
 
 ==== Option A: Default Self-Signed Certificate
 
+===== Fetch from SUSE Application Collection
+
+Use this option to pull the security-hardened cert-manager chart listed in the https://apps.rancher.io/applications/cert-manager[SUSE Application Collection] available to Prime users.
+
+====== 1. Log in to AppCo registry on an internet-connected machine:
+
+Use your https://docs.apps.rancher.io/get-started/authentication[enterprise credentials] to log in to the secure SUSE Application Collection registry:
+
+[source,shell]
+----
+helm registry login dp.apps.rancher.io -u <username-or-service-account-username> -p <access-token-or-service-account-token>
+----
+
+====== 2. Export and download the OCI chart archive:
+
+Use `helm pull` to download the chart directly from the OCI registry as a local tarball:
+
+[source,shell]
+----
+helm pull oci://dp.apps.rancher.io/charts/cert-manager --version <cert-manager-version>
+----
+
+This saves `cert-manager-<cert-manager-version>.tgz` to your current working directory.
+
+====== 3. Populate the Private Registry with AppCo Images
+
+Before installing cert-manager inside the air-gapped cluster, you must pull the secure container images from SUSE on your internet-connected machine, save them, transfer them via secure media (like a USB drive), and push them to your local registry.
+
+The below command pulls the secure container images from SUSE:
+
+[source,shell]
+----
+docker pull dp.apps.rancher.io/cert-manager-controller:<cert-manager-version>
+docker pull dp.apps.rancher.io/cert-manager-cainjector:<cert-manager-version>
+docker pull dp.apps.rancher.io/cert-manager-webhook:<cert-manager-version>
+----
+
+The below command saves, transfers, and retags the images for your internal air-gapped registry:
+
+[source,shell]
+----
+# Save to tarball
+docker save -o cert-manager-appco.tar \
+   dp.apps.rancher.io/cert-manager-controller:<cert-manager-version> \
+   dp.apps.rancher.io/cert-manager-cainjector:<cert-manager-version> \
+   dp.apps.rancher.io/cert-manager-webhook:<cert-manager-version>
+
+# Transfer the tar file and chart .tgz file into the air-gapped network
+
+# Load on air-gapped machine
+docker load -i cert-manager-appco.tar
+
+# Retag for your internal registry (e.g., registry.internal.corp)
+docker tag dp.apps.rancher.io/cert-manager-controller:<cert-manager-version> <registry.internal.corp>/cert-manager-controller:<cert-manager-version>
+docker tag dp.apps.rancher.io/cert-manager-cainjector:<cert-manager-version> <registry.internal.corp>/cert-manager-cainjector:<cert-manager-version>
+docker tag dp.apps.rancher.io/cert-manager-webhook:<cert-manager-version> <registry.internal.corp>/cert-manager-webhook:<cert-manager-version>
+
+# Push to internal registry
+docker push <registry.internal.corp>/cert-manager-controller:<cert-manager-version>
+docker push <registry.internal.corp>/cert-manager-cainjector:<cert-manager-version>
+docker push <registry.internal.corp>/cert-manager-webhook:<cert-manager-version>
+----
+
+===== Fetch from Upstream Helm Jetstack Repository
+
+Use this option to pull the community open-source chart.
+
 By default, Rancher generates a CA and uses cert-manager to issue the certificate for access to the Rancher server interface.
 
 [NOTE]
@@ -187,7 +254,7 @@ Recent changes to cert-manager require an upgrade. If you are upgrading Rancher 
 ====
 
 
-===== 1. Add the cert-manager Repo
+====== 1. Add the cert-manager Repo
 
 From a system connected to the internet, add the cert-manager repo to Helm:
 
@@ -197,7 +264,7 @@ helm repo add jetstack https://charts.jetstack.io
 helm repo update
 ----
 
-===== 2. Fetch the cert-manager Chart
+====== 2. Fetch the cert-manager Chart
 
 Fetch the latest cert-manager chart available from the https://artifacthub.io/packages/helm/cert-manager/cert-manager[Helm chart repository].
 
@@ -206,7 +273,7 @@ Fetch the latest cert-manager chart available from the https://artifacthub.io/pa
 helm fetch jetstack/cert-manager --version v1.11.0
 ----
 
-===== 3. Retrieve the cert-manager CRDs
+====== 3. Retrieve the cert-manager CRDs
 
 Download the required CRD file for cert-manager:
 
@@ -229,8 +296,30 @@ Install cert-manager with the same options you would use to install the chart. R
 To see options on how to customize the cert-manager install (including for cases where your cluster uses PodSecurityPolicies), see the https://artifacthub.io/packages/helm/cert-manager/cert-manager#configuration[cert-manager docs].
 ====
 
+.Click to expand - SUSE Application Collection cert-manager Installation Instructions
+[%collapsible]
+======
+. Create the namespace.
++
+[source,shell]
+----
+kubectl create namespace cert-manager
+----
 
-.Click to expand
+. Install using the local chart tarball file.
++
+[source,shell]
+----
+helm install cert-manager ./<cert-manager-version>.tgz \
+  --namespace cert-manager \
+  --set installCRDs=true \
+  --set image.repository=<registry.internal.corp>/cert-manager-controller \
+  --set webhook.image.repository=<registry.internal.corp>/cert-manager-webhook \
+  --set cainjector.image.repository=<registry.internal.corp>/cert-manager-cainjector
+----
+======
+
+.Click to expand - Helm Jetstack cert-manager Installation Instructions
 [%collapsible]
 ======
 If you are using self-signed certificates, install cert-manager:

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -178,6 +178,7 @@ Based on the choice your made in <<_2_choose_your_ssl_configuration,2. Choose yo
 
 ==== Option A: Default Self-Signed Certificate
 
+ifeval::["{build-type}" != "community"]
 ===== Fetch from SUSE Application Collection
 
 Use this option to pull the security-hardened cert-manager chart listed in the https://apps.rancher.io/applications/cert-manager[SUSE Application Collection] available to Prime users.
@@ -240,6 +241,7 @@ docker push <registry.internal.corp>/cert-manager-controller:<cert-manager-versi
 docker push <registry.internal.corp>/cert-manager-cainjector:<cert-manager-version>
 docker push <registry.internal.corp>/cert-manager-webhook:<cert-manager-version>
 ----
+endif::[]
 
 ===== Fetch from Upstream Helm Jetstack Repository
 
@@ -296,6 +298,7 @@ Install cert-manager with the same options you would use to install the chart. R
 To see options on how to customize the cert-manager install (including for cases where your cluster uses PodSecurityPolicies), see the https://artifacthub.io/packages/helm/cert-manager/cert-manager#configuration[cert-manager docs].
 ====
 
+ifeval::["{build-type}" != "community"]
 .Click to expand - SUSE Application Collection cert-manager Installation Instructions
 [%collapsible]
 ======
@@ -318,6 +321,7 @@ helm install cert-manager ./<cert-manager-version>.tgz \
   --set cainjector.image.repository=<registry.internal.corp>/cert-manager-cainjector
 ----
 ======
+endif::[]
 
 .Click to expand - Helm Jetstack cert-manager Installation Instructions
 [%collapsible]

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -181,7 +181,7 @@ Based on the choice your made in <<_2_choose_your_ssl_configuration,2. Choose yo
 ifeval::["{build-type}" != "community"]
 ===== Fetch from SUSE Application Collection
 
-Use this option to pull the security-hardened cert-manager chart listed in the https://apps.rancher.io/applications/cert-manager[SUSE Application Collection] available to Prime users.
+Use this option to pull the security-hardened cert-manager chart listed in the https://apps.rancher.io/applications/cert-manager[SUSE Application Collection] (AppCo) available to Prime users.
 
 . Log in to AppCo registry on an internet-connected machine:
 +

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -183,41 +183,41 @@ ifeval::["{build-type}" != "community"]
 
 Use this option to pull the security-hardened cert-manager chart listed in the https://apps.rancher.io/applications/cert-manager[SUSE Application Collection] available to Prime users.
 
-====== 1. Log in to AppCo registry on an internet-connected machine:
-
+. Log in to AppCo registry on an internet-connected machine:
++
 Use your https://docs.apps.rancher.io/get-started/authentication[enterprise credentials] to log in to the secure SUSE Application Collection registry:
-
++
 [source,shell]
 ----
 helm registry login dp.apps.rancher.io -u <username-or-service-account-username> -p <access-token-or-service-account-token>
 ----
 
-====== 2. Export and download the OCI chart archive:
-
+. Export and download the OCI chart archive:
++
 Use `helm pull` to download the chart directly from the OCI registry as a local tarball:
-
++
 [source,shell]
 ----
 helm pull oci://dp.apps.rancher.io/charts/cert-manager --version <cert-manager-version>
 ----
-
++
 This saves `cert-manager-<cert-manager-version>.tgz` to your current working directory.
 
-====== 3. Populate the Private Registry with AppCo Images
-
+. Populate the Private Registry with AppCo Images.
++
 Before installing cert-manager inside the air-gapped cluster, you must pull the secure container images from SUSE on your internet-connected machine, save them, transfer them via secure media (like a USB drive), and push them to your local registry.
-
++
 The below command pulls the secure container images from SUSE:
-
++
 [source,shell]
 ----
 docker pull dp.apps.rancher.io/cert-manager-controller:<cert-manager-version>
 docker pull dp.apps.rancher.io/cert-manager-cainjector:<cert-manager-version>
 docker pull dp.apps.rancher.io/cert-manager-webhook:<cert-manager-version>
 ----
-
++
 The below command saves, transfers, and retags the images for your internal air-gapped registry:
-
++
 [source,shell]
 ----
 # Save to tarball
@@ -256,29 +256,29 @@ Recent changes to cert-manager require an upgrade. If you are upgrading Rancher 
 ====
 
 
-====== 1. Add the cert-manager Repo
-
+. Add the cert-manager Repo.
++
 From a system connected to the internet, add the cert-manager repo to Helm:
-
++
 [,plain]
 ----
 helm repo add jetstack https://charts.jetstack.io
 helm repo update
 ----
 
-====== 2. Fetch the cert-manager Chart
-
+. Fetch the cert-manager Chart.
++
 Fetch the latest cert-manager chart available from the https://artifacthub.io/packages/helm/cert-manager/cert-manager[Helm chart repository].
-
++
 [,plain]
 ----
 helm fetch jetstack/cert-manager --version v1.11.0
 ----
 
-====== 3. Retrieve the cert-manager CRDs
-
+. Retrieve the cert-manager CRDs.
++
 Download the required CRD file for cert-manager:
-
++
 [,plain]
 ----
    curl -L -o cert-manager-crd.yaml https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cert-manager.crds.yaml

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
@@ -32,11 +32,9 @@ sudo ./get_helm.sh
 
 == Install cert-manager
 
-[tabs]
-======
-Using SUSE Application Collection::
-+
---
+ifeval::["{build-type}" != "community"]
+=== Using SUSE Application Collection
+
 https://docs.apps.rancher.io/[SUSE Application Collection] provides a cert-manager chart that is compatible with Rancher. If you are using SUSE Application Collection, we recommend installing cert-manager using this option. 
 
 . Log in to the secure SUSE Application Collection registry:
@@ -101,12 +99,10 @@ cert-manager-56cc584bd4-nhjx7              1/1     Running   0          3m
 cert-manager-cainjector-7cfc74b84b-kg7m2   1/1     Running   0          3m
 cert-manager-webhook-784f6dd68-69dvn       1/1     Running   0          3m
 ----
+endif::[]
 
---
+=== Using Upstream Jetstack Helm Repository
 
-Using Upstream Jetstack Helm Repository::
-+
---
 Add the cert-manager Helm repository:
 
 ----
@@ -148,8 +144,6 @@ Now you should wait until cert-manager is finished starting up:
 kubectl rollout status deployment -n cert-manager cert-manager
 kubectl rollout status deployment -n cert-manager cert-manager-webhook
 ----
---
-======
 
 == Install {rancher-product-name}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
@@ -83,7 +83,7 @@ helm install <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert
 If you are deploying in a cluster that requires FIPS cryptography compliance, you can substitute the chart path with `oci://dp.apps.rancher.io/charts/cert-manager-fips`.
 ====
 
-. Verify the Installation
+. Verify the Installation.
 +
 Once you've installed cert-manager, you can verify it is deployed correctly by checking the `cert-manager` namespace for running pods:
 +

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2026-04-21
+:revdate: 2026-06-10
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/install-rancher.adoc 
 :product-path: installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
@@ -32,6 +32,81 @@ sudo ./get_helm.sh
 
 == Install cert-manager
 
+[tabs]
+======
+Using SUSE Application Collection::
++
+--
+https://docs.apps.rancher.io/[SUSE Application Collection] provides a cert-manager chart that is compatible with Rancher. If you are using SUSE Application Collection, we recommend installing cert-manager using this option. 
+
+. Log in to the secure SUSE Application Collection registry:
++
+Before installing, https://docs.apps.rancher.io/get-started/authentication[authenticate your Helm CLI] against the Application Collection OCI registry using your enterprise credentials:
++
+[source,shell]
+----
+helm registry login dp.apps.rancher.io -u <username-or-service-account-username> -p <access-token-or-service-account-token>
+----
+
+. Create the target namespace `cert-manager`:
++
+[source,shell]
+----
+kubectl create namespace cert-manager
+----
+
+. Create the Image Pull Secret:
++
+Because the Application Collection is a private registry, your cluster's nodes need a secret to pull the images. Generate this secret in the `cert-manager` namespace:
++
+[source,shell]
+----
+kubectl create secret docker-registry application-collection \
+  --namespace cert-manager \
+  --docker-server=dp.apps.rancher.io \
+  --docker-username=<YOUR_APPCO_USERNAME> \
+  --docker-password=<YOUR_APPCO_TOKEN>
+----
+
+. Install cert-manager via the OCI chart path:
++
+Deploy the chart directly from the OCI registry path. Ensure you pass the `global.imagePullSecrets` flag so the pods can authenticate:
++
+[source,shell]
+----
+helm install <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert-manager \
+    --namespace cert-manager \
+    --set global.imagePullSecrets={application-collection} \
+    --set crds.enabled=true
+----
++
+[NOTE]
+====
+If you are deploying in a cluster that requires FIPS cryptography compliance, you can substitute the chart path with `oci://dp.apps.rancher.io/charts/cert-manager-fips`.
+====
+
+. Verify the Installation
++
+Once you've installed cert-manager, you can verify it is deployed correctly by checking the `cert-manager` namespace for running pods:
++
+[source,shell]
+----
+kubectl get pods --namespace cert-manager
+----
++
+[source,shell]
+----
+NAME                                       READY   STATUS    RESTARTS   AGE
+cert-manager-56cc584bd4-nhjx7              1/1     Running   0          3m
+cert-manager-cainjector-7cfc74b84b-kg7m2   1/1     Running   0          3m
+cert-manager-webhook-784f6dd68-69dvn       1/1     Running   0          3m
+----
+
+--
+
+Using Upstream Jetstack Helm Repository::
++
+--
 Add the cert-manager Helm repository:
 
 ----
@@ -73,6 +148,8 @@ Now you should wait until cert-manager is finished starting up:
 kubectl rollout status deployment -n cert-manager cert-manager
 kubectl rollout status deployment -n cert-manager cert-manager-webhook
 ----
+--
+======
 
 == Install {rancher-product-name}
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
@@ -271,6 +271,7 @@ Refer to the https://cert-manager.io/docs/usage/cmctl/#migrate-api-version[API v
 . Upgrade Rancher normally with `helm upgrade`.
 ======
 
+ifeval::["{build-type}" != "community"]
 === Option D: Upgrade cert-manager Using SUSE Application Collection
 
 .Click to expand
@@ -294,6 +295,7 @@ helm upgrade <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert
 ----
 
 ======
+endif::[]
 
 === Verify the Deployment
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
@@ -42,7 +42,38 @@ The namespace used in these instructions depends on the namespace cert-manager i
 
 In order to upgrade cert-manager, follow these instructions:
 
+ifeval::["{build-type}" != "community"]
+=== Option A: Upgrade cert-manager Using SUSE Application Collection
+
+.Click to expand
+[%collapsible]
+======
+
+The cert-manager chart can be upgraded in-place using the Helm `upgrade` workflow to a https://apps.rancher.io/applications/cert-manager[specific version] listed in the SUSE Application Collection, below is an example command:
+
+[source,shell]
+----
+helm upgrade <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert-manager \
+  --set global.imagePullSecrets={application-collection}
+----
+
+To reuse the existing values and only upgrade the chart version:
+
+[source,shell]
+----
+helm upgrade <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert-manager \
+  --reuse-values
+----
+
+======
+endif::[]
+
+ifeval::["{build-type}" != "community"]
+=== Option B: Upgrade cert-manager with Internet Access
+endif::[]
+ifeval::["{build-type}" == "community"]
 === Option A: Upgrade cert-manager with Internet Access
+endif::[]
 
 .Click to expand
 [%collapsible]
@@ -131,13 +162,20 @@ helm repo update
 +
 ======
 
+ifeval::["{build-type}" != "community"]
+=== Option C: Upgrade cert-manager in an Air-Gapped Environment
+endif::[]
+ifeval::["{build-type}" == "community"]
 === Option B: Upgrade cert-manager in an Air-Gapped Environment
+endif::[]
 
 .Click to expand
 [%collapsible]
 ======
 
-=== Prerequisites
+[#_prerequisites]
+[pass]
+<h3><a id="_prerequisites"></a>Prerequisites</h3>
 
 Before you can perform the upgrade, you must prepare your air gapped environment by adding the necessary container images to your private registry and downloading or rendering the required Kubernetes manifest files.
 
@@ -249,7 +287,12 @@ If you are running Kubernetes v1.15 or below, you will need to add the `--valida
 ----
 ======
 
+ifeval::["{build-type}" != "community"]
+=== Option D: Upgrade cert-manager from Versions 1.5 and Below
+endif::[]
+ifeval::["{build-type}" == "community"]
 === Option C: Upgrade cert-manager from Versions 1.5 and Below
+endif::[]
 
 .Click to expand
 [%collapsible]
@@ -270,32 +313,6 @@ Refer to the https://cert-manager.io/docs/usage/cmctl/#migrate-api-version[API v
 . In the decoded file, search for `cert-manager.io/v1beta1` and *replace it* with `cert-manager.io/v1`.
 . Upgrade Rancher normally with `helm upgrade`.
 ======
-
-ifeval::["{build-type}" != "community"]
-=== Option D: Upgrade cert-manager Using SUSE Application Collection
-
-.Click to expand
-[%collapsible]
-======
-
-The cert-manager chart can be upgraded in-place using the Helm `upgrade` workflow to a https://apps.rancher.io/applications/cert-manager[specific version] listed in the SUSE Application Collection, below is an example command:
-
-[source,shell]
-----
-helm upgrade <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert-manager \
-  --set global.imagePullSecrets={application-collection}
-----
-
-To reuse the existing values and only upgrade the chart version:
-
-[source,shell]
-----
-helm upgrade <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert-manager \
-  --reuse-values
-----
-
-======
-endif::[]
 
 === Verify the Deployment
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
@@ -31,19 +31,18 @@ To address these changes, this guide will do two things:
 [NOTE]
 .Important:
 ====
-
-If you are upgrading cert-manager to the latest version from a version older than 1.5, follow the steps in <<_option_c_upgrade_cert_manager_from_versions_1_5_and_below,Option C>> below to do so. Note that you do not need to reinstall Rancher to perform this upgrade.
+If you are upgrading cert-manager to the latest version from a version older than 1.5, follow the steps via the method <<_upgrade_cert_manager_from_versions_1_5_and_below,Upgrade cert-manager from Versions 1.5 and Below>>. Note that you do not need to reinstall Rancher to perform this upgrade.
 ====
 
 
-== Upgrade Cert-Manager
+== cert-manager Upgrade Methods
 
 The namespace used in these instructions depends on the namespace cert-manager is currently installed in. If it is in kube-system use that in the instructions below. You can verify by running `kubectl get pods --all-namespaces` and checking which namespace the cert-manager-* pods are listed in. Do not change the namespace cert-manager is running in or this can cause issues.
 
 In order to upgrade cert-manager, follow these instructions:
 
 ifeval::["{build-type}" != "community"]
-=== Option A: Upgrade cert-manager Using SUSE Application Collection
+=== Upgrade cert-manager Using SUSE Application Collection
 
 .Click to expand
 [%collapsible]
@@ -68,12 +67,7 @@ helm upgrade <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert
 ======
 endif::[]
 
-ifeval::["{build-type}" != "community"]
-=== Option B: Upgrade cert-manager with Internet Access
-endif::[]
-ifeval::["{build-type}" == "community"]
-=== Option A: Upgrade cert-manager with Internet Access
-endif::[]
+=== Upgrade cert-manager with Internet Access
 
 .Click to expand
 [%collapsible]
@@ -162,12 +156,7 @@ helm repo update
 +
 ======
 
-ifeval::["{build-type}" != "community"]
-=== Option C: Upgrade cert-manager in an Air-Gapped Environment
-endif::[]
-ifeval::["{build-type}" == "community"]
-=== Option B: Upgrade cert-manager in an Air-Gapped Environment
-endif::[]
+=== Upgrade cert-manager in an Air-Gapped Environment
 
 .Click to expand
 [%collapsible]
@@ -287,12 +276,7 @@ If you are running Kubernetes v1.15 or below, you will need to add the `--valida
 ----
 ======
 
-ifeval::["{build-type}" != "community"]
-=== Option D: Upgrade cert-manager from Versions 1.5 and Below
-endif::[]
-ifeval::["{build-type}" == "community"]
-=== Option C: Upgrade cert-manager from Versions 1.5 and Below
-endif::[]
+=== Upgrade cert-manager from Versions 1.5 and Below
 
 .Click to expand
 [%collapsible]

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2026-04-21
+:revdate: 2026-06-10
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/resources/upgrade-cert-manager.adoc 
 :product-path: installation-and-upgrade/resources/upgrade-cert-manager.adoc
@@ -269,6 +269,30 @@ Refer to the https://cert-manager.io/docs/usage/cmctl/#migrate-api-version[API v
 . Follow the Helm tutorial to https://helm.sh/docs/topics/kubernetes_apis/#updating-api-versions-of-a-release-manifest[update the API version of a release manifest]. The chart release name is `release_name=rancher` and the release namespace is `release_namespace=cattle-system`.
 . In the decoded file, search for `cert-manager.io/v1beta1` and *replace it* with `cert-manager.io/v1`.
 . Upgrade Rancher normally with `helm upgrade`.
+======
+
+=== Option D: Upgrade cert-manager Using SUSE Application Collection
+
+.Click to expand
+[%collapsible]
+======
+
+The cert-manager chart can be upgraded in-place using the Helm `upgrade` workflow to a https://apps.rancher.io/applications/cert-manager[specific version] listed in the SUSE Application Collection, below is an example command:
+
+[source,shell]
+----
+helm upgrade <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert-manager \
+  --set global.imagePullSecrets={application-collection}
+----
+
+To reuse the existing values and only upgrade the chart version:
+
+[source,shell]
+----
+helm upgrade <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert-manager \
+  --reuse-values
+----
+
 ======
 
 === Verify the Deployment

--- a/versions/v2.13/modules/en/pages/installation-and-upgrade/install-rancher.adoc
+++ b/versions/v2.13/modules/en/pages/installation-and-upgrade/install-rancher.adoc
@@ -240,7 +240,7 @@ helm install <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert
 If you are deploying in a cluster that requires FIPS cryptography compliance, you can substitute the chart path with `oci://dp.apps.rancher.io/charts/cert-manager-fips`.
 ====
 
-. Verify the Installation
+. Verify the Installation.
 +
 Once you've installed cert-manager, you can verify it is deployed correctly by checking the `cert-manager` namespace for running pods:
 +

--- a/versions/v2.13/modules/en/pages/installation-and-upgrade/install-rancher.adoc
+++ b/versions/v2.13/modules/en/pages/installation-and-upgrade/install-rancher.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2026-02-18
+:revdate: 2026-06-10
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/index.adoc 
 :product-path: installation-and-upgrade/install-rancher.adoc
@@ -189,6 +189,81 @@ There are three recommended options for the source of the certificate used for T
 
 === 4. Install cert-manager
 
+[tabs]
+=======
+Using SUSE Application Collection::
++
+--
+https://docs.apps.rancher.io/[SUSE Application Collection] provides a cert-manager chart that is compatible with Rancher. If you are using SUSE Application Collection, we recommend installing cert-manager using this option. 
+
+. Log in to the secure SUSE Application Collection registry:
++
+Before installing, https://docs.apps.rancher.io/get-started/authentication[authenticate your Helm CLI] against the Application Collection OCI registry using your enterprise credentials:
++
+[source,shell]
+----
+helm registry login dp.apps.rancher.io -u <username-or-service-account-username> -p <access-token-or-service-account-token>
+----
+
+. Create the target namespace `cert-manager`:
++
+[source,shell]
+----
+kubectl create namespace cert-manager
+----
+
+. Create the Image Pull Secret:
++
+Because the Application Collection is a private registry, your cluster's nodes need a secret to pull the images. Generate this secret in the `cert-manager` namespace:
++
+[source,shell]
+----
+kubectl create secret docker-registry application-collection \
+  --namespace cert-manager \
+  --docker-server=dp.apps.rancher.io \
+  --docker-username=<YOUR_APPCO_USERNAME> \
+  --docker-password=<YOUR_APPCO_TOKEN>
+----
+
+. Install cert-manager via the OCI chart path:
++
+Deploy the chart directly from the OCI registry path. Ensure you pass the `global.imagePullSecrets` flag so the pods can authenticate:
++
+[source,shell]
+----
+helm install <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert-manager \
+    --namespace cert-manager \
+    --set global.imagePullSecrets={application-collection} \
+    --set crds.enabled=true
+----
++
+[NOTE]
+====
+If you are deploying in a cluster that requires FIPS cryptography compliance, you can substitute the chart path with `oci://dp.apps.rancher.io/charts/cert-manager-fips`.
+====
+
+. Verify the Installation
++
+Once you've installed cert-manager, you can verify it is deployed correctly by checking the `cert-manager` namespace for running pods:
++
+[source,shell]
+----
+kubectl get pods --namespace cert-manager
+----
++
+[source,shell]
+----
+NAME                                       READY   STATUS    RESTARTS   AGE
+cert-manager-56cc584bd4-nhjx7              1/1     Running   0          3m
+cert-manager-cainjector-7cfc74b84b-kg7m2   1/1     Running   0          3m
+cert-manager-webhook-784f6dd68-69dvn       1/1     Running   0          3m
+----
+
+--
+
+Using Upstream Jetstack Helm Repository::
++
+--
 ____
 You should skip this step if you are bringing your own certificate files (option `ingress.tls.source=secret`), or if you use {xref-helm-chart-options}#_external_tls_termination[TLS termination on an external load balancer].
 ____
@@ -245,6 +320,9 @@ cert-manager-webhook-787858fcdb-nlzsq      1/1     Running   0          2m
 ----
 
 ======
+
+--
+=======
 
 === 5. Install Rancher with Helm and Your Chosen Certificate Option
 

--- a/versions/v2.13/modules/en/pages/installation-and-upgrade/install-rancher.adoc
+++ b/versions/v2.13/modules/en/pages/installation-and-upgrade/install-rancher.adoc
@@ -189,11 +189,9 @@ There are three recommended options for the source of the certificate used for T
 
 === 4. Install cert-manager
 
-[tabs]
-=======
-Using SUSE Application Collection::
-+
---
+ifeval::["{build-type}" != "community"]
+==== Using SUSE Application Collection
+
 https://docs.apps.rancher.io/[SUSE Application Collection] provides a cert-manager chart that is compatible with Rancher. If you are using SUSE Application Collection, we recommend installing cert-manager using this option. 
 
 . Log in to the secure SUSE Application Collection registry:
@@ -258,12 +256,10 @@ cert-manager-56cc584bd4-nhjx7              1/1     Running   0          3m
 cert-manager-cainjector-7cfc74b84b-kg7m2   1/1     Running   0          3m
 cert-manager-webhook-784f6dd68-69dvn       1/1     Running   0          3m
 ----
+endif::[]
 
---
+==== Using Upstream Jetstack Helm Repository
 
-Using Upstream Jetstack Helm Repository::
-+
---
 ____
 You should skip this step if you are bringing your own certificate files (option `ingress.tls.source=secret`), or if you use {xref-helm-chart-options}#_external_tls_termination[TLS termination on an external load balancer].
 ____
@@ -320,9 +316,6 @@ cert-manager-webhook-787858fcdb-nlzsq      1/1     Running   0          2m
 ----
 
 ======
-
---
-=======
 
 === 5. Install Rancher with Helm and Your Chosen Certificate Option
 

--- a/versions/v2.13/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
+++ b/versions/v2.13/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -171,7 +171,7 @@ Based on the choice your made in <<_2_choose_your_ssl_configuration,2. Choose yo
 ifeval::["{build-type}" != "community"]
 ===== Fetch from SUSE Application Collection
 
-Use this option to pull the security-hardened cert-manager chart listed in the https://apps.rancher.io/applications/cert-manager[SUSE Application Collection] available to Prime users.
+Use this option to pull the security-hardened cert-manager chart listed in the https://apps.rancher.io/applications/cert-manager[SUSE Application Collection] (AppCo) available to Prime users.
 
 . Log in to AppCo registry on an internet-connected machine:
 +

--- a/versions/v2.13/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
+++ b/versions/v2.13/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -168,6 +168,7 @@ Based on the choice your made in <<_2_choose_your_ssl_configuration,2. Choose yo
 
 ==== Option A: Default Self-Signed Certificate
 
+ifeval::["{build-type}" != "community"]
 ===== Fetch from SUSE Application Collection
 
 Use this option to pull the security-hardened cert-manager chart listed in the https://apps.rancher.io/applications/cert-manager[SUSE Application Collection] available to Prime users.
@@ -230,6 +231,7 @@ docker push <registry.internal.corp>/cert-manager-controller:<cert-manager-versi
 docker push <registry.internal.corp>/cert-manager-cainjector:<cert-manager-version>
 docker push <registry.internal.corp>/cert-manager-webhook:<cert-manager-version>
 ----
+endif::[]
 
 ===== Fetch from Upstream Helm Jetstack Repository
 
@@ -286,6 +288,7 @@ Install cert-manager with the same options you would use to install the chart. R
 To see options on how to customize the cert-manager install (including for cases where your cluster uses PodSecurityPolicies), see the https://artifacthub.io/packages/helm/cert-manager/cert-manager#configuration[cert-manager docs].
 ====
 
+ifeval::["{build-type}" != "community"]
 .Click to expand - SUSE Application Collection cert-manager Installation Instructions
 [%collapsible]
 ======
@@ -308,6 +311,7 @@ helm install cert-manager ./<cert-manager-version>.tgz \
   --set cainjector.image.repository=<registry.internal.corp>/cert-manager-cainjector
 ----
 ======
+endif::[]
 
 .Click to expand - Helm Jetstack cert-manager Installation Instructions
 [%collapsible]

--- a/versions/v2.13/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
+++ b/versions/v2.13/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2026-04-22
+:revdate: 2026-06-10
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/install-rancher-ha.adoc 
 :product-path: installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -168,6 +168,73 @@ Based on the choice your made in <<_2_choose_your_ssl_configuration,2. Choose yo
 
 ==== Option A: Default Self-Signed Certificate
 
+===== Fetch from SUSE Application Collection
+
+Use this option to pull the security-hardened cert-manager chart listed in the https://apps.rancher.io/applications/cert-manager[SUSE Application Collection] available to Prime users.
+
+====== 1. Log in to AppCo registry on an internet-connected machine:
+
+Use your https://docs.apps.rancher.io/get-started/authentication[enterprise credentials] to log in to the secure SUSE Application Collection registry:
+
+[source,shell]
+----
+helm registry login dp.apps.rancher.io -u <username-or-service-account-username> -p <access-token-or-service-account-token>
+----
+
+====== 2. Export and download the OCI chart archive:
+
+Use `helm pull` to download the chart directly from the OCI registry as a local tarball:
+
+[source,shell]
+----
+helm pull oci://dp.apps.rancher.io/charts/cert-manager --version <cert-manager-version>
+----
+
+This saves `cert-manager-<cert-manager-version>.tgz` to your current working directory.
+
+====== 3. Populate the Private Registry with AppCo Images
+
+Before installing cert-manager inside the air-gapped cluster, you must pull the secure container images from SUSE on your internet-connected machine, save them, transfer them via secure media (like a USB drive), and push them to your local registry.
+
+The below command pulls the secure container images from SUSE:
+
+[source,shell]
+----
+docker pull dp.apps.rancher.io/cert-manager-controller:<cert-manager-version>
+docker pull dp.apps.rancher.io/cert-manager-cainjector:<cert-manager-version>
+docker pull dp.apps.rancher.io/cert-manager-webhook:<cert-manager-version>
+----
+
+The below command saves, transfers, and retags the images for your internal air-gapped registry:
+
+[source,shell]
+----
+# Save to tarball
+docker save -o cert-manager-appco.tar \
+   dp.apps.rancher.io/cert-manager-controller:<cert-manager-version> \
+   dp.apps.rancher.io/cert-manager-cainjector:<cert-manager-version> \
+   dp.apps.rancher.io/cert-manager-webhook:<cert-manager-version>
+
+# Transfer the tar file and chart .tgz file into the air-gapped network
+
+# Load on air-gapped machine
+docker load -i cert-manager-appco.tar
+
+# Retag for your internal registry (e.g., registry.internal.corp)
+docker tag dp.apps.rancher.io/cert-manager-controller:<cert-manager-version> <registry.internal.corp>/cert-manager-controller:<cert-manager-version>
+docker tag dp.apps.rancher.io/cert-manager-cainjector:<cert-manager-version> <registry.internal.corp>/cert-manager-cainjector:<cert-manager-version>
+docker tag dp.apps.rancher.io/cert-manager-webhook:<cert-manager-version> <registry.internal.corp>/cert-manager-webhook:<cert-manager-version>
+
+# Push to internal registry
+docker push <registry.internal.corp>/cert-manager-controller:<cert-manager-version>
+docker push <registry.internal.corp>/cert-manager-cainjector:<cert-manager-version>
+docker push <registry.internal.corp>/cert-manager-webhook:<cert-manager-version>
+----
+
+===== Fetch from Upstream Helm Jetstack Repository
+
+Use this option to pull the community open-source chart.
+
 By default, Rancher generates a CA and uses cert-manager to issue the certificate for access to the Rancher server interface.
 
 [NOTE]
@@ -177,7 +244,7 @@ Recent changes to cert-manager require an upgrade. If you are upgrading Rancher 
 ====
 
 
-===== 1. Add the cert-manager Repo
+====== 1. Add the cert-manager Repo
 
 From a system connected to the internet, add the cert-manager repo to Helm:
 
@@ -187,7 +254,7 @@ helm repo add jetstack https://charts.jetstack.io
 helm repo update
 ----
 
-===== 2. Fetch the cert-manager Chart
+====== 2. Fetch the cert-manager Chart
 
 Fetch the latest cert-manager chart available from the https://artifacthub.io/packages/helm/cert-manager/cert-manager[Helm chart repository].
 
@@ -196,7 +263,7 @@ Fetch the latest cert-manager chart available from the https://artifacthub.io/pa
 helm fetch jetstack/cert-manager --version v1.11.0
 ----
 
-===== 3. Retrieve the cert-manager CRDs
+====== 3. Retrieve the cert-manager CRDs
 
 Download the required CRD file for cert-manager:
 
@@ -219,8 +286,30 @@ Install cert-manager with the same options you would use to install the chart. R
 To see options on how to customize the cert-manager install (including for cases where your cluster uses PodSecurityPolicies), see the https://artifacthub.io/packages/helm/cert-manager/cert-manager#configuration[cert-manager docs].
 ====
 
+.Click to expand - SUSE Application Collection cert-manager Installation Instructions
+[%collapsible]
+======
+. Create the namespace.
++
+[source,shell]
+----
+kubectl create namespace cert-manager
+----
 
-.Click to expand
+. Install using the local chart tarball file.
++
+[source,shell]
+----
+helm install cert-manager ./<cert-manager-version>.tgz \
+  --namespace cert-manager \
+  --set installCRDs=true \
+  --set image.repository=<registry.internal.corp>/cert-manager-controller \
+  --set webhook.image.repository=<registry.internal.corp>/cert-manager-webhook \
+  --set cainjector.image.repository=<registry.internal.corp>/cert-manager-cainjector
+----
+======
+
+.Click to expand - Helm Jetstack cert-manager Installation Instructions
 [%collapsible]
 ======
 If you are using self-signed certificates, install cert-manager:

--- a/versions/v2.13/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
+++ b/versions/v2.13/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -173,41 +173,41 @@ ifeval::["{build-type}" != "community"]
 
 Use this option to pull the security-hardened cert-manager chart listed in the https://apps.rancher.io/applications/cert-manager[SUSE Application Collection] available to Prime users.
 
-====== 1. Log in to AppCo registry on an internet-connected machine:
-
+. Log in to AppCo registry on an internet-connected machine:
++
 Use your https://docs.apps.rancher.io/get-started/authentication[enterprise credentials] to log in to the secure SUSE Application Collection registry:
-
++
 [source,shell]
 ----
 helm registry login dp.apps.rancher.io -u <username-or-service-account-username> -p <access-token-or-service-account-token>
 ----
 
-====== 2. Export and download the OCI chart archive:
-
+. Export and download the OCI chart archive:
++
 Use `helm pull` to download the chart directly from the OCI registry as a local tarball:
-
++
 [source,shell]
 ----
 helm pull oci://dp.apps.rancher.io/charts/cert-manager --version <cert-manager-version>
 ----
-
++
 This saves `cert-manager-<cert-manager-version>.tgz` to your current working directory.
 
-====== 3. Populate the Private Registry with AppCo Images
-
+. Populate the Private Registry with AppCo Images.
++
 Before installing cert-manager inside the air-gapped cluster, you must pull the secure container images from SUSE on your internet-connected machine, save them, transfer them via secure media (like a USB drive), and push them to your local registry.
-
++
 The below command pulls the secure container images from SUSE:
-
++
 [source,shell]
 ----
 docker pull dp.apps.rancher.io/cert-manager-controller:<cert-manager-version>
 docker pull dp.apps.rancher.io/cert-manager-cainjector:<cert-manager-version>
 docker pull dp.apps.rancher.io/cert-manager-webhook:<cert-manager-version>
 ----
-
++
 The below command saves, transfers, and retags the images for your internal air-gapped registry:
-
++
 [source,shell]
 ----
 # Save to tarball
@@ -246,29 +246,29 @@ Recent changes to cert-manager require an upgrade. If you are upgrading Rancher 
 ====
 
 
-====== 1. Add the cert-manager Repo
-
+. Add the cert-manager Repo.
++
 From a system connected to the internet, add the cert-manager repo to Helm:
-
++
 [,plain]
 ----
 helm repo add jetstack https://charts.jetstack.io
 helm repo update
 ----
 
-====== 2. Fetch the cert-manager Chart
-
+. Fetch the cert-manager Chart.
++
 Fetch the latest cert-manager chart available from the https://artifacthub.io/packages/helm/cert-manager/cert-manager[Helm chart repository].
-
++
 [,plain]
 ----
 helm fetch jetstack/cert-manager --version v1.11.0
 ----
 
-====== 3. Retrieve the cert-manager CRDs
-
+. Retrieve the cert-manager CRDs.
++
 Download the required CRD file for cert-manager:
-
++
 [,plain]
 ----
    curl -L -o cert-manager-crd.yaml https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cert-manager.crds.yaml

--- a/versions/v2.13/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
+++ b/versions/v2.13/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
@@ -32,11 +32,9 @@ sudo ./get_helm.sh
 
 == Install cert-manager
 
-[tabs]
-======
-Using SUSE Application Collection::
-+
---
+ifeval::["{build-type}" != "community"]
+=== Using SUSE Application Collection
+
 https://docs.apps.rancher.io/[SUSE Application Collection] provides a cert-manager chart that is compatible with Rancher. If you are using SUSE Application Collection, we recommend installing cert-manager using this option. 
 
 . Log in to the secure SUSE Application Collection registry:
@@ -101,12 +99,10 @@ cert-manager-56cc584bd4-nhjx7              1/1     Running   0          3m
 cert-manager-cainjector-7cfc74b84b-kg7m2   1/1     Running   0          3m
 cert-manager-webhook-784f6dd68-69dvn       1/1     Running   0          3m
 ----
+endif::[]
 
---
+=== Using Upstream Jetstack Helm Repository
 
-Using Upstream Jetstack Helm Repository::
-+
---
 Add the cert-manager Helm repository:
 
 ----
@@ -148,8 +144,6 @@ Now you should wait until cert-manager is finished starting up:
 kubectl rollout status deployment -n cert-manager cert-manager
 kubectl rollout status deployment -n cert-manager cert-manager-webhook
 ----
---
-======
 
 == Install {rancher-product-name}
 

--- a/versions/v2.13/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
+++ b/versions/v2.13/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
@@ -83,7 +83,7 @@ helm install <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert
 If you are deploying in a cluster that requires FIPS cryptography compliance, you can substitute the chart path with `oci://dp.apps.rancher.io/charts/cert-manager-fips`.
 ====
 
-. Verify the Installation
+. Verify the Installation.
 +
 Once you've installed cert-manager, you can verify it is deployed correctly by checking the `cert-manager` namespace for running pods:
 +

--- a/versions/v2.13/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
+++ b/versions/v2.13/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2026-04-21
+:revdate: 2026-06-10
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/install-rancher.adoc 
 :product-path: installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
@@ -32,6 +32,81 @@ sudo ./get_helm.sh
 
 == Install cert-manager
 
+[tabs]
+======
+Using SUSE Application Collection::
++
+--
+https://docs.apps.rancher.io/[SUSE Application Collection] provides a cert-manager chart that is compatible with Rancher. If you are using SUSE Application Collection, we recommend installing cert-manager using this option. 
+
+. Log in to the secure SUSE Application Collection registry:
++
+Before installing, https://docs.apps.rancher.io/get-started/authentication[authenticate your Helm CLI] against the Application Collection OCI registry using your enterprise credentials:
++
+[source,shell]
+----
+helm registry login dp.apps.rancher.io -u <username-or-service-account-username> -p <access-token-or-service-account-token>
+----
+
+. Create the target namespace `cert-manager`:
++
+[source,shell]
+----
+kubectl create namespace cert-manager
+----
+
+. Create the Image Pull Secret:
++
+Because the Application Collection is a private registry, your cluster's nodes need a secret to pull the images. Generate this secret in the `cert-manager` namespace:
++
+[source,shell]
+----
+kubectl create secret docker-registry application-collection \
+  --namespace cert-manager \
+  --docker-server=dp.apps.rancher.io \
+  --docker-username=<YOUR_APPCO_USERNAME> \
+  --docker-password=<YOUR_APPCO_TOKEN>
+----
+
+. Install cert-manager via the OCI chart path:
++
+Deploy the chart directly from the OCI registry path. Ensure you pass the `global.imagePullSecrets` flag so the pods can authenticate:
++
+[source,shell]
+----
+helm install <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert-manager \
+    --namespace cert-manager \
+    --set global.imagePullSecrets={application-collection} \
+    --set crds.enabled=true
+----
++
+[NOTE]
+====
+If you are deploying in a cluster that requires FIPS cryptography compliance, you can substitute the chart path with `oci://dp.apps.rancher.io/charts/cert-manager-fips`.
+====
+
+. Verify the Installation
++
+Once you've installed cert-manager, you can verify it is deployed correctly by checking the `cert-manager` namespace for running pods:
++
+[source,shell]
+----
+kubectl get pods --namespace cert-manager
+----
++
+[source,shell]
+----
+NAME                                       READY   STATUS    RESTARTS   AGE
+cert-manager-56cc584bd4-nhjx7              1/1     Running   0          3m
+cert-manager-cainjector-7cfc74b84b-kg7m2   1/1     Running   0          3m
+cert-manager-webhook-784f6dd68-69dvn       1/1     Running   0          3m
+----
+
+--
+
+Using Upstream Jetstack Helm Repository::
++
+--
 Add the cert-manager Helm repository:
 
 ----
@@ -73,6 +148,8 @@ Now you should wait until cert-manager is finished starting up:
 kubectl rollout status deployment -n cert-manager cert-manager
 kubectl rollout status deployment -n cert-manager cert-manager-webhook
 ----
+--
+======
 
 == Install {rancher-product-name}
 

--- a/versions/v2.13/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
+++ b/versions/v2.13/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
@@ -271,6 +271,7 @@ Refer to the https://cert-manager.io/docs/usage/cmctl/#migrate-api-version[API v
 . Upgrade Rancher normally with `helm upgrade`.
 ======
 
+ifeval::["{build-type}" != "community"]
 === Option D: Upgrade cert-manager Using SUSE Application Collection
 
 .Click to expand
@@ -294,6 +295,7 @@ helm upgrade <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert
 ----
 
 ======
+endif::[]
 
 === Verify the Deployment
 

--- a/versions/v2.13/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
+++ b/versions/v2.13/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
@@ -42,7 +42,38 @@ The namespace used in these instructions depends on the namespace cert-manager i
 
 In order to upgrade cert-manager, follow these instructions:
 
+ifeval::["{build-type}" != "community"]
+=== Option A: Upgrade cert-manager Using SUSE Application Collection
+
+.Click to expand
+[%collapsible]
+======
+
+The cert-manager chart can be upgraded in-place using the Helm `upgrade` workflow to a https://apps.rancher.io/applications/cert-manager[specific version] listed in the SUSE Application Collection, below is an example command:
+
+[source,shell]
+----
+helm upgrade <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert-manager \
+  --set global.imagePullSecrets={application-collection}
+----
+
+To reuse the existing values and only upgrade the chart version:
+
+[source,shell]
+----
+helm upgrade <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert-manager \
+  --reuse-values
+----
+
+======
+endif::[]
+
+ifeval::["{build-type}" != "community"]
+=== Option B: Upgrade cert-manager with Internet Access
+endif::[]
+ifeval::["{build-type}" == "community"]
 === Option A: Upgrade cert-manager with Internet Access
+endif::[]
 
 .Click to expand
 [%collapsible]
@@ -131,13 +162,20 @@ helm repo update
 +
 ======
 
+ifeval::["{build-type}" != "community"]
+=== Option C: Upgrade cert-manager in an Air-Gapped Environment
+endif::[]
+ifeval::["{build-type}" == "community"]
 === Option B: Upgrade cert-manager in an Air-Gapped Environment
+endif::[]
 
 .Click to expand
 [%collapsible]
 ======
 
-=== Prerequisites
+[#_prerequisites]
+[pass]
+<h3><a id="_prerequisites"></a>Prerequisites</h3>
 
 Before you can perform the upgrade, you must prepare your air gapped environment by adding the necessary container images to your private registry and downloading or rendering the required Kubernetes manifest files.
 
@@ -249,7 +287,12 @@ If you are running Kubernetes v1.15 or below, you will need to add the `--valida
 ----
 ======
 
+ifeval::["{build-type}" != "community"]
+=== Option D: Upgrade cert-manager from Versions 1.5 and Below
+endif::[]
+ifeval::["{build-type}" == "community"]
 === Option C: Upgrade cert-manager from Versions 1.5 and Below
+endif::[]
 
 .Click to expand
 [%collapsible]
@@ -270,32 +313,6 @@ Refer to the https://cert-manager.io/docs/usage/cmctl/#migrate-api-version[API v
 . In the decoded file, search for `cert-manager.io/v1beta1` and *replace it* with `cert-manager.io/v1`.
 . Upgrade Rancher normally with `helm upgrade`.
 ======
-
-ifeval::["{build-type}" != "community"]
-=== Option D: Upgrade cert-manager Using SUSE Application Collection
-
-.Click to expand
-[%collapsible]
-======
-
-The cert-manager chart can be upgraded in-place using the Helm `upgrade` workflow to a https://apps.rancher.io/applications/cert-manager[specific version] listed in the SUSE Application Collection, below is an example command:
-
-[source,shell]
-----
-helm upgrade <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert-manager \
-  --set global.imagePullSecrets={application-collection}
-----
-
-To reuse the existing values and only upgrade the chart version:
-
-[source,shell]
-----
-helm upgrade <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert-manager \
-  --reuse-values
-----
-
-======
-endif::[]
 
 === Verify the Deployment
 

--- a/versions/v2.13/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
+++ b/versions/v2.13/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
@@ -31,19 +31,18 @@ To address these changes, this guide will do two things:
 [NOTE]
 .Important:
 ====
-
-If you are upgrading cert-manager to the latest version from a version older than 1.5, follow the steps in <<_option_c_upgrade_cert_manager_from_versions_1_5_and_below,Option C>> below to do so. Note that you do not need to reinstall Rancher to perform this upgrade.
+If you are upgrading cert-manager to the latest version from a version older than 1.5, follow the steps via the method <<_upgrade_cert_manager_from_versions_1_5_and_below,Upgrade cert-manager from Versions 1.5 and Below>>. Note that you do not need to reinstall Rancher to perform this upgrade.
 ====
 
 
-== Upgrade Cert-Manager
+== cert-manager Upgrade Methods
 
 The namespace used in these instructions depends on the namespace cert-manager is currently installed in. If it is in kube-system use that in the instructions below. You can verify by running `kubectl get pods --all-namespaces` and checking which namespace the cert-manager-* pods are listed in. Do not change the namespace cert-manager is running in or this can cause issues.
 
 In order to upgrade cert-manager, follow these instructions:
 
 ifeval::["{build-type}" != "community"]
-=== Option A: Upgrade cert-manager Using SUSE Application Collection
+=== Upgrade cert-manager Using SUSE Application Collection
 
 .Click to expand
 [%collapsible]
@@ -68,12 +67,7 @@ helm upgrade <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert
 ======
 endif::[]
 
-ifeval::["{build-type}" != "community"]
-=== Option B: Upgrade cert-manager with Internet Access
-endif::[]
-ifeval::["{build-type}" == "community"]
-=== Option A: Upgrade cert-manager with Internet Access
-endif::[]
+=== Upgrade cert-manager with Internet Access
 
 .Click to expand
 [%collapsible]
@@ -162,12 +156,7 @@ helm repo update
 +
 ======
 
-ifeval::["{build-type}" != "community"]
-=== Option C: Upgrade cert-manager in an Air-Gapped Environment
-endif::[]
-ifeval::["{build-type}" == "community"]
-=== Option B: Upgrade cert-manager in an Air-Gapped Environment
-endif::[]
+=== Upgrade cert-manager in an Air-Gapped Environment
 
 .Click to expand
 [%collapsible]
@@ -287,12 +276,7 @@ If you are running Kubernetes v1.15 or below, you will need to add the `--valida
 ----
 ======
 
-ifeval::["{build-type}" != "community"]
-=== Option D: Upgrade cert-manager from Versions 1.5 and Below
-endif::[]
-ifeval::["{build-type}" == "community"]
-=== Option C: Upgrade cert-manager from Versions 1.5 and Below
-endif::[]
+=== Upgrade cert-manager from Versions 1.5 and Below
 
 .Click to expand
 [%collapsible]

--- a/versions/v2.13/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
+++ b/versions/v2.13/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2026-04-21
+:revdate: 2026-06-10
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/resources/upgrade-cert-manager.adoc 
 :product-path: installation-and-upgrade/resources/upgrade-cert-manager.adoc
@@ -269,6 +269,30 @@ Refer to the https://cert-manager.io/docs/usage/cmctl/#migrate-api-version[API v
 . Follow the Helm tutorial to https://helm.sh/docs/topics/kubernetes_apis/#updating-api-versions-of-a-release-manifest[update the API version of a release manifest]. The chart release name is `release_name=rancher` and the release namespace is `release_namespace=cattle-system`.
 . In the decoded file, search for `cert-manager.io/v1beta1` and *replace it* with `cert-manager.io/v1`.
 . Upgrade Rancher normally with `helm upgrade`.
+======
+
+=== Option D: Upgrade cert-manager Using SUSE Application Collection
+
+.Click to expand
+[%collapsible]
+======
+
+The cert-manager chart can be upgraded in-place using the Helm `upgrade` workflow to a https://apps.rancher.io/applications/cert-manager[specific version] listed in the SUSE Application Collection, below is an example command:
+
+[source,shell]
+----
+helm upgrade <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert-manager \
+  --set global.imagePullSecrets={application-collection}
+----
+
+To reuse the existing values and only upgrade the chart version:
+
+[source,shell]
+----
+helm upgrade <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert-manager \
+  --reuse-values
+----
+
 ======
 
 === Verify the Deployment

--- a/versions/v2.14/modules/en/pages/installation-and-upgrade/install-rancher.adoc
+++ b/versions/v2.14/modules/en/pages/installation-and-upgrade/install-rancher.adoc
@@ -250,7 +250,7 @@ helm install <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert
 If you are deploying in a cluster that requires FIPS cryptography compliance, you can substitute the chart path with `oci://dp.apps.rancher.io/charts/cert-manager-fips`.
 ====
 
-. Verify the Installation
+. Verify the Installation.
 +
 Once you've installed cert-manager, you can verify it is deployed correctly by checking the `cert-manager` namespace for running pods:
 +

--- a/versions/v2.14/modules/en/pages/installation-and-upgrade/install-rancher.adoc
+++ b/versions/v2.14/modules/en/pages/installation-and-upgrade/install-rancher.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, de, es, fr, ja, pt, zh]
 endif::[]
-:revdate: 2026-04-16
+:revdate: 2026-06-10
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/index.adoc 
 :product-path: installation-and-upgrade/install-rancher.adoc
@@ -198,6 +198,81 @@ There are three recommended options for the source of the certificate used for T
 [#_4_install_cert_manager]
 === 4. Install cert-manager
 
+[tabs]
+=======
+Using SUSE Application Collection::
++
+--
+https://docs.apps.rancher.io/[SUSE Application Collection] provides a cert-manager chart that is compatible with Rancher. If you are using SUSE Application Collection, we recommend installing cert-manager using this option. 
+
+. Log in to the secure SUSE Application Collection registry:
++
+Before installing, https://docs.apps.rancher.io/get-started/authentication[authenticate your Helm CLI] against the Application Collection OCI registry using your enterprise credentials:
++
+[source,shell]
+----
+helm registry login dp.apps.rancher.io -u <username-or-service-account-username> -p <access-token-or-service-account-token>
+----
+
+. Create the target namespace `cert-manager`:
++
+[source,shell]
+----
+kubectl create namespace cert-manager
+----
+
+. Create the Image Pull Secret:
++
+Because the Application Collection is a private registry, your cluster's nodes need a secret to pull the images. Generate this secret in the `cert-manager` namespace:
++
+[source,shell]
+----
+kubectl create secret docker-registry application-collection \
+  --namespace cert-manager \
+  --docker-server=dp.apps.rancher.io \
+  --docker-username=<YOUR_APPCO_USERNAME> \
+  --docker-password=<YOUR_APPCO_TOKEN>
+----
+
+. Install cert-manager via the OCI chart path:
++
+Deploy the chart directly from the OCI registry path. Ensure you pass the `global.imagePullSecrets` flag so the pods can authenticate:
++
+[source,shell]
+----
+helm install <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert-manager \
+    --namespace cert-manager \
+    --set global.imagePullSecrets={application-collection} \
+    --set crds.enabled=true
+----
++
+[NOTE]
+====
+If you are deploying in a cluster that requires FIPS cryptography compliance, you can substitute the chart path with `oci://dp.apps.rancher.io/charts/cert-manager-fips`.
+====
+
+. Verify the Installation
++
+Once you've installed cert-manager, you can verify it is deployed correctly by checking the `cert-manager` namespace for running pods:
++
+[source,shell]
+----
+kubectl get pods --namespace cert-manager
+----
++
+[source,shell]
+----
+NAME                                       READY   STATUS    RESTARTS   AGE
+cert-manager-56cc584bd4-nhjx7              1/1     Running   0          3m
+cert-manager-cainjector-7cfc74b84b-kg7m2   1/1     Running   0          3m
+cert-manager-webhook-784f6dd68-69dvn       1/1     Running   0          3m
+----
+
+--
+
+Using Upstream Jetstack Helm Repository::
++
+--
 ____
 You should skip this step if you are bringing your own certificate files (option `ingress.tls.source=secret`), or if you use {xref-helm-chart-options}#_external_tls_termination[TLS termination on an external load balancer].
 ____
@@ -254,6 +329,9 @@ cert-manager-webhook-787858fcdb-nlzsq      1/1     Running   0          2m
 ----
 
 ======
+
+--
+=======
 
 [#_5_install_rancher_with_helm_and_your_chosen_certificate_option]
 === 5. Install Rancher with Helm and Your Chosen Certificate Option

--- a/versions/v2.14/modules/en/pages/installation-and-upgrade/install-rancher.adoc
+++ b/versions/v2.14/modules/en/pages/installation-and-upgrade/install-rancher.adoc
@@ -198,11 +198,10 @@ There are three recommended options for the source of the certificate used for T
 [#_4_install_cert_manager]
 === 4. Install cert-manager
 
-[tabs]
-=======
-Using SUSE Application Collection::
-+
---
+ifeval::["{build-type}" != "community"]
+[#_using_suse_application_collection]
+==== Using SUSE Application Collection
+
 https://docs.apps.rancher.io/[SUSE Application Collection] provides a cert-manager chart that is compatible with Rancher. If you are using SUSE Application Collection, we recommend installing cert-manager using this option. 
 
 . Log in to the secure SUSE Application Collection registry:
@@ -267,12 +266,11 @@ cert-manager-56cc584bd4-nhjx7              1/1     Running   0          3m
 cert-manager-cainjector-7cfc74b84b-kg7m2   1/1     Running   0          3m
 cert-manager-webhook-784f6dd68-69dvn       1/1     Running   0          3m
 ----
+endif::[]
 
---
+[#_using_upstream_jetstack_helm_repository]
+==== Using Upstream Jetstack Helm Repository
 
-Using Upstream Jetstack Helm Repository::
-+
---
 ____
 You should skip this step if you are bringing your own certificate files (option `ingress.tls.source=secret`), or if you use {xref-helm-chart-options}#_external_tls_termination[TLS termination on an external load balancer].
 ____
@@ -329,9 +327,6 @@ cert-manager-webhook-787858fcdb-nlzsq      1/1     Running   0          2m
 ----
 
 ======
-
---
-=======
 
 [#_5_install_rancher_with_helm_and_your_chosen_certificate_option]
 === 5. Install Rancher with Helm and Your Chosen Certificate Option

--- a/versions/v2.14/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
+++ b/versions/v2.14/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -170,6 +170,7 @@ Based on the choice your made in <<_2_choose_your_ssl_configuration,2. Choose yo
 [#_option_a_default_self_signed_certificate]
 ==== Option A: Default Self-Signed Certificate
 
+ifeval::["{build-type}" != "community"]
 [#_fetch_from_suse_application_collection]
 ===== Fetch from SUSE Application Collection
 
@@ -236,6 +237,7 @@ docker push <registry.internal.corp>/cert-manager-controller:<cert-manager-versi
 docker push <registry.internal.corp>/cert-manager-cainjector:<cert-manager-version>
 docker push <registry.internal.corp>/cert-manager-webhook:<cert-manager-version>
 ----
+endif::[]
 
 [#_fetch_from_upstream_helm_jetstack_repository]
 ===== Fetch from Upstream Helm Jetstack Repository
@@ -298,6 +300,7 @@ Install cert-manager with the same options you would use to install the chart. R
 To see options on how to customize the cert-manager install (including for cases where your cluster uses PodSecurityPolicies), see the https://artifacthub.io/packages/helm/cert-manager/cert-manager#configuration[cert-manager docs].
 ====
 
+ifeval::["{build-type}" != "community"]
 .Click to expand - SUSE Application Collection cert-manager Installation Instructions
 [%collapsible]
 ======
@@ -320,6 +323,7 @@ helm install cert-manager ./<cert-manager-version>.tgz \
   --set cainjector.image.repository=<registry.internal.corp>/cert-manager-cainjector
 ----
 ======
+endif::[]
 
 .Click to expand - Helm Jetstack cert-manager Installation Instructions
 [%collapsible]

--- a/versions/v2.14/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
+++ b/versions/v2.14/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -174,7 +174,7 @@ ifeval::["{build-type}" != "community"]
 [#_fetch_from_suse_application_collection]
 ===== Fetch from SUSE Application Collection
 
-Use this option to pull the security-hardened cert-manager chart listed in the https://apps.rancher.io/applications/cert-manager[SUSE Application Collection] available to Prime users.
+Use this option to pull the security-hardened cert-manager chart listed in the https://apps.rancher.io/applications/cert-manager[SUSE Application Collection] (AppCo) available to Prime users.
 
 . Log in to AppCo registry on an internet-connected machine:
 +

--- a/versions/v2.14/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
+++ b/versions/v2.14/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, de, es, fr, ja, pt, zh]
 endif::[]
-:revdate: 2026-04-22
+:revdate: 2026-06-10
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/install-rancher-ha.adoc 
 :product-path: installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -170,6 +170,78 @@ Based on the choice your made in <<_2_choose_your_ssl_configuration,2. Choose yo
 [#_option_a_default_self_signed_certificate]
 ==== Option A: Default Self-Signed Certificate
 
+[#_fetch_from_suse_application_collection]
+===== Fetch from SUSE Application Collection
+
+Use this option to pull the security-hardened cert-manager chart listed in the https://apps.rancher.io/applications/cert-manager[SUSE Application Collection] available to Prime users.
+
+[#_1_log_in_to_appco_registry_on_an_internet_connected_machine]
+====== 1. Log in to AppCo registry on an internet-connected machine:
+
+Use your https://docs.apps.rancher.io/get-started/authentication[enterprise credentials] to log in to the secure SUSE Application Collection registry:
+
+[source,shell]
+----
+helm registry login dp.apps.rancher.io -u <username-or-service-account-username> -p <access-token-or-service-account-token>
+----
+
+[#_2_export_and_download_the_oci_chart_archive]
+====== 2. Export and download the OCI chart archive:
+
+Use `helm pull` to download the chart directly from the OCI registry as a local tarball:
+
+[source,shell]
+----
+helm pull oci://dp.apps.rancher.io/charts/cert-manager --version <cert-manager-version>
+----
+
+This saves `cert-manager-<cert-manager-version>.tgz` to your current working directory.
+
+[#_3_populate_the_private_registry_with_appco_images]
+====== 3. Populate the Private Registry with AppCo Images
+
+Before installing cert-manager inside the air-gapped cluster, you must pull the secure container images from SUSE on your internet-connected machine, save them, transfer them via secure media (like a USB drive), and push them to your local registry.
+
+The below command pulls the secure container images from SUSE:
+
+[source,shell]
+----
+docker pull dp.apps.rancher.io/cert-manager-controller:<cert-manager-version>
+docker pull dp.apps.rancher.io/cert-manager-cainjector:<cert-manager-version>
+docker pull dp.apps.rancher.io/cert-manager-webhook:<cert-manager-version>
+----
+
+The below command saves, transfers, and retags the images for your internal air-gapped registry:
+
+[source,shell]
+----
+# Save to tarball
+docker save -o cert-manager-appco.tar \
+   dp.apps.rancher.io/cert-manager-controller:<cert-manager-version> \
+   dp.apps.rancher.io/cert-manager-cainjector:<cert-manager-version> \
+   dp.apps.rancher.io/cert-manager-webhook:<cert-manager-version>
+
+# Transfer the tar file and chart .tgz file into the air-gapped network
+
+# Load on air-gapped machine
+docker load -i cert-manager-appco.tar
+
+# Retag for your internal registry (e.g., registry.internal.corp)
+docker tag dp.apps.rancher.io/cert-manager-controller:<cert-manager-version> registry.internal.corp/cert-manager-controller:<cert-manager-version>
+docker tag dp.apps.rancher.io/cert-manager-cainjector:<cert-manager-version> registry.internal.corp/cert-manager-cainjector:<cert-manager-version>
+docker tag dp.apps.rancher.io/cert-manager-webhook:<cert-manager-version> registry.internal.corp/cert-manager-webhook:<cert-manager-version>
+
+# Push to internal registry
+docker push registry.internal.corp/cert-manager-controller:<cert-manager-version>
+docker push registry.internal.corp/cert-manager-cainjector:<cert-manager-version>
+docker push registry.internal.corp/cert-manager-webhook:<cert-manager-version>
+----
+
+[#_fetch_from_upstream_helm_jetstack_repository]
+===== Fetch from Upstream Helm Jetstack Repository
+
+Use this option to pull the community open-source chart.
+
 By default, Rancher generates a CA and uses cert-manager to issue the certificate for access to the Rancher server interface.
 
 [NOTE]
@@ -180,7 +252,7 @@ Recent changes to cert-manager require an upgrade. If you are upgrading Rancher 
 
 
 [#_1_add_the_cert_manager_repo]
-===== 1. Add the cert-manager Repo
+====== 1. Add the cert-manager Repo
 
 From a system connected to the internet, add the cert-manager repo to Helm:
 
@@ -191,7 +263,7 @@ helm repo update
 ----
 
 [#_2_fetch_the_cert_manager_chart]
-===== 2. Fetch the cert-manager Chart
+====== 2. Fetch the cert-manager Chart
 
 Fetch the latest cert-manager chart available from the https://artifacthub.io/packages/helm/cert-manager/cert-manager[Helm chart repository].
 
@@ -201,7 +273,7 @@ helm fetch jetstack/cert-manager --version v1.11.0
 ----
 
 [#_3_retrieve_the_cert_manager_crds]
-===== 3. Retrieve the cert-manager CRDs
+====== 3. Retrieve the cert-manager CRDs
 
 Download the required CRD file for cert-manager:
 
@@ -226,8 +298,30 @@ Install cert-manager with the same options you would use to install the chart. R
 To see options on how to customize the cert-manager install (including for cases where your cluster uses PodSecurityPolicies), see the https://artifacthub.io/packages/helm/cert-manager/cert-manager#configuration[cert-manager docs].
 ====
 
+.Click to expand - SUSE Application Collection cert-manager Installation Instructions
+[%collapsible]
+======
+. Create the namespace.
++
+[source,shell]
+----
+kubectl create namespace cert-manager
+----
 
-.Click to expand
+. Install using the local chart tarball file.
++
+[source,shell]
+----
+helm install cert-manager ./cert-manager-1.14.0.tgz \
+  --namespace cert-manager \
+  --set installCRDs=true \
+  --set image.repository=registry.internal.corp/cert-manager-controller \
+  --set webhook.image.repository=registry.internal.corp/cert-manager-webhook \
+  --set cainjector.image.repository=registry.internal.corp/cert-manager-cainjector
+----
+======
+
+.Click to expand - Helm Jetstack cert-manager Installation Instructions
 [%collapsible]
 ======
 If you are using self-signed certificates, install cert-manager:

--- a/versions/v2.14/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
+++ b/versions/v2.14/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -176,44 +176,41 @@ ifeval::["{build-type}" != "community"]
 
 Use this option to pull the security-hardened cert-manager chart listed in the https://apps.rancher.io/applications/cert-manager[SUSE Application Collection] available to Prime users.
 
-[#_1_log_in_to_appco_registry_on_an_internet_connected_machine]
-====== 1. Log in to AppCo registry on an internet-connected machine:
-
+. Log in to AppCo registry on an internet-connected machine:
++
 Use your https://docs.apps.rancher.io/get-started/authentication[enterprise credentials] to log in to the secure SUSE Application Collection registry:
-
++
 [source,shell]
 ----
 helm registry login dp.apps.rancher.io -u <username-or-service-account-username> -p <access-token-or-service-account-token>
 ----
 
-[#_2_export_and_download_the_oci_chart_archive]
-====== 2. Export and download the OCI chart archive:
-
+. Export and download the OCI chart archive:
++
 Use `helm pull` to download the chart directly from the OCI registry as a local tarball:
-
++
 [source,shell]
 ----
 helm pull oci://dp.apps.rancher.io/charts/cert-manager --version <cert-manager-version>
 ----
-
++
 This saves `cert-manager-<cert-manager-version>.tgz` to your current working directory.
 
-[#_3_populate_the_private_registry_with_appco_images]
-====== 3. Populate the Private Registry with AppCo Images
-
+. Populate the Private Registry with AppCo Images.
++
 Before installing cert-manager inside the air-gapped cluster, you must pull the secure container images from SUSE on your internet-connected machine, save them, transfer them via secure media (like a USB drive), and push them to your local registry.
-
++
 The below command pulls the secure container images from SUSE:
-
++
 [source,shell]
 ----
 docker pull dp.apps.rancher.io/cert-manager-controller:<cert-manager-version>
 docker pull dp.apps.rancher.io/cert-manager-cainjector:<cert-manager-version>
 docker pull dp.apps.rancher.io/cert-manager-webhook:<cert-manager-version>
 ----
-
++
 The below command saves, transfers, and retags the images for your internal air-gapped registry:
-
++
 [source,shell]
 ----
 # Save to tarball
@@ -253,32 +250,29 @@ Recent changes to cert-manager require an upgrade. If you are upgrading Rancher 
 ====
 
 
-[#_1_add_the_cert_manager_repo]
-====== 1. Add the cert-manager Repo
-
+. Add the cert-manager Repo.
++
 From a system connected to the internet, add the cert-manager repo to Helm:
-
++
 [,plain]
 ----
 helm repo add jetstack https://charts.jetstack.io
 helm repo update
 ----
 
-[#_2_fetch_the_cert_manager_chart]
-====== 2. Fetch the cert-manager Chart
-
+. Fetch the cert-manager Chart.
++
 Fetch the latest cert-manager chart available from the https://artifacthub.io/packages/helm/cert-manager/cert-manager[Helm chart repository].
-
++
 [,plain]
 ----
 helm fetch jetstack/cert-manager --version v1.11.0
 ----
 
-[#_3_retrieve_the_cert_manager_crds]
-====== 3. Retrieve the cert-manager CRDs
-
+. Retrieve the cert-manager CRDs.
++
 Download the required CRD file for cert-manager:
-
++
 [,plain]
 ----
    curl -L -o cert-manager-crd.yaml https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cert-manager.crds.yaml

--- a/versions/v2.14/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
+++ b/versions/v2.14/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -227,14 +227,14 @@ docker save -o cert-manager-appco.tar \
 docker load -i cert-manager-appco.tar
 
 # Retag for your internal registry (e.g., registry.internal.corp)
-docker tag dp.apps.rancher.io/cert-manager-controller:<cert-manager-version> registry.internal.corp/cert-manager-controller:<cert-manager-version>
-docker tag dp.apps.rancher.io/cert-manager-cainjector:<cert-manager-version> registry.internal.corp/cert-manager-cainjector:<cert-manager-version>
-docker tag dp.apps.rancher.io/cert-manager-webhook:<cert-manager-version> registry.internal.corp/cert-manager-webhook:<cert-manager-version>
+docker tag dp.apps.rancher.io/cert-manager-controller:<cert-manager-version> <registry.internal.corp>/cert-manager-controller:<cert-manager-version>
+docker tag dp.apps.rancher.io/cert-manager-cainjector:<cert-manager-version> <registry.internal.corp>/cert-manager-cainjector:<cert-manager-version>
+docker tag dp.apps.rancher.io/cert-manager-webhook:<cert-manager-version> <registry.internal.corp>/cert-manager-webhook:<cert-manager-version>
 
 # Push to internal registry
-docker push registry.internal.corp/cert-manager-controller:<cert-manager-version>
-docker push registry.internal.corp/cert-manager-cainjector:<cert-manager-version>
-docker push registry.internal.corp/cert-manager-webhook:<cert-manager-version>
+docker push <registry.internal.corp>/cert-manager-controller:<cert-manager-version>
+docker push <registry.internal.corp>/cert-manager-cainjector:<cert-manager-version>
+docker push <registry.internal.corp>/cert-manager-webhook:<cert-manager-version>
 ----
 
 [#_fetch_from_upstream_helm_jetstack_repository]
@@ -312,12 +312,12 @@ kubectl create namespace cert-manager
 +
 [source,shell]
 ----
-helm install cert-manager ./cert-manager-1.14.0.tgz \
+helm install cert-manager ./<cert-manager-version>.tgz \
   --namespace cert-manager \
   --set installCRDs=true \
-  --set image.repository=registry.internal.corp/cert-manager-controller \
-  --set webhook.image.repository=registry.internal.corp/cert-manager-webhook \
-  --set cainjector.image.repository=registry.internal.corp/cert-manager-cainjector
+  --set image.repository=<registry.internal.corp>/cert-manager-controller \
+  --set webhook.image.repository=<registry.internal.corp>/cert-manager-webhook \
+  --set cainjector.image.repository=<registry.internal.corp>/cert-manager-cainjector
 ----
 ======
 

--- a/versions/v2.14/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
+++ b/versions/v2.14/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
@@ -86,7 +86,7 @@ helm install <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert
 If you are deploying in a cluster that requires FIPS cryptography compliance, you can substitute the chart path with `oci://dp.apps.rancher.io/charts/cert-manager-fips`.
 ====
 
-. Verify the Installation
+. Verify the Installation.
 +
 Once you've installed cert-manager, you can verify it is deployed correctly by checking the `cert-manager` namespace for running pods:
 +

--- a/versions/v2.14/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
+++ b/versions/v2.14/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, de, es, fr, ja, pt, zh]
 endif::[]
-:revdate: 2026-04-21
+:revdate: 2026-06-10
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/install-rancher.adoc 
 :product-path: installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
@@ -34,6 +34,81 @@ sudo ./get_helm.sh
 [#_install_cert_manager]
 == Install cert-manager
 
+[tabs]
+======
+Using SUSE Application Collection::
++
+--
+https://docs.apps.rancher.io/[SUSE Application Collection] provides a cert-manager chart that is compatible with Rancher. If you are using SUSE Application Collection, we recommend installing cert-manager using this option. 
+
+. Log in to the secure SUSE Application Collection registry:
++
+Before installing, https://docs.apps.rancher.io/get-started/authentication[authenticate your Helm CLI] against the Application Collection OCI registry using your enterprise credentials:
++
+[source,shell]
+----
+helm registry login dp.apps.rancher.io -u <username-or-service-account-username> -p <access-token-or-service-account-token>
+----
+
+. Create the target namespace `cert-manager`:
++
+[source,shell]
+----
+kubectl create namespace cert-manager
+----
+
+. Create the Image Pull Secret:
++
+Because the Application Collection is a private registry, your cluster's nodes need a secret to pull the images. Generate this secret in the `cert-manager` namespace:
++
+[source,shell]
+----
+kubectl create secret docker-registry application-collection \
+  --namespace cert-manager \
+  --docker-server=dp.apps.rancher.io \
+  --docker-username=<YOUR_APPCO_USERNAME> \
+  --docker-password=<YOUR_APPCO_TOKEN>
+----
+
+. Install cert-manager via the OCI chart path:
++
+Deploy the chart directly from the OCI registry path. Ensure you pass the `global.imagePullSecrets` flag so the pods can authenticate:
++
+[source,shell]
+----
+helm install <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert-manager \
+    --namespace cert-manager \
+    --set global.imagePullSecrets={application-collection} \
+    --set crds.enabled=true
+----
++
+[NOTE]
+====
+If you are deploying in a cluster that requires FIPS cryptography compliance, you can substitute the chart path with `oci://dp.apps.rancher.io/charts/cert-manager-fips`.
+====
+
+. Verify the Installation
++
+Once you've installed cert-manager, you can verify it is deployed correctly by checking the `cert-manager` namespace for running pods:
++
+[source,shell]
+----
+kubectl get pods --namespace cert-manager
+----
++
+[source,shell]
+----
+NAME                                       READY   STATUS    RESTARTS   AGE
+cert-manager-56cc584bd4-nhjx7              1/1     Running   0          3m
+cert-manager-cainjector-7cfc74b84b-kg7m2   1/1     Running   0          3m
+cert-manager-webhook-784f6dd68-69dvn       1/1     Running   0          3m
+----
+
+--
+
+Using Upstream Jetstack Helm Repository::
++
+--
 Add the cert-manager Helm repository:
 
 ----
@@ -75,6 +150,8 @@ Now you should wait until cert-manager is finished starting up:
 kubectl rollout status deployment -n cert-manager cert-manager
 kubectl rollout status deployment -n cert-manager cert-manager-webhook
 ----
+--
+======
 
 [#_install_rancher_product_name]
 == Install {rancher-product-name}

--- a/versions/v2.14/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
+++ b/versions/v2.14/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
@@ -34,11 +34,10 @@ sudo ./get_helm.sh
 [#_install_cert_manager]
 == Install cert-manager
 
-[tabs]
-======
-Using SUSE Application Collection::
-+
---
+ifeval::["{build-type}" != "community"]
+[#_using_suse_application_collection]
+=== Using SUSE Application Collection
+
 https://docs.apps.rancher.io/[SUSE Application Collection] provides a cert-manager chart that is compatible with Rancher. If you are using SUSE Application Collection, we recommend installing cert-manager using this option. 
 
 . Log in to the secure SUSE Application Collection registry:
@@ -103,12 +102,11 @@ cert-manager-56cc584bd4-nhjx7              1/1     Running   0          3m
 cert-manager-cainjector-7cfc74b84b-kg7m2   1/1     Running   0          3m
 cert-manager-webhook-784f6dd68-69dvn       1/1     Running   0          3m
 ----
+endif::[]
 
---
+[#_using_upstream_jetstack_helm_repository]
+=== Using Upstream Jetstack Helm Repository
 
-Using Upstream Jetstack Helm Repository::
-+
---
 Add the cert-manager Helm repository:
 
 ----
@@ -150,8 +148,6 @@ Now you should wait until cert-manager is finished starting up:
 kubectl rollout status deployment -n cert-manager cert-manager
 kubectl rollout status deployment -n cert-manager cert-manager-webhook
 ----
---
-======
 
 [#_install_rancher_product_name]
 == Install {rancher-product-name}

--- a/versions/v2.14/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
+++ b/versions/v2.14/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
@@ -277,6 +277,7 @@ Refer to the https://cert-manager.io/docs/usage/cmctl/#migrate-api-version[API v
 . Upgrade Rancher normally with `helm upgrade`.
 ======
 
+ifeval::["{build-type}" != "community"]
 [#_option_d_upgrade_cert_manager_using_suse_application_collection]
 === Option D: Upgrade cert-manager Using SUSE Application Collection
 
@@ -301,6 +302,7 @@ helm upgrade <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert
 ----
 
 ======
+endif::[]
 
 [#_verify_the_deployment]
 === Verify the Deployment

--- a/versions/v2.14/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
+++ b/versions/v2.14/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
@@ -43,8 +43,41 @@ The namespace used in these instructions depends on the namespace cert-manager i
 
 In order to upgrade cert-manager, follow these instructions:
 
+ifeval::["{build-type}" != "community"]
+[#_option_a_upgrade_cert_manager_using_suse_application_collection]
+=== Option A: Upgrade cert-manager Using SUSE Application Collection
+
+.Click to expand
+[%collapsible]
+======
+
+The cert-manager chart can be upgraded in-place using the Helm `upgrade` workflow to a https://apps.rancher.io/applications/cert-manager[specific version] listed in the SUSE Application Collection, below is an example command:
+
+[source,shell]
+----
+helm upgrade <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert-manager \
+  --set global.imagePullSecrets={application-collection}
+----
+
+To reuse the existing values and only upgrade the chart version:
+
+[source,shell]
+----
+helm upgrade <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert-manager \
+  --reuse-values
+----
+
+======
+endif::[]
+
+ifeval::["{build-type}" != "community"]
+[#_option_b_upgrade_cert_manager_with_internet_access]
+=== Option B: Upgrade cert-manager with Internet Access
+endif::[]
+ifeval::["{build-type}" == "community"]
 [#_option_a_upgrade_cert_manager_with_internet_access]
 === Option A: Upgrade cert-manager with Internet Access
+endif::[]
 
 .Click to expand
 [%collapsible]
@@ -133,15 +166,22 @@ helm repo update
 +
 ======
 
+ifeval::["{build-type}" != "community"]
+[#_option_c_upgrade_cert_manager_in_an_air_gapped_environment]
+=== Option C: Upgrade cert-manager in an Air-Gapped Environment
+endif::[]
+ifeval::["{build-type}" == "community"]
 [#_option_b_upgrade_cert_manager_in_an_air_gapped_environment]
 === Option B: Upgrade cert-manager in an Air-Gapped Environment
+endif::[]
 
 .Click to expand
 [%collapsible]
 ======
 
 [#_prerequisites]
-=== Prerequisites
+[pass]
+<h3><a id="_prerequisites"></a>Prerequisites</h3>
 
 Before you can perform the upgrade, you must prepare your air gapped environment by adding the necessary container images to your private registry and downloading or rendering the required Kubernetes manifest files.
 
@@ -254,8 +294,14 @@ If you are running Kubernetes v1.15 or below, you will need to add the `--valida
 ----
 ======
 
+ifeval::["{build-type}" != "community"]
+[#_option_d_upgrade_cert_manager_from_versions_1_5_and_below]
+=== Option D: Upgrade cert-manager from Versions 1.5 and Below
+endif::[]
+ifeval::["{build-type}" == "community"]
 [#_option_c_upgrade_cert_manager_from_versions_1_5_and_below]
 === Option C: Upgrade cert-manager from Versions 1.5 and Below
+endif::[]
 
 .Click to expand
 [%collapsible]
@@ -276,33 +322,6 @@ Refer to the https://cert-manager.io/docs/usage/cmctl/#migrate-api-version[API v
 . In the decoded file, search for `cert-manager.io/v1beta1` and *replace it* with `cert-manager.io/v1`.
 . Upgrade Rancher normally with `helm upgrade`.
 ======
-
-ifeval::["{build-type}" != "community"]
-[#_option_d_upgrade_cert_manager_using_suse_application_collection]
-=== Option D: Upgrade cert-manager Using SUSE Application Collection
-
-.Click to expand
-[%collapsible]
-======
-
-The cert-manager chart can be upgraded in-place using the Helm `upgrade` workflow to a https://apps.rancher.io/applications/cert-manager[specific version] listed in the SUSE Application Collection, below is an example command:
-
-[source,shell]
-----
-helm upgrade <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert-manager \
-  --set global.imagePullSecrets={application-collection}
-----
-
-To reuse the existing values and only upgrade the chart version:
-
-[source,shell]
-----
-helm upgrade <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert-manager \
-  --reuse-values
-----
-
-======
-endif::[]
 
 [#_verify_the_deployment]
 === Verify the Deployment

--- a/versions/v2.14/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
+++ b/versions/v2.14/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
@@ -31,21 +31,20 @@ To address these changes, this guide will do two things:
 [NOTE]
 .Important:
 ====
-
-If you are upgrading cert-manager to the latest version from a version older than 1.5, follow the steps in <<_option_c_upgrade_cert_manager_from_versions_1_5_and_below,Option C>> below to do so. Note that you do not need to reinstall Rancher to perform this upgrade.
+If you are upgrading cert-manager to the latest version from a version older than 1.5, follow the steps via the method <<_upgrade_cert_manager_from_versions_1_5_and_below,Upgrade cert-manager from Versions 1.5 and Below>>. Note that you do not need to reinstall Rancher to perform this upgrade.
 ====
 
 
-[#_upgrade_cert_manager]
-== Upgrade Cert-Manager
+[#_cert_manager_upgrade_methods]
+== cert-manager Upgrade Methods
 
 The namespace used in these instructions depends on the namespace cert-manager is currently installed in. If it is in kube-system use that in the instructions below. You can verify by running `kubectl get pods --all-namespaces` and checking which namespace the cert-manager-* pods are listed in. Do not change the namespace cert-manager is running in or this can cause issues.
 
 In order to upgrade cert-manager, follow these instructions:
 
 ifeval::["{build-type}" != "community"]
-[#_option_a_upgrade_cert_manager_using_suse_application_collection]
-=== Option A: Upgrade cert-manager Using SUSE Application Collection
+[#_upgrade_cert_manager_using_suse_application_collection]
+=== Upgrade cert-manager Using SUSE Application Collection
 
 .Click to expand
 [%collapsible]
@@ -70,14 +69,8 @@ helm upgrade <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert
 ======
 endif::[]
 
-ifeval::["{build-type}" != "community"]
-[#_option_b_upgrade_cert_manager_with_internet_access]
-=== Option B: Upgrade cert-manager with Internet Access
-endif::[]
-ifeval::["{build-type}" == "community"]
-[#_option_a_upgrade_cert_manager_with_internet_access]
-=== Option A: Upgrade cert-manager with Internet Access
-endif::[]
+[#_upgrade_cert_manager_with_internet_access]
+=== Upgrade cert-manager with Internet Access
 
 .Click to expand
 [%collapsible]
@@ -166,14 +159,8 @@ helm repo update
 +
 ======
 
-ifeval::["{build-type}" != "community"]
-[#_option_c_upgrade_cert_manager_in_an_air_gapped_environment]
-=== Option C: Upgrade cert-manager in an Air-Gapped Environment
-endif::[]
-ifeval::["{build-type}" == "community"]
-[#_option_b_upgrade_cert_manager_in_an_air_gapped_environment]
-=== Option B: Upgrade cert-manager in an Air-Gapped Environment
-endif::[]
+[#_upgrade_cert_manager_in_an_air_gapped_environment]
+=== Upgrade cert-manager in an Air-Gapped Environment
 
 .Click to expand
 [%collapsible]
@@ -294,14 +281,8 @@ If you are running Kubernetes v1.15 or below, you will need to add the `--valida
 ----
 ======
 
-ifeval::["{build-type}" != "community"]
-[#_option_d_upgrade_cert_manager_from_versions_1_5_and_below]
-=== Option D: Upgrade cert-manager from Versions 1.5 and Below
-endif::[]
-ifeval::["{build-type}" == "community"]
-[#_option_c_upgrade_cert_manager_from_versions_1_5_and_below]
-=== Option C: Upgrade cert-manager from Versions 1.5 and Below
-endif::[]
+[#_upgrade_cert_manager_from_versions_1_5_and_below]
+=== Upgrade cert-manager from Versions 1.5 and Below
 
 .Click to expand
 [%collapsible]

--- a/versions/v2.14/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
+++ b/versions/v2.14/modules/en/pages/installation-and-upgrade/resources/upgrade-cert-manager.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, de, es, fr, ja, pt, zh]
 endif::[]
-:revdate: 2026-04-21
+:revdate: 2026-06-10
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/resources/upgrade-cert-manager.adoc 
 :product-path: installation-and-upgrade/resources/upgrade-cert-manager.adoc
@@ -275,6 +275,31 @@ Refer to the https://cert-manager.io/docs/usage/cmctl/#migrate-api-version[API v
 . Follow the Helm tutorial to https://helm.sh/docs/topics/kubernetes_apis/#updating-api-versions-of-a-release-manifest[update the API version of a release manifest]. The chart release name is `release_name=rancher` and the release namespace is `release_namespace=cattle-system`.
 . In the decoded file, search for `cert-manager.io/v1beta1` and *replace it* with `cert-manager.io/v1`.
 . Upgrade Rancher normally with `helm upgrade`.
+======
+
+[#_option_d_upgrade_cert_manager_using_suse_application_collection]
+=== Option D: Upgrade cert-manager Using SUSE Application Collection
+
+.Click to expand
+[%collapsible]
+======
+
+The cert-manager chart can be upgraded in-place using the Helm `upgrade` workflow to a https://apps.rancher.io/applications/cert-manager[specific version] listed in the SUSE Application Collection, below is an example command:
+
+[source,shell]
+----
+helm upgrade <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert-manager \
+  --set global.imagePullSecrets={application-collection}
+----
+
+To reuse the existing values and only upgrade the chart version:
+
+[source,shell]
+----
+helm upgrade <cert-manager-release-version> oci://dp.apps.rancher.io/charts/cert-manager \
+  --reuse-values
+----
+
 ======
 
 [#_verify_the_deployment]


### PR DESCRIPTION
This PR updates install instructions for cert-manager using SUSE Application Collection across relevant pages and versions. They have been conditionalized for the product build as cert-manager is a Prime subscription AppCo chart. The below were used as references from the upstream AppCo documentation regarding configuration and chart installation. For reviewing purposes, the changes in v2.14 can be focused on as the changes there were synced across supported Rancher versions. Related to SURE-10769

https://docs.apps.rancher.io/get-started/authentication#helm

https://docs.apps.rancher.io/reference-guides/opentelemetry-operator#install-cert-manager

https://docs.apps.rancher.io/get-started/first-steps#distribution-platform

https://docs.apps.rancher.io/reference-guides/thanos#upgrade-the-chart