### PR TITLE
Update Integrations - CAPI section (v2.13+)

### DIFF
--- a/community-docs/v2.14/antora.yml
+++ b/community-docs/v2.14/antora.yml
@@ -15,4 +15,4 @@ asciidoc:
     kubewarden-docs-version: 1.31
     elemental-docs-version: 1.7
     fleet-docs-version: 0.15
-    turtles-docs-version: v0.26
+    turtles-docs-version: stable

--- a/community-docs/v2.14/antora.yml
+++ b/community-docs/v2.14/antora.yml
@@ -15,4 +15,4 @@ asciidoc:
     kubewarden-docs-version: 1.31
     elemental-docs-version: 1.7
     fleet-docs-version: 0.15
-    turtles-docs-version: stable
+    turtles-docs-version: stable # v0.26

--- a/community-docs/v2.15/antora.yml
+++ b/community-docs/v2.15/antora.yml
@@ -16,4 +16,4 @@ asciidoc:
     kubewarden-docs-version: 1.31
     elemental-docs-version: 1.7
     fleet-docs-version: 0.15
-    turtles-docs-version: stable
+    turtles-docs-version: stable # v0.26

--- a/community-docs/v2.15/antora.yml
+++ b/community-docs/v2.15/antora.yml
@@ -16,4 +16,4 @@ asciidoc:
     kubewarden-docs-version: 1.31
     elemental-docs-version: 1.7
     fleet-docs-version: 0.15
-    turtles-docs-version: v0.26
+    turtles-docs-version: stable

--- a/versions/v2.13/modules/en/pages/integrations/cluster-api/cluster-api.adoc
+++ b/versions/v2.13/modules/en/pages/integrations/cluster-api/cluster-api.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2026-04-24
+:revdate: 2026-07-09
 :page-revdate: {revdate}
 :community-path: integrations-in-rancher/cluster-api/index.adoc 
 :product-path: integrations/cluster-api/cluster-api.adoc
@@ -17,9 +17,9 @@ ifeval::["{build-type}" == "community"]
 :xref-turtles-overview: xref:integrations-in-rancher/cluster-api/overview.adoc
 endif::[]
 
-{url-cluster-api-index}[{turtles-product-name}] is a https://kubernetes.io/docs/concepts/extend-kubernetes/operator/#operators-in-kubernetes[Kubernetes Operator] that manages the lifecycle of provisioned Kubernetes clusters, by providing integration between your Cluster API (CAPI) and Rancher. With Rancher Turtles, you can:
+{url-cluster-api-index}[{turtles-product-name}] is a https://kubernetes.io/docs/concepts/extend-kubernetes/operator/#operators-in-kubernetes[Kubernetes Operator] that manages the lifecycle of provisioned Kubernetes clusters by integrating Cluster API (CAPI) and Rancher where it is automatically deployed as a Rancher system component. With {turtles-product-name}, you can:
 
 * Import CAPI clusters into Rancher, by installing the Rancher Cluster Agent in CAPI provisioned clusters.
 * Manage the https://cluster-api-operator.sigs.k8s.io/[CAPI Operator] using the {url-cluster-api-capiprovider}[CAPIProvider] resource.
 
-The {xref-turtles-overview}[Overview] section outlines installation options, Rancher Turtles architecture, and a brief demo. For more details, see the {url-cluster-api-index}[{turtles-product-name} documentation].
+The {xref-turtles-overview}[Overview] section outlines installing CAPI providers, Supply-chain Levels for Software Artifacts (SLSA) security compliance, and uninstalling {turtles-product-name}. For more details, see the {url-cluster-api-index}[{turtles-product-name} documentation].

--- a/versions/v2.13/modules/en/pages/integrations/cluster-api/overview.adoc
+++ b/versions/v2.13/modules/en/pages/integrations/cluster-api/overview.adoc
@@ -2,269 +2,89 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-05
+:revdate: 2026-07-09
 :page-revdate: {revdate}
 :community-path: integrations-in-rancher/cluster-api/overview.adoc 
 :product-path: integrations/cluster-api/overview.adoc
 :experimental:
 ifeval::["{build-type}" != "community"]
+:xref-ref-capiprovider: https://documentation.suse.com/cloudnative/cluster-api/{turtles-docs-version}/en/reference/capiprovider.html
 :url-capi-slsa: https://documentation.suse.com/cloudnative/cluster-api/{turtles-docs-version}/en/security/slsa.html
 endif::[]
 ifeval::["{build-type}" == "community"]
+:xref-ref-capiprovider: https://turtles.docs.rancher.com/turtles/{turtles-docs-version}/en/reference/capiprovider.html
 :url-capi-slsa: https://turtles.docs.rancher.com/turtles/{turtles-docs-version}/en/security/slsa.html 
 endif::[]
 
-== Architecture Diagram
+[NOTE]
+====
+The core CAPI controller manifest is embedded in a ConfigMap, which simplifies operation in air-gapped environments.
+====
 
-Below is a visual representation of the key components of Rancher Turtles and their relationship to Rancher and the Rancher Cluster Agent. Understanding these components is essential for gaining insights into how Rancher leverages the CAPI operator for cluster management.
+{turtles-product-name} is automatically deployed as a system component in the `cattle-turtles-system` namespace. This includes:
 
-image::30000ft_view.png[overview]
+* The `rancher-turtles-controller-manager` pod, which handles all CAPI-related resources.
+* Core CAPI CRDs and the core CAPI controller.
+* The `CAPIProvider` custom resource, which allows declarative definition of CAPI providers.
 
 == Security
 
 As defined by https://slsa.dev/spec/v1.0/about[Supply-chain Levels for Software Artifacts (SLSA)], SLSA is a set of incrementally adoptable guidelines for supply chain security, established by industry consensus. The specification set by SLSA is useful for both software producers and consumers: producers can follow SLSA's guidelines to make their software supply chain more secure, and consumers can use SLSA to make decisions about whether to trust a software package.
 
-Rancher Turtles meets https://slsa.dev/spec/v1.0/levels#build-l3[SLSA Level 3] requirements as an appropriate hardened build platform, with consistent build processes, and provenance distribution. For more information, visit the {url-capi-slsa}[{turtles-product-name} Security] document.
+{turtles-product-name} meets https://slsa.dev/spec/v1.0/levels#build-l3[SLSA Level 3] requirements as an appropriate hardened build platform, with consistent build processes, and provenance distribution. For more information, visit the {url-capi-slsa}[{turtles-product-name} Security] document.
 
-== Prerequisites
+== Installing CAPI Providers
 
-Before installing Rancher Turtles in your Rancher environment, you must disable Rancher's `embedded-cluster-api` functionality. This also includes cleaning up Rancher-specific webhooks that otherwise would conflict with CAPI ones.
+With {turtles-product-name} embedded in Rancher, CAPI providers are no longer bundled by default. Providers are managed declaratively using the `CAPIProvider` custom resource. 
 
-To simplify setting up Rancher for installing Rancher Turtles, the official Rancher Turtles Helm chart includes a `pre-install` hook that removes the following:
+ifeval::["{build-type}" != "community"]
+A separate providers chart for Prime users is available for installing certified providers. For more information, refer to https://documentation.suse.com/cloudnative/cluster-api/{turtles-docs-version}/en/user/providers.html[Install certified providers].
+endif::[]
 
-* Disables the `embedded-cluster-api` feature in Rancher.
-* Deletes the `mutating-webhook-configuration` and `validating-webhook-configuration` webhooks, as they are no longer needed.
+For example, to define a provider:
 
-These webhooks can be removed through the Rancher UI as well:
-
-. In the upper left corner, click *☰* > *Cluster Management*.
-. Select your local cluster.
-. In the left-hand navigation menu, select *More Resources* > *Admission*.
-. From the dropdown, select the Resource pages for `MutatingWebhookConfiguration` and `ValidatingWebhookConfiguration`.
-. On the respective Resource pages, click the *⋮* that are attached to the `mutating-webhook-configuration` and `validating-webhook-configuration` webhooks and select the *Delete* option.
-
-The webhooks can also be accessed by entering the names of the webhooks into the *Resource Search* field.
-
-The following `kubectl` commands can manually remove the necessary webhooks:
-
-[,console]
+[source,yaml]
 ----
-kubectl delete mutatingwebhookconfiguration.admissionregistration.k8s.io mutating-webhook-configuration
-----
-
-[,console]
-----
-kubectl delete validatingwebhookconfigurations.admissionregistration.k8s.io validating-webhook-configuration
-----
-
-Use the following example to disable the `embedded-cluster-api` feature from the console:
-
-. Create a `feature.yaml` file, with `embedded-cluster-api` set to false:
-+
-.feature.yaml
-[,yaml]
-----
-apiVersion: management.cattle.io/v3
-kind: Feature
+apiVersion: turtles-capi.cattle.io/v1alpha1
+kind: CAPIProvider
 metadata:
-  name: embedded-cluster-api
+  name: aws
+  namespace: cattle-turtles-system
 spec:
-  value: false
+  type: infrastructure
+  name: aws
 ----
 
-. Use `kubectl` to apply the `feature.yaml` file to the cluster:
-+
-[,bash]
-----
-kubectl apply -f feature.yaml
-----
+Refer to the {xref-ref-capiprovider}[CAPIProvider reference] for the full list of configuration options.
 
-== Installing the {turtles-product-name} Operator
-
-You can install the Rancher Turtles operator via the Rancher UI, or with Helm. The first method is recommended for most environments.
+== Uninstalling
 
 [CAUTION]
 ====
-If you already have the Cluster API (CAPI) Operator installed in your cluster, you must use the <<_installing_via_helm,manual Helm installation method>>.
-====
+When installing {turtles-product-name} in your Rancher environment, the CAPI Operator cleanup is enabled by default. This includes cleaning up CAPI Operator specific webhooks and deployments that otherwise cause issues with Rancher provisioning.
 
-
-=== Installing via the Rancher UI
-
-By adding the Turtles repository via the Rancher UI, Rancher can process the installation and configuration of the CAPI Extension.
-
-. Click *☰*. Under *Explore Cluster* in the left navigation menu, select *local*.
-. In the left navigation menu of the *Cluster Dashboard*, select menu:Apps[Repositories].
-. Click *Create* to add a new repository.
-. Enter the following:
- ** *Name*: turtles
- ** *Index URL*: https://rancher.github.io/turtles
-. Wait until the new repository has a status of `Active`.
-. In the left navigation menu, select menu:Apps[Charts].
-. Enter "turtles" into the search filter to find the Turtles chart.
-. Click *Rancher Turtles - the Cluster API Extension*.
-. Click menu:Install[Next > Install].
-
-This process uses the default values for the Helm chart, which are good for most installations. If your configuration requires overriding some of these defaults, you can either specify the values during installation from the Rancher UI or you can <<_installing_via_helm,manually install the chart via Helm>>. For details about available values, see the https://documentation.suse.com/cloudnative/cluster-api/{turtles-docs-version}/en/operator/chart.html[Cluster API documentation].
-
-The installation may take a few minutes and after completing you can see the following new deployments in the cluster:
-
-* `rancher-turtles-system/rancher-turtles-controller-manager`
-* `rancher-turtles-system/rancher-turtles-cluster-api-operator`
-* `capi-system/capi-controller-manager`
-
-==== Demo
-
-This demo illustrates how to use the Rancher UI to install Rancher Turtles, create/import a CAPI cluster, and install monitoring on the cluster:+++<iframe width="560" height="315" src="https://www.youtube.com/embed/lGsr7KfBjgU?si=ORkzuAJjcdXUXMxh" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen="">++++++</iframe>+++
-
-=== Installing via Helm
-
-There are two ways to install Rancher Turtles with Helm, depending on whether you include the https://github.com/kubernetes-sigs/cluster-api-operator[CAPI Operator] as a dependency:
-
-* <<_installing_rancher_turtles_with_cluster_api_capi_operator_as_a_helm_dependency,Install Rancher Turtles with CAPI Operator as a dependency>>.
-* <<_installing_rancher_turtles_without_cluster_api_capi_operator_as_a_helm_dependency,Install Rancher Turtles without CAPI Operator>>.
-
-The CAPI Operator is required for installing Rancher Turtles. You can choose whether you want to take care of this dependency yourself or let the Rancher Turtles Helm chart manage it for you. <<_installing_rancher_turtles_with_cluster_api_capi_operator_as_a_helm_dependency,Installing Turtles as a dependency>> is simpler, but your best option depends on your specific configuration.
-
-The CAPI Operator allows for handling the lifecycle of https://documentation.suse.com/cloudnative/cluster-api/{turtles-docs-version}/en/operator/manual.html[CAPI providers] using a declarative approach, extending the capabilities of `clusterctl`. If you want to learn more about it, you can refer to https://cluster-api-operator.sigs.k8s.io/[Cluster API Operator book].
-
-[#_installing_rancher_turtles_with_cluster_api_capi_operator_as_a_helm_dependency]
-==== Installing {turtles-product-name} with `Cluster API (CAPI) Operator` as a Helm dependency
-
-. Add the Helm repository containing the `rancher-turtles` chart as the first step in installation:
-+
-[,bash]
-----
-helm repo add turtles https://rancher.github.io/turtles
-helm repo update
-----
-
-. As mentioned before, installing Rancher Turtles requires the https://github.com/kubernetes-sigs/cluster-api-operator[CAPI Operator]. The Helm chart can automatically install it with a minimal set of flags:
-+
-[,bash]
-----
-helm install rancher-turtles turtles/rancher-turtles --version <version> \
-    -n rancher-turtles-system \
-    --dependency-update \
-    --create-namespace --wait \
-    --timeout 180s
-----
-
-. This operation could take a few minutes and after completing you can review the installed controllers listed below:
-+
-* `rancher-turtles-controller`
-* `capi-operator`
-+
-[NOTE]
-====
-* If `cert-manager` is already available in the cluster, disable its installation as a Rancher Turtles dependency. This prevents dependency conflicts:
-`--set cluster-api-operator.cert-manager.enabled=false`
-* For a list of Rancher Turtles versions, refer to the https://github.com/rancher/turtles/releases[Turtles release page].
-====
-
-
-This is the basic, recommended configuration, which manages the creation of a secret containing the required CAPI feature flags (`CLUSTER_TOPOLOGY`, `EXP_CLUSTER_RESOURCE_SET` and `EXP_MACHINE_POOL` enabled) in the core provider namespace. These feature flags are required to enable additional CAPI functionality.
-
-If you need to override the default behavior and use an existing secret (or add custom environment variables), you can pass the secret name Helm flag. In this case, as a user, you are in charge of managing the secret creation and its content, including enabling the minimum required features: `CLUSTER_TOPOLOGY`, `EXP_CLUSTER_RESOURCE_SET` and `EXP_MACHINE_POOL`.
-
-[,bash]
-----
-helm install ...
-    # Passing secret name and namespace for additional environment variables
-    --set cluster-api-operator.cluster-api.configSecret.name=<secret-name>
-----
-
-The following is an example of a user-managed secret `cluster-api-operator.cluster-api.configSecret.name=variables` with `CLUSTER_TOPOLOGY`, `EXP_CLUSTER_RESOURCE_SET` and `EXP_MACHINE_POOL` feature flags set and an extra custom variable:
-
-.secret.yaml
-[,yaml]
-----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: variables
-  namespace: rancher-turtles-system
-type: Opaque
-stringData:
-  CLUSTER_TOPOLOGY: "true"
-  EXP_CLUSTER_RESOURCE_SET: "true"
-  EXP_MACHINE_POOL: "true"
-  CUSTOM_ENV_VAR: "false"
-----
-
-[IMPORTANT]
-====
-
-For detailed information on the values supported by the chart and their usage, refer to https://documentation.suse.com/cloudnative/cluster-api/{turtles-docs-version}/en/operator/chart.html[Helm chart options].
-====
-
-[#_installing_rancher_turtles_without_cluster_api_capi_operator_as_a_helm_dependency]
-==== Installing {turtles-product-name} without `Cluster API (CAPI) Operator` as a Helm dependency
-
-[NOTE]
-====
-
-Remember that if you opt for this installation option, you must manage the CAPI Operator installation yourself. You can follow the link:https://documentation.suse.com/cloudnative/cluster-api/{turtles-docs-version}/en/operator/manual.html[manual installation guide] in the Cluster API documentation for assistance.
-====
-
-
-. Add the Helm repository containing the `rancher-turtles` chart as the first step in installation:
-+
-[,bash]
-----
-helm repo add turtles https://rancher.github.io/turtles
-helm repo update
-----
-
-. Install the chart into the `rancher-turtles-system` namespace:
-+
-[,bash]
-----
-helm install rancher-turtles turtles/rancher-turtles --version <version>
-    -n rancher-turtles-system
-    --set cluster-api-operator.enabled=false
-    --set cluster-api-operator.cluster-api.enabled=false
-    --create-namespace --wait
-    --dependency-update
-----
-+
-The previous commands tell Helm to ignore installing `cluster-api-operator` as a dependency.
-
-. This operation could take a few minutes and after completing you can review the installed controller listed below:
-+
-* `rancher-turtles-controller`
-
-== Uninstalling {turtles-product-name}
-
-[CAUTION]
-====
-
-When installing Rancher Turtles in your Rancher environment, by default, Rancher Turtles enables the CAPI Operator cleanup. This includes cleaning up CAPI Operator specific webhooks and deployments that otherwise cause issues with Rancher provisioning.
-
-To simplify uninstalling Rancher Turtles (via Rancher or Helm command), the official Rancher Turtles Helm chart includes a `post-delete` hook that removes the following:
+To simplify uninstalling {turtles-product-name} (via Rancher or Helm command), the official {turtles-product-name} Helm chart includes a `post-delete` hook that removes the following:
 
 * Deletes the `mutating-webhook-configuration` and `validating-webhook-configuration` webhooks that are no longer needed.
 * Deletes the CAPI `deployments` that are no longer needed.
 ====
 
-
-To uninstall Rancher Turtles:
+To uninstall {turtles-product-name}:
 
 [,bash]
 ----
-helm uninstall -n rancher-turtles-system rancher-turtles --cascade foreground --wait
+helm uninstall -n cattle-turtles-system rancher-turtles --cascade foreground --wait
 ----
 
 This may take a few minutes to complete.
 
 [NOTE]
 ====
-
 Remember that, if you use a different name for the installation or a different namespace, you may need to customize the command for your specific configuration.
 ====
 
 
-After Rancher Turtles is uninstalled, Rancher's `embedded-cluster-api` feature must be re-enabled:
+After {turtles-product-name} is uninstalled, Rancher's `embedded-cluster-api` feature must be re-enabled:
 
 . Create a `feature.yaml` file, with `embedded-cluster-api` set to true:
 +

--- a/versions/v2.14/modules/en/pages/integrations/cluster-api/cluster-api.adoc
+++ b/versions/v2.14/modules/en/pages/integrations/cluster-api/cluster-api.adoc
@@ -1,6 +1,6 @@
 = {turtles-product-name}
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-04-24
+:revdate: 2026-07-09
 :page-revdate: {revdate}
 :community-path: integrations-in-rancher/cluster-api/index.adoc 
 :product-path: integrations/cluster-api/cluster-api.adoc
@@ -10,14 +10,14 @@ ifeval::["{build-type}" != "community"]
 :xref-turtles-overview: xref:integrations/cluster-api/overview.adoc
 endif::[]
 ifeval::["{build-type}" == "community"]
-:url-cluster-api-index: https://turtles.docs.rancher.com/turtles/{turtles-docs-version}/en/index.html
-:url-cluster-api-capiprovider: https://turtles.docs.rancher.com/turtles/{turtles-docs-version}/en/reference/capiprovider.html
+:url-cluster-api-index: https://turtles.docs.rancher.com/turtles/stable/en/index.html
+:url-cluster-api-capiprovider: https://turtles.docs.rancher.com/turtles/stable/en/reference/capiprovider.html
 :xref-turtles-overview: xref:integrations-in-rancher/cluster-api/overview.adoc
 endif::[]
 
-{url-cluster-api-index}[{turtles-product-name}] is a https://kubernetes.io/docs/concepts/extend-kubernetes/operator/#operators-in-kubernetes[Kubernetes Operator] that manages the lifecycle of provisioned Kubernetes clusters, by providing integration between your Cluster API (CAPI) and Rancher. With Rancher Turtles, you can:
+{url-cluster-api-index}[{turtles-product-name}] is a https://kubernetes.io/docs/concepts/extend-kubernetes/operator/#operators-in-kubernetes[Kubernetes Operator] that manages the lifecycle of provisioned Kubernetes clusters by integrating Cluster API (CAPI) and Rancher where it is automatically deployed as a Rancher system component. With {turtles-product-name}, you can:
 
 * Import CAPI clusters into Rancher, by installing the Rancher Cluster Agent in CAPI provisioned clusters.
 * Manage the https://cluster-api-operator.sigs.k8s.io/[CAPI Operator] using the {url-cluster-api-capiprovider}[CAPIProvider] resource.
 
-The {xref-turtles-overview}[Overview] section outlines installation options, Rancher Turtles architecture, and a brief demo. For more details, see the {url-cluster-api-index}[{turtles-product-name} documentation].
+The {xref-turtles-overview}[Overview] section outlines installing CAPI providers, Supply-chain Levels for Software Artifacts (SLSA) security compliance, and uninstalling {turtles-product-name}. For more details, see the {url-cluster-api-index}[{turtles-product-name} documentation].

--- a/versions/v2.14/modules/en/pages/integrations/cluster-api/cluster-api.adoc
+++ b/versions/v2.14/modules/en/pages/integrations/cluster-api/cluster-api.adoc
@@ -10,8 +10,8 @@ ifeval::["{build-type}" != "community"]
 :xref-turtles-overview: xref:integrations/cluster-api/overview.adoc
 endif::[]
 ifeval::["{build-type}" == "community"]
-:url-cluster-api-index: https://turtles.docs.rancher.com/turtles/stable/en/index.html
-:url-cluster-api-capiprovider: https://turtles.docs.rancher.com/turtles/stable/en/reference/capiprovider.html
+:url-cluster-api-index: https://turtles.docs.rancher.com/turtles/{turtles-docs-version}/en/index.html
+:url-cluster-api-capiprovider: https://turtles.docs.rancher.com/turtles/{turtles-docs-version}/en/reference/capiprovider.html
 :xref-turtles-overview: xref:integrations-in-rancher/cluster-api/overview.adoc
 endif::[]
 

--- a/versions/v2.14/modules/en/pages/integrations/cluster-api/overview.adoc
+++ b/versions/v2.14/modules/en/pages/integrations/cluster-api/overview.adoc
@@ -1,222 +1,80 @@
 = Overview
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-04-06
+:revdate: 2026-07-09
 :page-revdate: {revdate}
 :community-path: integrations-in-rancher/cluster-api/overview.adoc 
 :product-path: integrations/cluster-api/overview.adoc
 :experimental:
 ifeval::["{build-type}" != "community"]
-:url-capi-overview: https://documentation.suse.com/cloudnative/cluster-api/latest/en/index.html
+:xref-ref-capiprovider: https://documentation.suse.com/cloudnative/cluster-api/{turtles-docs-version}/en/reference/capiprovider.html
 :url-capi-slsa: https://documentation.suse.com/cloudnative/cluster-api/{turtles-docs-version}/en/security/slsa.html
 endif::[]
 ifeval::["{build-type}" == "community"]
-:url-capi-overview: https://turtles.docs.rancher.com/turtles/stable/en/index.html
-:url-capi-slsa: https://turtles.docs.rancher.com/turtles/{turtles-docs-version}/en/security/slsa.html
+:xref-ref-capiprovider: https://turtles.docs.rancher.com/turtles/stable/en/reference/capiprovider.html
+:url-capi-slsa: https://turtles.docs.rancher.com/turtles/stable/en/security/slsa.html 
 endif::[]
 
-[#_architecture_diagram]
-== Architecture Diagram
+[NOTE]
+====
+The core CAPI controller manifest is embedded in a ConfigMap, which simplifies operation in air-gapped environments.
+====
 
-Below is a visual representation of the key components of Rancher Turtles and their relationship to Rancher and the Rancher Cluster Agent. Understanding these components is essential for gaining insights into how Rancher leverages the CAPI operator for cluster management.
+{turtles-product-name} is automatically deployed as a system component in the `cattle-turtles-system` namespace. This includes:
 
-image::30000ft_view.png[overview]
+* The `rancher-turtles-controller-manager` pod, which handles all CAPI-related resources.
+* Core CAPI CRDs and the core CAPI controller.
+* The `CAPIProvider` custom resource, which allows declarative definition of CAPI providers.
 
 [#_security]
 == Security
 
 As defined by https://slsa.dev/spec/v1.0/about[Supply-chain Levels for Software Artifacts (SLSA)], SLSA is a set of incrementally adoptable guidelines for supply chain security, established by industry consensus. The specification set by SLSA is useful for both software producers and consumers: producers can follow SLSA's guidelines to make their software supply chain more secure, and consumers can use SLSA to make decisions about whether to trust a software package.
 
-Rancher Turtles meets https://slsa.dev/spec/v1.0/levels#build-l3[SLSA Level 3] requirements as an appropriate hardened build platform, with consistent build processes, and provenance distribution. For more information, visit the {url-capi-slsa}[{turtles-product-name} Security] document.
+{turtles-product-name} meets https://slsa.dev/spec/v1.0/levels#build-l3[SLSA Level 3] requirements as an appropriate hardened build platform, with consistent build processes, and provenance distribution. For more information, visit the {url-capi-slsa}[{turtles-product-name} Security] document.
 
-[#_prerequisites]
-== Prerequisites
+[#_installing_capi_providers]
+== Installing CAPI Providers
 
-[NOTE]
-====
-Starting with Rancher v2.14, the built-in `embedded-cluster-api` functionality (also known as the `rancher-provisioning-capi` chart) has been removed. {url-capi-overview}[{turtles-product-name}] is now the only supported method for Cluster API integration with Rancher.
+With {turtles-product-name} embedded in Rancher, CAPI providers are no longer bundled by default. Providers are managed declaratively using the `CAPIProvider` custom resource. 
 
-If you are upgrading from a previous version of Rancher (v2.13 or earlier), you no longer need to manually disable the `embedded-cluster-api` feature flag or clean up related webhooks before installing {turtles-product-name}.
-====
+ifeval::["{build-type}" != "community"]
+A separate providers chart for Prime users is available for installing certified providers. For more information, refer to https://documentation.suse.com/cloudnative/cluster-api/{turtles-docs-version}/en/user/providers.html[Install certified providers].
+endif::[]
 
-[#_installing_the_turtles_product_name_operator]
-== Installing the {turtles-product-name} Operator
+For example, to define a provider:
 
-You can install the Rancher Turtles operator via the Rancher UI, or with Helm. The first method is recommended for most environments.
-
-[CAUTION]
-====
-If you already have the Cluster API (CAPI) Operator installed in your cluster, you must use the <<_installing_via_helm,manual Helm installation method>>.
-====
-
-
-[#_installing_via_the_rancher_ui]
-=== Installing via the Rancher UI
-
-By adding the Turtles repository via the Rancher UI, Rancher can process the installation and configuration of the CAPI Extension.
-
-. Click *☰*. Under *Explore Cluster* in the left navigation menu, select *local*.
-. In the left navigation menu of the *Cluster Dashboard*, select menu:Apps[Repositories].
-. Click *Create* to add a new repository.
-. Enter the following:
- ** *Name*: turtles
- ** *Index URL*: https://rancher.github.io/turtles
-. Wait until the new repository has a status of `Active`.
-. In the left navigation menu, select menu:Apps[Charts].
-. Enter "turtles" into the search filter to find the Turtles chart.
-. Click *Rancher Turtles - the Cluster API Extension*.
-. Click menu:Install[Next > Install].
-
-This process uses the default values for the Helm chart, which are good for most installations. If your configuration requires overriding some of these defaults, you can either specify the values during installation from the Rancher UI or you can <<_installing_via_helm,manually install the chart via Helm>>. For details about available values, see the https://documentation.suse.com/cloudnative/cluster-api/{turtles-docs-version}/en/operator/chart.html[Cluster API documentation].
-
-The installation may take a few minutes and after completing you can see the following new deployments in the cluster:
-
-* `rancher-turtles-system/rancher-turtles-controller-manager`
-* `rancher-turtles-system/rancher-turtles-cluster-api-operator`
-* `capi-system/capi-controller-manager`
-
-[#_demo]
-==== Demo
-
-This demo illustrates how to use the Rancher UI to install Rancher Turtles, create/import a CAPI cluster, and install monitoring on the cluster:+++<iframe width="560" height="315" src="https://www.youtube.com/embed/lGsr7KfBjgU?si=ORkzuAJjcdXUXMxh" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen="">++++++</iframe>+++
-
-[#_installing_via_helm]
-=== Installing via Helm
-
-There are two ways to install Rancher Turtles with Helm, depending on whether you include the https://github.com/kubernetes-sigs/cluster-api-operator[CAPI Operator] as a dependency:
-
-* <<_installing_rancher_turtles_with_cluster_api_capi_operator_as_a_helm_dependency,Install Rancher Turtles with CAPI Operator as a dependency>>.
-* <<_installing_rancher_turtles_without_cluster_api_capi_operator_as_a_helm_dependency,Install Rancher Turtles without CAPI Operator>>.
-
-The CAPI Operator is required for installing Rancher Turtles. You can choose whether you want to take care of this dependency yourself or let the Rancher Turtles Helm chart manage it for you. <<_installing_rancher_turtles_with_cluster_api_capi_operator_as_a_helm_dependency,Installing Turtles as a dependency>> is simpler, but your best option depends on your specific configuration.
-
-The CAPI Operator allows for handling the lifecycle of https://documentation.suse.com/cloudnative/cluster-api/{turtles-docs-version}/en/operator/manual.html[CAPI providers] using a declarative approach, extending the capabilities of `clusterctl`. If you want to learn more about it, you can refer to https://cluster-api-operator.sigs.k8s.io/[Cluster API Operator book].
-
-[#_installing_rancher_turtles_with_cluster_api_capi_operator_as_a_helm_dependency]
-==== Installing {turtles-product-name} with `Cluster API (CAPI) Operator` as a Helm dependency
-
-. Add the Helm repository containing the `rancher-turtles` chart as the first step in installation:
-+
-[,bash]
+[source,yaml]
 ----
-helm repo add turtles https://rancher.github.io/turtles
-helm repo update
-----
-
-. As mentioned before, installing Rancher Turtles requires the https://github.com/kubernetes-sigs/cluster-api-operator[CAPI Operator]. The Helm chart can automatically install it with a minimal set of flags:
-+
-[,bash]
-----
-helm install rancher-turtles turtles/rancher-turtles --version <version> \
-    -n rancher-turtles-system \
-    --dependency-update \
-    --create-namespace --wait \
-    --timeout 180s
-----
-
-. This operation could take a few minutes and after completing you can review the installed controllers listed below:
-+
-* `rancher-turtles-controller`
-* `capi-operator`
-+
-[NOTE]
-====
-* If `cert-manager` is already available in the cluster, disable its installation as a Rancher Turtles dependency. This prevents dependency conflicts:
-`--set cluster-api-operator.cert-manager.enabled=false`
-* For a list of Rancher Turtles versions, refer to the https://github.com/rancher/turtles/releases[Turtles release page].
-====
-
-
-This is the basic, recommended configuration, which manages the creation of a secret containing the required CAPI feature flags (`CLUSTER_TOPOLOGY`, `EXP_CLUSTER_RESOURCE_SET` and `EXP_MACHINE_POOL` enabled) in the core provider namespace. These feature flags are required to enable additional CAPI functionality.
-
-If you need to override the default behavior and use an existing secret (or add custom environment variables), you can pass the secret name Helm flag. In this case, as a user, you are in charge of managing the secret creation and its content, including enabling the minimum required features: `CLUSTER_TOPOLOGY`, `EXP_CLUSTER_RESOURCE_SET` and `EXP_MACHINE_POOL`.
-
-[,bash]
-----
-helm install ...
-    # Passing secret name and namespace for additional environment variables
-    --set cluster-api-operator.cluster-api.configSecret.name=<secret-name>
-----
-
-The following is an example of a user-managed secret `cluster-api-operator.cluster-api.configSecret.name=variables` with `CLUSTER_TOPOLOGY`, `EXP_CLUSTER_RESOURCE_SET` and `EXP_MACHINE_POOL` feature flags set and an extra custom variable:
-
-.secret.yaml
-[,yaml]
-----
-apiVersion: v1
-kind: Secret
+apiVersion: turtles-capi.cattle.io/v1alpha1
+kind: CAPIProvider
 metadata:
-  name: variables
-  namespace: rancher-turtles-system
-type: Opaque
-stringData:
-  CLUSTER_TOPOLOGY: "true"
-  EXP_CLUSTER_RESOURCE_SET: "true"
-  EXP_MACHINE_POOL: "true"
-  CUSTOM_ENV_VAR: "false"
+  name: aws
+  namespace: cattle-turtles-system
+spec:
+  type: infrastructure
+  name: aws
 ----
 
-[IMPORTANT]
-====
+Refer to the {xref-ref-capiprovider}[CAPIProvider reference] for the full list of configuration options.
 
-For detailed information on the values supported by the chart and their usage, refer to https://documentation.suse.com/cloudnative/cluster-api/{turtles-docs-version}/en/operator/chart.html[Helm chart options].
-====
-
-[#_installing_rancher_turtles_without_cluster_api_capi_operator_as_a_helm_dependency]
-==== Installing {turtles-product-name} without `Cluster API (CAPI) Operator` as a Helm dependency
-
-[NOTE]
-====
-
-Remember that if you opt for this installation option, you must manage the CAPI Operator installation yourself. You can follow the link:https://documentation.suse.com/cloudnative/cluster-api/{turtles-docs-version}/en/operator/manual.html[manual installation guide] in the Cluster API documentation for assistance.
-====
-
-
-. Add the Helm repository containing the `rancher-turtles` chart as the first step in installation:
-+
-[,bash]
-----
-helm repo add turtles https://rancher.github.io/turtles
-helm repo update
-----
-
-. Install the chart into the `rancher-turtles-system` namespace:
-+
-[,bash]
-----
-helm install rancher-turtles turtles/rancher-turtles --version <version>
-    -n rancher-turtles-system
-    --set cluster-api-operator.enabled=false
-    --set cluster-api-operator.cluster-api.enabled=false
-    --create-namespace --wait
-    --dependency-update
-----
-+
-The previous commands tell Helm to ignore installing `cluster-api-operator` as a dependency.
-
-. This operation could take a few minutes and after completing you can review the installed controller listed below:
-+
-* `rancher-turtles-controller`
-
-[#_uninstalling_turtles_product_name]
-== Uninstalling {turtles-product-name}
+[#_uninstalling]
+== Uninstalling
 
 [CAUTION]
 ====
+When installing {turtles-product-name} in your Rancher environment, the CAPI Operator cleanup is enabled by default. This includes cleaning up CAPI Operator specific webhooks and deployments that otherwise cause issues with Rancher provisioning.
 
-When installing Rancher Turtles in your Rancher environment, by default, Rancher Turtles enables the CAPI Operator cleanup. This includes cleaning up CAPI Operator specific webhooks and deployments that otherwise cause issues with Rancher provisioning.
-
-To simplify uninstalling Rancher Turtles (via Rancher or Helm command), the official Rancher Turtles Helm chart includes a `post-delete` hook that removes the following:
+To simplify uninstalling {turtles-product-name} (via Rancher or Helm command), the official {turtles-product-name} Helm chart includes a `post-delete` hook that removes the following:
 
 * Deletes the `mutating-webhook-configuration` and `validating-webhook-configuration` webhooks that are no longer needed.
 * Deletes the CAPI `deployments` that are no longer needed.
 ====
 
-
-To uninstall Rancher Turtles:
+To uninstall {turtles-product-name}:
 
 [,bash]
 ----
-helm uninstall -n rancher-turtles-system rancher-turtles --cascade foreground --wait
+helm uninstall -n cattle-turtles-system rancher-turtles --cascade foreground --wait
 ----
 
 This may take a few minutes to complete.
@@ -225,3 +83,27 @@ This may take a few minutes to complete.
 ====
 Remember that, if you use a different name for the installation or a different namespace, you may need to customize the command for your specific configuration.
 ====
+
+
+After {turtles-product-name} is uninstalled, Rancher's `embedded-cluster-api` feature must be re-enabled:
+
+. Create a `feature.yaml` file, with `embedded-cluster-api` set to true:
++
+.feature.yaml
+[,yaml]
+----
+apiVersion: management.cattle.io/v3
+kind: Feature
+metadata:
+  name: embedded-cluster-api
+spec:
+  value: true
+
+----
+
+. Use `kubectl` to apply the `feature.yaml` file to the cluster:
++
+[,bash]
+----
+kubectl apply -f feature.yaml
+----

--- a/versions/v2.14/modules/en/pages/integrations/cluster-api/overview.adoc
+++ b/versions/v2.14/modules/en/pages/integrations/cluster-api/overview.adoc
@@ -10,8 +10,8 @@ ifeval::["{build-type}" != "community"]
 :url-capi-slsa: https://documentation.suse.com/cloudnative/cluster-api/{turtles-docs-version}/en/security/slsa.html
 endif::[]
 ifeval::["{build-type}" == "community"]
-:xref-ref-capiprovider: https://turtles.docs.rancher.com/turtles/stable/en/reference/capiprovider.html
-:url-capi-slsa: https://turtles.docs.rancher.com/turtles/stable/en/security/slsa.html 
+:xref-ref-capiprovider: https://turtles.docs.rancher.com/turtles/{turtles-docs-version}/en/reference/capiprovider.html
+:url-capi-slsa: https://turtles.docs.rancher.com/turtles/{turtles-docs-version}/en/security/slsa.html
 endif::[]
 
 [NOTE]

--- a/versions/v2.15/modules/en/pages/integrations/cluster-api/cluster-api.adoc
+++ b/versions/v2.15/modules/en/pages/integrations/cluster-api/cluster-api.adoc
@@ -1,6 +1,6 @@
 = {turtles-product-name}
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-04-24
+:revdate: 2026-07-09
 :page-revdate: {revdate}
 :community-path: integrations-in-rancher/cluster-api/index.adoc 
 :product-path: integrations/cluster-api/cluster-api.adoc
@@ -10,14 +10,14 @@ ifeval::["{build-type}" != "community"]
 :xref-turtles-overview: xref:integrations/cluster-api/overview.adoc
 endif::[]
 ifeval::["{build-type}" == "community"]
-:url-cluster-api-index: https://turtles.docs.rancher.com/turtles/{turtles-docs-version}/en/index.html
-:url-cluster-api-capiprovider: https://turtles.docs.rancher.com/turtles/{turtles-docs-version}/en/reference/capiprovider.html
+:url-cluster-api-index: https://turtles.docs.rancher.com/turtles/stable/en/index.html
+:url-cluster-api-capiprovider: https://turtles.docs.rancher.com/turtles/stable/en/reference/capiprovider.html
 :xref-turtles-overview: xref:integrations-in-rancher/cluster-api/overview.adoc
 endif::[]
 
-{url-cluster-api-index}[{turtles-product-name}] is a https://kubernetes.io/docs/concepts/extend-kubernetes/operator/#operators-in-kubernetes[Kubernetes Operator] that manages the lifecycle of provisioned Kubernetes clusters, by providing integration between your Cluster API (CAPI) and Rancher. With Rancher Turtles, you can:
+{url-cluster-api-index}[{turtles-product-name}] is a https://kubernetes.io/docs/concepts/extend-kubernetes/operator/#operators-in-kubernetes[Kubernetes Operator] that manages the lifecycle of provisioned Kubernetes clusters by integrating Cluster API (CAPI) and Rancher where it is automatically deployed as a Rancher system component. With {turtles-product-name}, you can:
 
 * Import CAPI clusters into Rancher, by installing the Rancher Cluster Agent in CAPI provisioned clusters.
 * Manage the https://cluster-api-operator.sigs.k8s.io/[CAPI Operator] using the {url-cluster-api-capiprovider}[CAPIProvider] resource.
 
-The {xref-turtles-overview}[Overview] section outlines installation options, Rancher Turtles architecture, and a brief demo. For more details, see the {url-cluster-api-index}[{turtles-product-name} documentation].
+The {xref-turtles-overview}[Overview] section outlines installing CAPI providers, Supply-chain Levels for Software Artifacts (SLSA) security compliance, and uninstalling {turtles-product-name}. For more details, see the {url-cluster-api-index}[{turtles-product-name} documentation].

--- a/versions/v2.15/modules/en/pages/integrations/cluster-api/cluster-api.adoc
+++ b/versions/v2.15/modules/en/pages/integrations/cluster-api/cluster-api.adoc
@@ -10,8 +10,8 @@ ifeval::["{build-type}" != "community"]
 :xref-turtles-overview: xref:integrations/cluster-api/overview.adoc
 endif::[]
 ifeval::["{build-type}" == "community"]
-:url-cluster-api-index: https://turtles.docs.rancher.com/turtles/stable/en/index.html
-:url-cluster-api-capiprovider: https://turtles.docs.rancher.com/turtles/stable/en/reference/capiprovider.html
+:url-cluster-api-index: https://turtles.docs.rancher.com/turtles/{turtles-docs-version}/en/index.html
+:url-cluster-api-capiprovider: https://turtles.docs.rancher.com/turtles/{turtles-docs-version}/en/reference/capiprovider.html
 :xref-turtles-overview: xref:integrations-in-rancher/cluster-api/overview.adoc
 endif::[]
 

--- a/versions/v2.15/modules/en/pages/integrations/cluster-api/overview.adoc
+++ b/versions/v2.15/modules/en/pages/integrations/cluster-api/overview.adoc
@@ -10,8 +10,8 @@ ifeval::["{build-type}" != "community"]
 :url-capi-slsa: https://documentation.suse.com/cloudnative/cluster-api/{turtles-docs-version}/en/security/slsa.html
 endif::[]
 ifeval::["{build-type}" == "community"]
-:xref-ref-capiprovider: https://turtles.docs.rancher.com/turtles/stable/en/reference/capiprovider.html
-:url-capi-slsa: https://turtles.docs.rancher.com/turtles/stable/en/security/slsa.html 
+:xref-ref-capiprovider: https://turtles.docs.rancher.com/turtles/stable/en/{turtles-docs-version}/capiprovider.html
+:url-capi-slsa: https://turtles.docs.rancher.com/turtles/{turtles-docs-version}/en/security/slsa.html 
 endif::[]
 
 [NOTE]

--- a/versions/v2.15/modules/en/pages/integrations/cluster-api/overview.adoc
+++ b/versions/v2.15/modules/en/pages/integrations/cluster-api/overview.adoc
@@ -1,222 +1,81 @@
 = Overview
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-04-06
+:revdate: 2026-07-09
 :page-revdate: {revdate}
 :community-path: integrations-in-rancher/cluster-api/overview.adoc 
 :product-path: integrations/cluster-api/overview.adoc
 :experimental:
 ifeval::["{build-type}" != "community"]
-:url-capi-overview: https://documentation.suse.com/cloudnative/cluster-api/latest/en/index.html
+:xref-ref-capiprovider: https://documentation.suse.com/cloudnative/cluster-api/{turtles-docs-version}/en/reference/capiprovider.html
 :url-capi-slsa: https://documentation.suse.com/cloudnative/cluster-api/{turtles-docs-version}/en/security/slsa.html
 endif::[]
 ifeval::["{build-type}" == "community"]
-:url-capi-overview: https://turtles.docs.rancher.com/turtles/stable/en/index.html
-:url-capi-slsa: https://turtles.docs.rancher.com/turtles/{turtles-docs-version}/en/security/slsa.html
+:xref-ref-capiprovider: https://turtles.docs.rancher.com/turtles/stable/en/reference/capiprovider.html
+:url-capi-slsa: https://turtles.docs.rancher.com/turtles/stable/en/security/slsa.html 
 endif::[]
 
-[#_architecture_diagram]
-== Architecture Diagram
+[NOTE]
+====
+The core CAPI controller manifest is embedded in a ConfigMap, which simplifies operation in air-gapped environments.
+====
 
-Below is a visual representation of the key components of Rancher Turtles and their relationship to Rancher and the Rancher Cluster Agent. Understanding these components is essential for gaining insights into how Rancher leverages the CAPI operator for cluster management.
+{turtles-product-name} is automatically deployed as a system component in the `cattle-turtles-system` namespace. This includes:
 
-image::30000ft_view.png[overview]
+* The `rancher-turtles-controller-manager` pod, which handles all CAPI-related resources.
+* Core CAPI CRDs and the core CAPI controller.
+* The `CAPIProvider` custom resource, which allows declarative definition of CAPI providers.
 
 [#_security]
 == Security
 
 As defined by https://slsa.dev/spec/v1.0/about[Supply-chain Levels for Software Artifacts (SLSA)], SLSA is a set of incrementally adoptable guidelines for supply chain security, established by industry consensus. The specification set by SLSA is useful for both software producers and consumers: producers can follow SLSA's guidelines to make their software supply chain more secure, and consumers can use SLSA to make decisions about whether to trust a software package.
 
-Rancher Turtles meets https://slsa.dev/spec/v1.0/levels#build-l3[SLSA Level 3] requirements as an appropriate hardened build platform, with consistent build processes, and provenance distribution. For more information, visit the {url-capi-slsa}[{turtles-product-name} Security] document.
+{turtles-product-name} meets https://slsa.dev/spec/v1.0/levels#build-l3[SLSA Level 3] requirements as an appropriate hardened build platform, with consistent build processes, and provenance distribution. For more information, visit the {url-capi-slsa}[{turtles-product-name} Security] document.
 
-[#_prerequisites]
-== Prerequisites
+[#_installing_capi_providers]
+== Installing CAPI Providers
 
-[NOTE]
-====
-Starting with Rancher v2.14, the built-in `embedded-cluster-api` functionality (also known as the `rancher-provisioning-capi` chart) has been removed. {url-capi-overview}[{turtles-product-name}] is now the only supported method for Cluster API integration with Rancher.
+With {turtles-product-name} embedded in Rancher, CAPI providers are no longer bundled by default. Providers are managed declaratively using the `CAPIProvider` custom resource. 
 
-If you are upgrading from a previous version of Rancher (v2.13 or earlier), you no longer need to manually disable the `embedded-cluster-api` feature flag or clean up related webhooks before installing {turtles-product-name}.
-====
+ifeval::["{build-type}" != "community"]
+A separate providers chart for Prime users is available for installing certified providers. For more information, refer to https://documentation.suse.com/cloudnative/cluster-api/{turtles-docs-version}/en/user/providers.html[Install certified providers].
+endif::[]
 
-[#_installing_the_turtles_product_name_operator]
-== Installing the {turtles-product-name} Operator
+For example, to define a provider:
 
-You can install the Rancher Turtles operator via the Rancher UI, or with Helm. The first method is recommended for most environments.
-
-[CAUTION]
-====
-If you already have the Cluster API (CAPI) Operator installed in your cluster, you must use the <<_installing_via_helm,manual Helm installation method>>.
-====
-
-
-[#_installing_via_the_rancher_ui]
-=== Installing via the Rancher UI
-
-By adding the Turtles repository via the Rancher UI, Rancher can process the installation and configuration of the CAPI Extension.
-
-. Click *☰*. Under *Explore Cluster* in the left navigation menu, select *local*.
-. In the left navigation menu of the *Cluster Dashboard*, select menu:Apps[Repositories].
-. Click *Create* to add a new repository.
-. Enter the following:
- ** *Name*: turtles
- ** *Index URL*: https://rancher.github.io/turtles
-. Wait until the new repository has a status of `Active`.
-. In the left navigation menu, select menu:Apps[Charts].
-. Enter "turtles" into the search filter to find the Turtles chart.
-. Click *Rancher Turtles - the Cluster API Extension*.
-. Click menu:Install[Next > Install].
-
-This process uses the default values for the Helm chart, which are good for most installations. If your configuration requires overriding some of these defaults, you can either specify the values during installation from the Rancher UI or you can <<_installing_via_helm,manually install the chart via Helm>>. For details about available values, see the https://documentation.suse.com/cloudnative/cluster-api/{turtles-docs-version}/en/operator/chart.html[Cluster API documentation].
-
-The installation may take a few minutes and after completing you can see the following new deployments in the cluster:
-
-* `rancher-turtles-system/rancher-turtles-controller-manager`
-* `rancher-turtles-system/rancher-turtles-cluster-api-operator`
-* `capi-system/capi-controller-manager`
-
-[#_demo]
-==== Demo
-
-This demo illustrates how to use the Rancher UI to install Rancher Turtles, create/import a CAPI cluster, and install monitoring on the cluster:+++<iframe width="560" height="315" src="https://www.youtube.com/embed/lGsr7KfBjgU?si=ORkzuAJjcdXUXMxh" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen="">++++++</iframe>+++
-
-[#_installing_via_helm]
-=== Installing via Helm
-
-There are two ways to install Rancher Turtles with Helm, depending on whether you include the https://github.com/kubernetes-sigs/cluster-api-operator[CAPI Operator] as a dependency:
-
-* <<_installing_rancher_turtles_with_cluster_api_capi_operator_as_a_helm_dependency,Install Rancher Turtles with CAPI Operator as a dependency>>.
-* <<_installing_rancher_turtles_without_cluster_api_capi_operator_as_a_helm_dependency,Install Rancher Turtles without CAPI Operator>>.
-
-The CAPI Operator is required for installing Rancher Turtles. You can choose whether you want to take care of this dependency yourself or let the Rancher Turtles Helm chart manage it for you. <<_installing_rancher_turtles_with_cluster_api_capi_operator_as_a_helm_dependency,Installing Turtles as a dependency>> is simpler, but your best option depends on your specific configuration.
-
-The CAPI Operator allows for handling the lifecycle of https://documentation.suse.com/cloudnative/cluster-api/{turtles-docs-version}/en/operator/manual.html[CAPI providers] using a declarative approach, extending the capabilities of `clusterctl`. If you want to learn more about it, you can refer to https://cluster-api-operator.sigs.k8s.io/[Cluster API Operator book].
-
-[#_installing_rancher_turtles_with_cluster_api_capi_operator_as_a_helm_dependency]
-==== Installing {turtles-product-name} with `Cluster API (CAPI) Operator` as a Helm dependency
-
-. Add the Helm repository containing the `rancher-turtles` chart as the first step in installation:
-+
-[,bash]
+[source,yaml]
 ----
-helm repo add turtles https://rancher.github.io/turtles
-helm repo update
-----
-
-. As mentioned before, installing Rancher Turtles requires the https://github.com/kubernetes-sigs/cluster-api-operator[CAPI Operator]. The Helm chart can automatically install it with a minimal set of flags:
-+
-[,bash]
-----
-helm install rancher-turtles turtles/rancher-turtles --version <version> \
-    -n rancher-turtles-system \
-    --dependency-update \
-    --create-namespace --wait \
-    --timeout 180s
-----
-
-. This operation could take a few minutes and after completing you can review the installed controllers listed below:
-+
-* `rancher-turtles-controller`
-* `capi-operator`
-+
-[NOTE]
-====
-* If `cert-manager` is already available in the cluster, disable its installation as a Rancher Turtles dependency. This prevents dependency conflicts:
-`--set cluster-api-operator.cert-manager.enabled=false`
-* For a list of Rancher Turtles versions, refer to the https://github.com/rancher/turtles/releases[Turtles release page].
-====
-
-
-This is the basic, recommended configuration, which manages the creation of a secret containing the required CAPI feature flags (`CLUSTER_TOPOLOGY`, `EXP_CLUSTER_RESOURCE_SET` and `EXP_MACHINE_POOL` enabled) in the core provider namespace. These feature flags are required to enable additional CAPI functionality.
-
-If you need to override the default behavior and use an existing secret (or add custom environment variables), you can pass the secret name Helm flag. In this case, as a user, you are in charge of managing the secret creation and its content, including enabling the minimum required features: `CLUSTER_TOPOLOGY`, `EXP_CLUSTER_RESOURCE_SET` and `EXP_MACHINE_POOL`.
-
-[,bash]
-----
-helm install ...
-    # Passing secret name and namespace for additional environment variables
-    --set cluster-api-operator.cluster-api.configSecret.name=<secret-name>
-----
-
-The following is an example of a user-managed secret `cluster-api-operator.cluster-api.configSecret.name=variables` with `CLUSTER_TOPOLOGY`, `EXP_CLUSTER_RESOURCE_SET` and `EXP_MACHINE_POOL` feature flags set and an extra custom variable:
-
-.secret.yaml
-[,yaml]
-----
-apiVersion: v1
-kind: Secret
+apiVersion: turtles-capi.cattle.io/v1alpha1
+kind: CAPIProvider
 metadata:
-  name: variables
-  namespace: rancher-turtles-system
-type: Opaque
-stringData:
-  CLUSTER_TOPOLOGY: "true"
-  EXP_CLUSTER_RESOURCE_SET: "true"
-  EXP_MACHINE_POOL: "true"
-  CUSTOM_ENV_VAR: "false"
+  name: aws
+  namespace: cattle-turtles-system
+spec:
+  type: infrastructure
+  name: aws
 ----
 
-[IMPORTANT]
-====
+Refer to the {xref-ref-capiprovider}[CAPIProvider reference] for the full list of configuration options.
 
-For detailed information on the values supported by the chart and their usage, refer to https://documentation.suse.com/cloudnative/cluster-api/{turtles-docs-version}/en/operator/chart.html[Helm chart options].
-====
-
-[#_installing_rancher_turtles_without_cluster_api_capi_operator_as_a_helm_dependency]
-==== Installing {turtles-product-name} without `Cluster API (CAPI) Operator` as a Helm dependency
-
-[NOTE]
-====
-
-Remember that if you opt for this installation option, you must manage the CAPI Operator installation yourself. You can follow the link:https://documentation.suse.com/cloudnative/cluster-api/{turtles-docs-version}/en/operator/manual.html[manual installation guide] in the Cluster API documentation for assistance.
-====
-
-
-. Add the Helm repository containing the `rancher-turtles` chart as the first step in installation:
-+
-[,bash]
-----
-helm repo add turtles https://rancher.github.io/turtles
-helm repo update
-----
-
-. Install the chart into the `rancher-turtles-system` namespace:
-+
-[,bash]
-----
-helm install rancher-turtles turtles/rancher-turtles --version <version>
-    -n rancher-turtles-system
-    --set cluster-api-operator.enabled=false
-    --set cluster-api-operator.cluster-api.enabled=false
-    --create-namespace --wait
-    --dependency-update
-----
-+
-The previous commands tell Helm to ignore installing `cluster-api-operator` as a dependency.
-
-. This operation could take a few minutes and after completing you can review the installed controller listed below:
-+
-* `rancher-turtles-controller`
-
-[#_uninstalling_turtles_product_name]
-== Uninstalling {turtles-product-name}
+[#_uninstalling]
+== Uninstalling
 
 [CAUTION]
 ====
 
-When installing Rancher Turtles in your Rancher environment, by default, Rancher Turtles enables the CAPI Operator cleanup. This includes cleaning up CAPI Operator specific webhooks and deployments that otherwise cause issues with Rancher provisioning.
+When installing {turtles-product-name} in your Rancher environment, the CAPI Operator cleanup is enabled by default. This includes cleaning up CAPI Operator specific webhooks and deployments that otherwise cause issues with Rancher provisioning.
 
-To simplify uninstalling Rancher Turtles (via Rancher or Helm command), the official Rancher Turtles Helm chart includes a `post-delete` hook that removes the following:
+To simplify uninstalling {turtles-product-name} (via Rancher or Helm command), the official {turtles-product-name} Helm chart includes a `post-delete` hook that removes the following:
 
 * Deletes the `mutating-webhook-configuration` and `validating-webhook-configuration` webhooks that are no longer needed.
 * Deletes the CAPI `deployments` that are no longer needed.
 ====
 
-
-To uninstall Rancher Turtles:
+To uninstall {turtles-product-name}:
 
 [,bash]
 ----
-helm uninstall -n rancher-turtles-system rancher-turtles --cascade foreground --wait
+helm uninstall -n cattle-turtles-system rancher-turtles --cascade foreground --wait
 ----
 
 This may take a few minutes to complete.
@@ -225,3 +84,27 @@ This may take a few minutes to complete.
 ====
 Remember that, if you use a different name for the installation or a different namespace, you may need to customize the command for your specific configuration.
 ====
+
+
+After {turtles-product-name} is uninstalled, Rancher's `embedded-cluster-api` feature must be re-enabled:
+
+. Create a `feature.yaml` file, with `embedded-cluster-api` set to true:
++
+.feature.yaml
+[,yaml]
+----
+apiVersion: management.cattle.io/v3
+kind: Feature
+metadata:
+  name: embedded-cluster-api
+spec:
+  value: true
+
+----
+
+. Use `kubectl` to apply the `feature.yaml` file to the cluster:
++
+[,bash]
+----
+kubectl apply -f feature.yaml
+----


### PR DESCRIPTION
Updating Integrations - CAPI section for v2.13 and later as CAPI is installed as a Rancher system component as of Rancher v2.13.

References:
https://documentation.suse.com/cloudnative/cluster-api/v0.26/en/tutorials/rancher.html
https://github.com/rancher/rancher/releases/tag/v2.13.0