### PR TITLE
continue-on-error when Load App Credentials from Vault fails

### DIFF
--- a/.github/workflows/draft-release-notes.yml
+++ b/.github/workflows/draft-release-notes.yml
@@ -24,13 +24,14 @@ jobs:
 
       - name: Load App Credentials from Vault
         uses: rancher-eio/read-vault-secrets@7282bf97898cd1c16c89f837e0bb442e6d384c89 # main
+        continue-on-error: true
         with:
           secrets: |
             github/token/rancher--rancher-product-docs--pull_requests--write token | GH_TOKEN
 
       - name: Create Pull Request
         env:
-          GH_TOKEN: ${{ env.GH_TOKEN }}
+          GH_TOKEN: ${{ env.GH_TOKEN || github.token }}
           VERSION: ${{ inputs.version }}
           PR_BODY_TEMPLATE: |
             - [ ] Remove the old info, issues listed as Bug Fixes and Features, move previous 'Known Issues' and 'Behavior Changes' to 'Long-standing Known Issues' and 'Previous Rancher Behavior Changes' section.

--- a/.github/workflows/generate-release-maintenance.yaml
+++ b/.github/workflows/generate-release-maintenance.yaml
@@ -54,13 +54,14 @@ jobs:
 
       - name: Load App Credentials from Vault
         uses: rancher-eio/read-vault-secrets@7282bf97898cd1c16c89f837e0bb442e6d384c89 # main
+        continue-on-error: true
         with:
           secrets: |
             github/token/rancher--rancher-product-docs--pull_requests--write token | GH_TOKEN
 
       - name: Create Pull Request
         env:
-          GH_TOKEN: ${{ env.GH_TOKEN }}
+          GH_TOKEN: ${{ env.GH_TOKEN || github.token }}
         run: |
           BRANCH_NAME="${VERSION}-maintenance"
 

--- a/versions/v2.13/antora-yml/antora-srfa.yml
+++ b/versions/v2.13/antora-yml/antora-srfa.yml
@@ -14,6 +14,7 @@ asciidoc:
     rancher-product-name-tm: "SUSE® Rancher for AWS"
     rancher-short-name: "Rancher"
     rancher-helm-repo: "rancher-prime"
+    current-patch-version: 2.13.6
     # docs links
     harvester-docs-version: v1.7
     longhorn-docs-version: "1.10"


### PR DESCRIPTION
- [continue-on-error when Load App Credentials from Vault fails](https://github.com/rancher/rancher-product-docs/commit/570e1e2eaa7619888611e247427dd67cc3d7af74)
- [Fix antora-srfa.yml for release-maintenance.sh](https://github.com/rancher/rancher-product-docs/commit/adb867a4d555dfdcba43ddc0a5ac3b2a8bcb96c8)

Test PRs: https://github.com/pmkovar/rancher-product-docs/pull/40, https://github.com/pmkovar/rancher-product-docs/pull/39