### PR TITLE
Fix broken symlink

### DIFF
--- a/versions/v2.13/modules/zh/attachments/swagger-v2.13.json
+++ b/versions/v2.13/modules/zh/attachments/swagger-v2.13.json
@@ -1,1 +1,1 @@
-../../en/attachments/swagger-v2.13.json
+../../en/attachments/swagger.json


### PR DESCRIPTION
We missed updating this symlink as part of #1141 and its causing [DSC builds](https://github.com/rancher/product-docs-playbook/actions/runs/28136924318/job/83325710747) to break.