### PR TITLE
Update release-maintenance.sh to handle community block markers 

### DIFF
--- a/scripts/release-maintenance.sh
+++ b/scripts/release-maintenance.sh
@@ -151,6 +151,92 @@ EOF
   run_cmd "$file" "$ex_cmd"
 }
 
+# Update a specific block in the release-notes.adoc file.
+update_release_notes_block() {
+  local file="$1"
+  local version="$2"
+  local new_prime_mark="$3"
+  local new_community_mark="$4"
+  local current_marker="$5"
+  local current_end_marker="$6"
+  local past_marker="$7"
+  local rn_link="$8"
+
+  # Check if the block exists in the file before trying to update it.
+  if ! grep -q "//.*${current_marker}\." "$file"; then
+    return 0
+  fi
+
+  local current_block
+  current_block=$(awk "/\/\/.*${current_end_marker}\./{p=0} /\/\/.*${current_marker}\./{p=1; next} p" "$file")
+  
+  # Check if the block is empty or contains only whitespace
+  if [[ -z "$(echo -n "$current_block" | tr -d '[:space:]')" ]]; then
+    current_block=""
+  fi
+
+  local past_block=""
+  if [[ -n "$current_block" ]]; then
+    local old_version
+    # Get the first non-empty line to extract the version
+    old_version=$(echo "$current_block" | awk 'NF' | head -n 1 | cut -d '|' -f 2 | tr -d ' ')
+
+    if [[ -n "$old_version" ]]; then
+      # When moving a version to "Past", update its support matrix link from "N/A" to a URL.
+      local url_version_part="rancher-$(echo "$old_version" | tr '.' '-')"
+      local support_matrix_url="https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/${url_version_part}/"
+      local support_matrix_cell="| ${support_matrix_url}[View]"
+      # Replace the "| N/A" line for the support matrix with the generated URL.
+      # awk 'NF' to remove empty lines before processing with sed
+      past_block=$(echo "$current_block" | awk 'NF' | sed "0,/^| N\/A\$/s#^| N/A\$#${support_matrix_cell}#")
+    else
+      # Fallback if the old version couldn't be parsed, but still remove empty lines.
+      past_block=$(echo "$current_block" | awk 'NF')
+    fi
+    past_block="${past_block}"$'\n'
+  fi
+
+  # Create the new current version entry.
+  local new_current_block
+  new_current_block=$(cat <<EOF
+| ${version}
+| ${rn_link}
+| N/A
+| ${new_prime_mark}
+| ${new_community_mark}
+
+EOF
+)
+
+  # Atomically update the file: insert past version and replace current version.
+  local ex_cmd
+  # Only add the past block if it's not empty
+  if [[ -n "$past_block" ]]; then
+    ex_cmd=$(cat <<EOF
+/\/\/.*${past_marker}\./a
+${past_block}
+.
+/\/\/.*${current_marker}\./+1,/\/\/.*${current_end_marker}\./-1d
+/\/\/.*${current_marker}\./a
+${new_current_block}
+.
+x
+EOF
+)
+  else
+    # If there's no past block to add, just update the current version block.
+    ex_cmd=$(cat <<EOF
+/\/\/.*${current_marker}\./+1,/\/\/.*${current_end_marker}\./-1d
+/\/\/.*${current_marker}\./a
+${new_current_block}
+.
+x
+EOF
+)
+  fi
+  run_cmd "$file" "$ex_cmd"
+}
+
 # Update the release-notes.adoc file.
 update_release_notes() {
   local file="$1"
@@ -160,58 +246,13 @@ update_release_notes() {
 
   echo "-> Updating release notes in $file"
 
-  # 1. Capture the content of the current version block using specific markers.
-  local current_block
-  current_block=$(awk '/\/\/.*CURRENT VERSION END\./{p=0} /\/\/.*CURRENT VERSION\./{p=1; next} p' "$file")
-  if [[ -z "$current_block" ]]; then
-    echo "Error: Could not find 'CURRENT VERSION' block in $file" >&2
-    exit 1
-  fi
+  # Update Product block
+  update_release_notes_block "$file" "$version" "$new_prime_mark" "$new_community_mark" \
+    "CURRENT VERSION" "CURRENT VERSION END" "PAST VERSIONS" "xref:release-notes/${version}.adoc[View]"
 
-  # 2. Create the new past version entry by modifying the captured current block.
-  local old_version
-  old_version=$(echo "$current_block" | head -n 1 | cut -d '|' -f 2 | tr -d ' ')
-
-  local past_block
-  if [[ -n "$old_version" ]]; then
-    # When moving a version to "Past", update its support matrix link from "N/A" to a URL.
-    local url_version_part="rancher-$(echo "$old_version" | tr '.' '-')"
-    local support_matrix_url="https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/${url_version_part}/"
-    local support_matrix_cell="| ${support_matrix_url}[View]"
-    # Replace the "| N/A" line for the support matrix with the generated URL.
-    past_block=$(echo "${current_block}" | sed "0,/^| N\/A\$/s#^| N/A\$#${support_matrix_cell}#")
-  else
-    # Fallback if the old version couldn't be parsed.
-    past_block="${current_block}"
-  fi
-  past_block="${past_block}"$'\n'
-
-  # 3. Create the new current version entry.
-  local new_current_block
-  new_current_block=$(cat <<EOF
-| ${version}
-| xref:release-notes/${version}.adoc[View]
-| N/A
-| ${new_prime_mark}
-| ${new_community_mark}
-
-EOF
-)
-
-  # 4. Atomically update the file: insert past version and replace current version.
-  local ex_cmd
-  ex_cmd=$(cat <<EOF
-/\/\/.*PAST VERSIONS\./a
-${past_block}
-.
-/\/\/.*CURRENT VERSION\./+1,/\/\/.*CURRENT VERSION END\./-1d
-/\/\/.*CURRENT VERSION\./a
-${new_current_block}
-.
-x
-EOF
-)
-  run_cmd "$file" "$ex_cmd"
+  # Update Community block
+  update_release_notes_block "$file" "$version" "$new_prime_mark" "$new_community_mark" \
+    "CURRENT COMMUNITY VERSION" "CURRENT COMMUNITY VERSION END" "PAST COMMUNITY VERSIONS" "https://github.com/rancher/rancher/releases/tag/${version}[GitHub Release]"
 }
 
 # Update a simple compatibility matrix file.

--- a/versions/v2.10/modules/en/pages/release-notes.adoc
+++ b/versions/v2.10/modules/en/pages/release-notes.adoc
@@ -96,6 +96,8 @@ ifeval::["{build-type}" != "community"]
 | N/A
 | &#10003;
 | &#10003;
+// DO NOT EDIT THIS LINE, REQUIRED BY RELEASE SCRIPT. PAST VERSIONS END.
+
 |===
 endif::[]
 ifeval::["{build-type}" == "community"]
@@ -104,11 +106,14 @@ ifeval::["{build-type}" == "community"]
 |===
 | Version | Release Notes | Support Matrix | Prime | Community
 
+// DO NOT EDIT THIS LINE, REQUIRED BY RELEASE SCRIPT. CURRENT COMMUNITY VERSION.
 | v2.10.12
 | https://github.com/rancher/rancher/releases/tag/v2.10.12[GitHub Release]
 | N/A
 | &#10003;
 | N/A
+// DO NOT EDIT THIS LINE, REQUIRED BY RELEASE SCRIPT. CURRENT COMMUNITY VERSION END.
+
 |===
 
 == Past Versions
@@ -116,6 +121,7 @@ ifeval::["{build-type}" == "community"]
 |===
 | Version | Release Notes | Support Matrix | Prime | Community
 
+// DO NOT EDIT THIS LINE, REQUIRED BY RELEASE SCRIPT. PAST COMMUNITY VERSIONS.
 | v2.10.11
 | https://github.com/rancher/rancher/releases/tag/v2.10.11[GitHub Release]
 | https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/rancher-v2-10-11/[View]
@@ -187,5 +193,7 @@ ifeval::["{build-type}" == "community"]
 | N/A
 | &#10003;
 | &#10003;
+// DO NOT EDIT THIS LINE, REQUIRED BY RELEASE SCRIPT. PAST COMMUNITY VERSIONS END.
+
 |===
 endif::[]

--- a/versions/v2.11/modules/en/pages/release-notes.adoc
+++ b/versions/v2.11/modules/en/pages/release-notes.adoc
@@ -124,11 +124,13 @@ ifeval::["{build-type}" == "community"]
 |===
 | Version | Release Notes | Support Matrix | Prime | Community
 
+// DO NOT EDIT THIS LINE, REQUIRED BY RELEASE SCRIPT. CURRENT COMMUNITY VERSION.
 | v2.11.15
 | https://github.com/rancher/rancher/releases/tag/v2.11.15[GitHub Release]
 | N/A
 | &#10003;
 | N/A
+// DO NOT EDIT THIS LINE, REQUIRED BY RELEASE SCRIPT. CURRENT COMMUNITY VERSION END.
 
 |===
 
@@ -137,6 +139,7 @@ ifeval::["{build-type}" == "community"]
 |===
 | Version | Release Notes | Support Matrix | Prime | Community
 
+// DO NOT EDIT THIS LINE, REQUIRED BY RELEASE SCRIPT. PAST COMMUNITY VERSIONS.
 | v2.11.14
 | https://github.com/rancher/rancher/releases/tag/v2.11.14[GitHub Release]
 | https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/rancher-v2-11-14/[View]
@@ -226,6 +229,7 @@ ifeval::["{build-type}" == "community"]
 | N/A
 | N/A
 | &#10003;
+// DO NOT EDIT THIS LINE, REQUIRED BY RELEASE SCRIPT. PAST COMMUNITY VERSIONS END.
 
 |===
 endif::[]

--- a/versions/v2.12/modules/en/pages/release-notes.adoc
+++ b/versions/v2.12/modules/en/pages/release-notes.adoc
@@ -102,11 +102,13 @@ ifeval::["{build-type}" == "community"]
 |===
 | Version | Release Notes | Support Matrix | Prime | Community
 
+// DO NOT EDIT THIS LINE, REQUIRED BY RELEASE SCRIPT. CURRENT COMMUNITY VERSION.
 | v2.12.11
 | https://github.com/rancher/rancher/releases/tag/v2.12.11[GitHub Release]
 | N/A
 | &#10003;
 | N/A
+// DO NOT EDIT THIS LINE, REQUIRED BY RELEASE SCRIPT. CURRENT COMMUNITY VERSION END.
 
 |===
 
@@ -115,6 +117,7 @@ ifeval::["{build-type}" == "community"]
 |===
 | Version | Release Notes | Support Matrix | Prime | Community
 
+// DO NOT EDIT THIS LINE, REQUIRED BY RELEASE SCRIPT. PAST COMMUNITY VERSIONS.
 | v2.12.10
 | https://github.com/rancher/rancher/releases/tag/v2.12.10[GitHub Release]
 | https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/rancher-v2-12-10/[View]
@@ -180,6 +183,7 @@ ifeval::["{build-type}" == "community"]
 | N/A
 | N/A
 | &#10003;
+// DO NOT EDIT THIS LINE, REQUIRED BY RELEASE SCRIPT. PAST COMMUNITY VERSIONS END.
 
 |===
 endif::[]

--- a/versions/v2.13/modules/en/pages/release-notes.adoc
+++ b/versions/v2.13/modules/en/pages/release-notes.adoc
@@ -78,11 +78,13 @@ ifeval::["{build-type}" == "community"]
 |===
 | Version | Release Notes | Support Matrix | Prime | Community
 
+// DO NOT EDIT THIS LINE, REQUIRED BY RELEASE SCRIPT. CURRENT COMMUNITY VERSION.
 | v2.13.7
 | https://github.com/rancher/rancher/releases/tag/v2.13.7[GitHub Release]
 | N/A
 | &#10003;
 | N/A
+// DO NOT EDIT THIS LINE, REQUIRED BY RELEASE SCRIPT. CURRENT COMMUNITY VERSION END.
 
 |===
 
@@ -91,6 +93,7 @@ ifeval::["{build-type}" == "community"]
 |===
 | Version | Release Notes | Support Matrix | Prime | Community
 
+// DO NOT EDIT THIS LINE, REQUIRED BY RELEASE SCRIPT. PAST COMMUNITY VERSIONS.
 | v2.13.6
 | https://github.com/rancher/rancher/releases/tag/v2.13.6[GitHub Release]
 | https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/rancher-v2-13-6/[View]
@@ -132,6 +135,7 @@ ifeval::["{build-type}" == "community"]
 | N/A
 | N/A
 | &#10003;
+// DO NOT EDIT THIS LINE, REQUIRED BY RELEASE SCRIPT. PAST COMMUNITY VERSIONS END.
 
 |===
 endif::[]

--- a/versions/v2.14/modules/en/pages/release-notes.adoc
+++ b/versions/v2.14/modules/en/pages/release-notes.adoc
@@ -55,11 +55,13 @@ ifeval::["{build-type}" == "community"]
 |===
 | Version | Release Notes | Support Matrix | Prime | Community
 
+// DO NOT EDIT THIS LINE, REQUIRED BY RELEASE SCRIPT. CURRENT COMMUNITY VERSION.
 | v2.14.3
 | https://github.com/rancher/rancher/releases/tag/v2.14.3[GitHub Release]
 | N/A
 | &#10003;
 | &#10003;
+// DO NOT EDIT THIS LINE, REQUIRED BY RELEASE SCRIPT. CURRENT COMMUNITY VERSION END.
 
 |===
 
@@ -69,6 +71,7 @@ ifeval::["{build-type}" == "community"]
 |===
 | Version | Release Notes | Support Matrix | Prime | Community
 
+// DO NOT EDIT THIS LINE, REQUIRED BY RELEASE SCRIPT. PAST COMMUNITY VERSIONS.
 | v2.14.2
 | https://github.com/rancher/rancher/releases/tag/v2.14.2[GitHub Release]
 | https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/rancher-v2-14-2/[View]
@@ -86,6 +89,7 @@ ifeval::["{build-type}" == "community"]
 | N/A
 | N/A
 | &#10003;
+// DO NOT EDIT THIS LINE, REQUIRED BY RELEASE SCRIPT. PAST COMMUNITY VERSIONS END.
 
 |===
 endif::[]

--- a/versions/v2.15/modules/en/pages/release-notes.adoc
+++ b/versions/v2.15/modules/en/pages/release-notes.adoc
@@ -35,6 +35,10 @@ ifeval::["{build-type}" == "community"]
 |===
 | Version | Release Notes | Support Matrix | Prime | Community
 
+// DO NOT EDIT THIS LINE, REQUIRED BY RELEASE SCRIPT. CURRENT COMMUNITY VERSION.
+
+// DO NOT EDIT THIS LINE, REQUIRED BY RELEASE SCRIPT. CURRENT COMMUNITY VERSION END.
+
 |===
 
 [#_past_versions]
@@ -42,6 +46,10 @@ ifeval::["{build-type}" == "community"]
 
 |===
 | Version | Release Notes | Support Matrix | Prime | Community
+
+// DO NOT EDIT THIS LINE, REQUIRED BY RELEASE SCRIPT. PAST COMMUNITY VERSIONS.
+
+// DO NOT EDIT THIS LINE, REQUIRED BY RELEASE SCRIPT. PAST COMMUNITY VERSIONS END.
 
 |===
 endif::[]


### PR DESCRIPTION
Test PRs: https://github.com/pmkovar/rancher-product-docs/pull/42, https://github.com/pmkovar/rancher-product-docs/pull/41

See the outstanding Q in https://github.com/rancher/rancher-product-docs/issues/1105#issuecomment-4798207451.

A likely TODO: we need to update handling of `versions/v2.15/modules/en/pages/release-notes.adoc` for a .1 release. Suggestions welcome.