### PR TITLE
Update styling

### DIFF
--- a/community-supplemental-files/css/site-extra.css
+++ b/community-supplemental-files/css/site-extra.css
@@ -380,12 +380,12 @@ html, body {
 }
 
 body {
-  font-family: 'Poppins', sans-serif;
+  font-family: "SUSE", sans-serif;
 }
 
 /* Font for side toc
 .article-aside {
-  font-family: 'Montserrat', sans-serif;
+  font-family: "SUSE", sans-serif;
 }
  */
  
@@ -697,7 +697,7 @@ table.background-transparent tr:nth-child(even) {
   padding-left: 20px;
   color: #0c322c;
   font-weight: 600;
-  font-family: 'Poppins';
+  font-family: "SUSE", sans-serif;
 }
 
 .doc .admonitionblock .icon i {
@@ -818,7 +818,7 @@ ul {
   font-weight: 500;
   padding-left: 15px;
   background-color: #326ce5;
-  font-family: 'Poppins';
+  font-family: "SUSE", sans-serif;
   padding-top: 10px;
   padding-bottom: 10px;
 }

--- a/community-supplemental-files/partials/head-meta.hbs
+++ b/community-supplemental-files/partials/head-meta.hbs
@@ -5,7 +5,6 @@
 <link rel="stylesheet" href="{{uiRootPath}}/css/site-extra.css">
 <link rel="stylesheet" href="{{{uiRootPath}}}/css/vendor/tabs.css">
 <!-- <link rel="preconnect" href="https://fonts.gstatic.com"> -->
-<link href="https://documentation.suse.com/docserv/res/fonts/poppins/poppins.css" rel="stylesheet">
 <!-- <link href="https://fonts.googleapis.com/css?family=Montserrat|Roboto&display=swap" rel="stylesheet"> -->
 <link rel="stylesheet" href="{{uiRootPath}}/css/vendor/light.css">
 <script src="/docserv/res/lightheaded/analytics.js"

--- a/community-supplemental-files/partials/head-meta.hbs
+++ b/community-supplemental-files/partials/head-meta.hbs
@@ -7,5 +7,3 @@
 <!-- <link rel="preconnect" href="https://fonts.gstatic.com"> -->
 <!-- <link href="https://fonts.googleapis.com/css?family=Montserrat|Roboto&display=swap" rel="stylesheet"> -->
 <link rel="stylesheet" href="{{uiRootPath}}/css/vendor/light.css">
-<script src="/docserv/res/lightheaded/analytics.js"
-        type="text/javascript"></script>


### PR DESCRIPTION
Updates to SUSE font, aligned with [DSC style PR](https://github.com/SUSEdoc/dsc-style-bundle/pull/83).

Before:
<img width="1504" height="374" alt="Screenshot 2026-07-21 at 10 39 40 AM" src="https://github.com/user-attachments/assets/d157c8ae-0ca3-419e-870b-799603429760" />

After:
<img width="1505" height="340" alt="Screenshot 2026-07-21 at 10 37 48 AM" src="https://github.com/user-attachments/assets/ea2646f7-b45e-4198-ad64-7c8e3276c6fa" />

Also removed the analytics.js scipt from head-meta.hbs to fix error and help GTM tracking.
Ref commit: https://github.com/rancher/rancher-product-docs/commit/26da6b0477906ef4e73d23a4d28e46196f6d6506