### PR TITLE
Fix release notes folder - v2.15

### DIFF
--- a/versions/v2.15/modules/de/pages/release-notes
+++ b/versions/v2.15/modules/de/pages/release-notes
@@ -1,0 +1,1 @@
+../../en/pages/release-notes

--- a/versions/v2.15/modules/de/pages/release-notes
+++ b/versions/v2.15/modules/de/pages/release-notes
@@ -1,1 +1,0 @@
-../../en/pages/release-notes


### PR DESCRIPTION
Adding back release notes folder with dummy file v2.15, tied to build error seen on product docs playbook https://github.com/rancher/product-docs-playbook/actions/runs/28628602215/job/84900480986