### PR TITLE
Remove double slash from DOCS_REPO_PATH

### DIFF
--- a/scripts/release-maintenance.sh
+++ b/scripts/release-maintenance.sh
@@ -16,7 +16,7 @@ set -o pipefail
 # The script assumes it is located in the root of the docs repository.
 # It determines its own location to make the path portable.
 DOCS_REPO_PATH=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-DOCS_REPO_PATH=${DOCS_REPO_PATH%scripts}
+DOCS_REPO_PATH=${DOCS_REPO_PATH%/scripts}
 
 # --- Global Variables ---
 INTERACTIVE=false


### PR DESCRIPTION
Example output from a recent [workflow run](https://github.com/rancher/rancher-product-docs/actions/runs/27850044063/job/82427195558):

```
-> Updating revdate in /home/runner/work/rancher-product-docs/rancher-product-docs//versions/v2.14/modules/zh/pages/installation-and-upgrade/hosted-kubernetes/cloud-marketplace/aws/install-adapter.adoc
-> Updating revdate in /home/runner/work/rancher-product-docs/rancher-product-docs//versions/v2.14/modules/zh/pages/security/rancher-webhook/rancher-webhook.adoc
-> Updating revdate in /home/runner/work/rancher-product-docs/rancher-product-docs//versions/v2.14/modules/zh/pages/faq/deprecated-features.adoc
-> Updating turtles-docs-version in /home/runner/work/rancher-product-docs/rancher-product-docs//versions/v2.14/antora.yml
-> Updating turtles-docs-version in /home/runner/work/rancher-product-docs/rancher-product-docs//community-docs/v2.14/antora.yml
-> Updating turtles-docs-version in /home/runner/work/rancher-product-docs/rancher-product-docs//versions/v2.14/antora-yml/antora-srfa.yml
-> Updating fleet-docs-version in /home/runner/work/rancher-product-docs/rancher-product-docs//versions/v2.14/antora.yml
```