### PR TITLE
Add dummy header ID for v2.15 rancher monitoring dashboards chart

### DIFF
--- a/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/monitoring-and-dashboards.adoc
+++ b/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/monitoring-and-dashboards.adoc
@@ -44,6 +44,12 @@ ifeval::["{build-type}" == "community"]
 :xref-monitoring-windows: xref:integrations-in-rancher/monitoring-and-alerting/windows-support.adoc
 endif::[]
 
+[#_rancher_monitoring_dashboards]
+== Rancher Monitoring Dashboards
+
+[#_rancher_monitoring]
+== Rancher Monitoring
+
 The `rancher-monitoring` application can quickly deploy leading open-source monitoring and alerting solutions onto your cluster.
 
 Introduced in Rancher v2.5, the application is powered by https://prometheus.io/[Prometheus], https://grafana.com/grafana/[Grafana],  https://prometheus.io/docs/alerting/latest/alertmanager/[Alertmanager], the https://github.com/prometheus-operator/prometheus-operator[Prometheus Operator], and the https://github.com/DirectXMan12/k8s-prometheus-adapter[Prometheus adapter.]
@@ -53,7 +59,7 @@ For information on V1 monitoring and alerting, available in Rancher v2.2 up to v
 Using the `rancher-monitoring` application, you can quickly deploy leading open-source monitoring and alerting solutions onto your cluster.
 
 [#_features]
-== Features
+=== Features
 
 Prometheus lets you view metrics from your Rancher and Kubernetes objects. Using timestamps, Prometheus lets you query and view these metrics in easy-to-read graphs and visuals, either through the Rancher UI or Grafana, which is an analytics viewing platform deployed along with Prometheus.
 

--- a/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/monitoring-and-dashboards.adoc
+++ b/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/monitoring-and-dashboards.adoc
@@ -44,8 +44,8 @@ ifeval::["{build-type}" == "community"]
 :xref-monitoring-windows: xref:integrations-in-rancher/monitoring-and-alerting/windows-support.adoc
 endif::[]
 
-[#_rancher_monitoring_dashboards]
-== Rancher Monitoring Dashboards
+[#_monitoring_dashboards]
+== Monitoring Dashboards
 
 [#_rancher_monitoring]
 == Rancher Monitoring


### PR DESCRIPTION
- UI needs a live link for testing, i.e. https://documentation.suse.com/cloudnative/rancher-manager/v2.15/en/observability/monitoring-and-dashboards/monitoring-and-dashboards.html#_monitoring_dashboards should be live.
- Add dummy H2 ID `== Rancher Monitoring Dashboards` 
- Related to https://github.com/rancher/dashboard/issues/18149, https://github.com/rancher/ob-team-charts/issues/265, https://github.com/rancher/rancher-product-docs/issues/1187