### PR TITLE
Update CAPI uninstall section

### DIFF
--- a/versions/v2.10/modules/en/pages/integrations/cluster-api/overview.adoc
+++ b/versions/v2.10/modules/en/pages/integrations/cluster-api/overview.adoc
@@ -1,6 +1,6 @@
 = Overview
 :page-languages: [en, zh]
-:revdate: 2026-07-21
+:revdate: 2025-07-11
 :page-revdate: {revdate}
 :community-path: integrations-in-rancher/cluster-api/overview.adoc 
 :product-path: integrations/cluster-api/overview.adoc
@@ -240,6 +240,7 @@ The previous commands tell Helm to ignore installing `cluster-api-operator` as a
 
 [CAUTION]
 ====
+
 When installing Rancher Turtles in your Rancher environment, by default, Rancher Turtles enables the CAPI Operator cleanup. This includes cleaning up CAPI Operator specific webhooks and deployments that otherwise cause issues with Rancher provisioning.
 
 To simplify uninstalling Rancher Turtles (via Rancher or Helm command), the official Rancher Turtles Helm chart includes a `post-delete` hook that removes the following:
@@ -251,7 +252,7 @@ To simplify uninstalling Rancher Turtles (via Rancher or Helm command), the offi
 
 To uninstall Rancher Turtles:
 
-[source,bash]
+[,bash]
 ----
 helm uninstall -n rancher-turtles-system rancher-turtles --cascade foreground --wait
 ----
@@ -260,24 +261,17 @@ This may take a few minutes to complete.
 
 [NOTE]
 ====
+
 Remember that, if you use a different name for the installation or a different namespace, you may need to customize the command for your specific configuration.
 ====
 
-After {turtles-product-name} is uninstalled, the feature must be disabled in Rancher, example patch command below:
-+
-[source,bash]
-----
-kubectl patch feature.management.cattle.io turtles \
-  --type=merge \
-  -p '{"spec":{"value":false}}'
-----
 
-Rancher's `embedded-cluster-api` feature must be re-enabled:
+After Rancher Turtles is uninstalled, Rancher's `embedded-cluster-api` feature must be re-enabled:
 
 . Create a `feature.yaml` file, with `embedded-cluster-api` set to true:
 +
 .feature.yaml
-[source,yaml]
+[,yaml]
 ----
 apiVersion: management.cattle.io/v3
 kind: Feature
@@ -290,9 +284,7 @@ spec:
 
 . Use `kubectl` to apply the `feature.yaml` file to the cluster:
 +
-[source,bash]
+[,bash]
 ----
 kubectl apply -f feature.yaml
 ----
-
-Lastly, restart your Rancher pod to apply the changes.

--- a/versions/v2.10/modules/en/pages/integrations/cluster-api/overview.adoc
+++ b/versions/v2.10/modules/en/pages/integrations/cluster-api/overview.adoc
@@ -1,6 +1,6 @@
 = Overview
 :page-languages: [en, zh]
-:revdate: 2025-07-11
+:revdate: 2026-07-21
 :page-revdate: {revdate}
 :community-path: integrations-in-rancher/cluster-api/overview.adoc 
 :product-path: integrations/cluster-api/overview.adoc
@@ -240,7 +240,6 @@ The previous commands tell Helm to ignore installing `cluster-api-operator` as a
 
 [CAUTION]
 ====
-
 When installing Rancher Turtles in your Rancher environment, by default, Rancher Turtles enables the CAPI Operator cleanup. This includes cleaning up CAPI Operator specific webhooks and deployments that otherwise cause issues with Rancher provisioning.
 
 To simplify uninstalling Rancher Turtles (via Rancher or Helm command), the official Rancher Turtles Helm chart includes a `post-delete` hook that removes the following:
@@ -252,7 +251,7 @@ To simplify uninstalling Rancher Turtles (via Rancher or Helm command), the offi
 
 To uninstall Rancher Turtles:
 
-[,bash]
+[source,bash]
 ----
 helm uninstall -n rancher-turtles-system rancher-turtles --cascade foreground --wait
 ----
@@ -261,17 +260,24 @@ This may take a few minutes to complete.
 
 [NOTE]
 ====
-
 Remember that, if you use a different name for the installation or a different namespace, you may need to customize the command for your specific configuration.
 ====
 
+After {turtles-product-name} is uninstalled, the feature must be disabled in Rancher, example patch command below:
++
+[source,bash]
+----
+kubectl patch feature.management.cattle.io turtles \
+  --type=merge \
+  -p '{"spec":{"value":false}}'
+----
 
-After Rancher Turtles is uninstalled, Rancher's `embedded-cluster-api` feature must be re-enabled:
+Rancher's `embedded-cluster-api` feature must be re-enabled:
 
 . Create a `feature.yaml` file, with `embedded-cluster-api` set to true:
 +
 .feature.yaml
-[,yaml]
+[source,yaml]
 ----
 apiVersion: management.cattle.io/v3
 kind: Feature
@@ -284,7 +290,9 @@ spec:
 
 . Use `kubectl` to apply the `feature.yaml` file to the cluster:
 +
-[,bash]
+[source,bash]
 ----
 kubectl apply -f feature.yaml
 ----
+
+Lastly, restart your Rancher pod to apply the changes.

--- a/versions/v2.11/modules/en/pages/integrations/cluster-api/overview.adoc
+++ b/versions/v2.11/modules/en/pages/integrations/cluster-api/overview.adoc
@@ -1,6 +1,6 @@
 = Overview
 :page-languages: [en, zh]
-:revdate: 2026-07-21
+:revdate: 2025-07-11
 :page-revdate: {revdate}
 :community-path: integrations-in-rancher/cluster-api/overview.adoc 
 :product-path: integrations/cluster-api/overview.adoc
@@ -240,6 +240,7 @@ The previous commands tell Helm to ignore installing `cluster-api-operator` as a
 
 [CAUTION]
 ====
+
 When installing Rancher Turtles in your Rancher environment, by default, Rancher Turtles enables the CAPI Operator cleanup. This includes cleaning up CAPI Operator specific webhooks and deployments that otherwise cause issues with Rancher provisioning.
 
 To simplify uninstalling Rancher Turtles (via Rancher or Helm command), the official Rancher Turtles Helm chart includes a `post-delete` hook that removes the following:
@@ -251,7 +252,7 @@ To simplify uninstalling Rancher Turtles (via Rancher or Helm command), the offi
 
 To uninstall Rancher Turtles:
 
-[source,bash]
+[,bash]
 ----
 helm uninstall -n rancher-turtles-system rancher-turtles --cascade foreground --wait
 ----
@@ -260,24 +261,17 @@ This may take a few minutes to complete.
 
 [NOTE]
 ====
+
 Remember that, if you use a different name for the installation or a different namespace, you may need to customize the command for your specific configuration.
 ====
 
-After {turtles-product-name} is uninstalled, the feature must be disabled in Rancher, example patch command below:
-+
-[source,bash]
-----
-kubectl patch feature.management.cattle.io turtles \
-  --type=merge \
-  -p '{"spec":{"value":false}}'
-----
 
-Rancher's `embedded-cluster-api` feature must be re-enabled:
+After Rancher Turtles is uninstalled, Rancher's `embedded-cluster-api` feature must be re-enabled:
 
 . Create a `feature.yaml` file, with `embedded-cluster-api` set to true:
 +
 .feature.yaml
-[source,yaml]
+[,yaml]
 ----
 apiVersion: management.cattle.io/v3
 kind: Feature
@@ -290,9 +284,7 @@ spec:
 
 . Use `kubectl` to apply the `feature.yaml` file to the cluster:
 +
-[source,bash]
+[,bash]
 ----
 kubectl apply -f feature.yaml
 ----
-
-Lastly, restart your Rancher pod to apply the changes.

--- a/versions/v2.11/modules/en/pages/integrations/cluster-api/overview.adoc
+++ b/versions/v2.11/modules/en/pages/integrations/cluster-api/overview.adoc
@@ -1,6 +1,6 @@
 = Overview
 :page-languages: [en, zh]
-:revdate: 2025-07-11
+:revdate: 2026-07-21
 :page-revdate: {revdate}
 :community-path: integrations-in-rancher/cluster-api/overview.adoc 
 :product-path: integrations/cluster-api/overview.adoc
@@ -240,7 +240,6 @@ The previous commands tell Helm to ignore installing `cluster-api-operator` as a
 
 [CAUTION]
 ====
-
 When installing Rancher Turtles in your Rancher environment, by default, Rancher Turtles enables the CAPI Operator cleanup. This includes cleaning up CAPI Operator specific webhooks and deployments that otherwise cause issues with Rancher provisioning.
 
 To simplify uninstalling Rancher Turtles (via Rancher or Helm command), the official Rancher Turtles Helm chart includes a `post-delete` hook that removes the following:
@@ -252,7 +251,7 @@ To simplify uninstalling Rancher Turtles (via Rancher or Helm command), the offi
 
 To uninstall Rancher Turtles:
 
-[,bash]
+[source,bash]
 ----
 helm uninstall -n rancher-turtles-system rancher-turtles --cascade foreground --wait
 ----
@@ -261,17 +260,24 @@ This may take a few minutes to complete.
 
 [NOTE]
 ====
-
 Remember that, if you use a different name for the installation or a different namespace, you may need to customize the command for your specific configuration.
 ====
 
+After {turtles-product-name} is uninstalled, the feature must be disabled in Rancher, example patch command below:
++
+[source,bash]
+----
+kubectl patch feature.management.cattle.io turtles \
+  --type=merge \
+  -p '{"spec":{"value":false}}'
+----
 
-After Rancher Turtles is uninstalled, Rancher's `embedded-cluster-api` feature must be re-enabled:
+Rancher's `embedded-cluster-api` feature must be re-enabled:
 
 . Create a `feature.yaml` file, with `embedded-cluster-api` set to true:
 +
 .feature.yaml
-[,yaml]
+[source,yaml]
 ----
 apiVersion: management.cattle.io/v3
 kind: Feature
@@ -284,7 +290,9 @@ spec:
 
 . Use `kubectl` to apply the `feature.yaml` file to the cluster:
 +
-[,bash]
+[source,bash]
 ----
 kubectl apply -f feature.yaml
 ----
+
+Lastly, restart your Rancher pod to apply the changes.

--- a/versions/v2.12/modules/en/pages/integrations/cluster-api/overview.adoc
+++ b/versions/v2.12/modules/en/pages/integrations/cluster-api/overview.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2026-07-21
+:revdate: 2025-08-05
 :page-revdate: {revdate}
 :community-path: integrations-in-rancher/cluster-api/overview.adoc 
 :product-path: integrations/cluster-api/overview.adoc
@@ -242,6 +242,7 @@ The previous commands tell Helm to ignore installing `cluster-api-operator` as a
 
 [CAUTION]
 ====
+
 When installing Rancher Turtles in your Rancher environment, by default, Rancher Turtles enables the CAPI Operator cleanup. This includes cleaning up CAPI Operator specific webhooks and deployments that otherwise cause issues with Rancher provisioning.
 
 To simplify uninstalling Rancher Turtles (via Rancher or Helm command), the official Rancher Turtles Helm chart includes a `post-delete` hook that removes the following:
@@ -253,7 +254,7 @@ To simplify uninstalling Rancher Turtles (via Rancher or Helm command), the offi
 
 To uninstall Rancher Turtles:
 
-[source,bash]
+[,bash]
 ----
 helm uninstall -n rancher-turtles-system rancher-turtles --cascade foreground --wait
 ----
@@ -262,24 +263,17 @@ This may take a few minutes to complete.
 
 [NOTE]
 ====
+
 Remember that, if you use a different name for the installation or a different namespace, you may need to customize the command for your specific configuration.
 ====
 
-After {turtles-product-name} is uninstalled, the feature must be disabled in Rancher, example patch command below:
-+
-[source,bash]
-----
-kubectl patch feature.management.cattle.io turtles \
-  --type=merge \
-  -p '{"spec":{"value":false}}'
-----
 
-Rancher's `embedded-cluster-api` feature must be re-enabled:
+After Rancher Turtles is uninstalled, Rancher's `embedded-cluster-api` feature must be re-enabled:
 
 . Create a `feature.yaml` file, with `embedded-cluster-api` set to true:
 +
 .feature.yaml
-[source,yaml]
+[,yaml]
 ----
 apiVersion: management.cattle.io/v3
 kind: Feature
@@ -292,9 +286,7 @@ spec:
 
 . Use `kubectl` to apply the `feature.yaml` file to the cluster:
 +
-[source,bash]
+[,bash]
 ----
 kubectl apply -f feature.yaml
 ----
-
-Lastly, restart your Rancher pod to apply the changes.

--- a/versions/v2.12/modules/en/pages/integrations/cluster-api/overview.adoc
+++ b/versions/v2.12/modules/en/pages/integrations/cluster-api/overview.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-05
+:revdate: 2026-07-21
 :page-revdate: {revdate}
 :community-path: integrations-in-rancher/cluster-api/overview.adoc 
 :product-path: integrations/cluster-api/overview.adoc
@@ -242,7 +242,6 @@ The previous commands tell Helm to ignore installing `cluster-api-operator` as a
 
 [CAUTION]
 ====
-
 When installing Rancher Turtles in your Rancher environment, by default, Rancher Turtles enables the CAPI Operator cleanup. This includes cleaning up CAPI Operator specific webhooks and deployments that otherwise cause issues with Rancher provisioning.
 
 To simplify uninstalling Rancher Turtles (via Rancher or Helm command), the official Rancher Turtles Helm chart includes a `post-delete` hook that removes the following:
@@ -254,7 +253,7 @@ To simplify uninstalling Rancher Turtles (via Rancher or Helm command), the offi
 
 To uninstall Rancher Turtles:
 
-[,bash]
+[source,bash]
 ----
 helm uninstall -n rancher-turtles-system rancher-turtles --cascade foreground --wait
 ----
@@ -263,17 +262,24 @@ This may take a few minutes to complete.
 
 [NOTE]
 ====
-
 Remember that, if you use a different name for the installation or a different namespace, you may need to customize the command for your specific configuration.
 ====
 
+After {turtles-product-name} is uninstalled, the feature must be disabled in Rancher, example patch command below:
++
+[source,bash]
+----
+kubectl patch feature.management.cattle.io turtles \
+  --type=merge \
+  -p '{"spec":{"value":false}}'
+----
 
-After Rancher Turtles is uninstalled, Rancher's `embedded-cluster-api` feature must be re-enabled:
+Rancher's `embedded-cluster-api` feature must be re-enabled:
 
 . Create a `feature.yaml` file, with `embedded-cluster-api` set to true:
 +
 .feature.yaml
-[,yaml]
+[source,yaml]
 ----
 apiVersion: management.cattle.io/v3
 kind: Feature
@@ -286,7 +292,9 @@ spec:
 
 . Use `kubectl` to apply the `feature.yaml` file to the cluster:
 +
-[,bash]
+[source,bash]
 ----
 kubectl apply -f feature.yaml
 ----
+
+Lastly, restart your Rancher pod to apply the changes.

--- a/versions/v2.13/modules/en/pages/integrations/cluster-api/overview.adoc
+++ b/versions/v2.13/modules/en/pages/integrations/cluster-api/overview.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2026-07-09
+:revdate: 2026-07-21
 :page-revdate: {revdate}
 :community-path: integrations-in-rancher/cluster-api/overview.adoc 
 :product-path: integrations/cluster-api/overview.adoc
@@ -71,7 +71,7 @@ To simplify uninstalling {turtles-product-name} (via Rancher or Helm command), t
 
 To uninstall {turtles-product-name}:
 
-[,bash]
+[source,bash]
 ----
 helm uninstall -n cattle-turtles-system rancher-turtles --cascade foreground --wait
 ----
@@ -83,13 +83,21 @@ This may take a few minutes to complete.
 Remember that, if you use a different name for the installation or a different namespace, you may need to customize the command for your specific configuration.
 ====
 
+After {turtles-product-name} is uninstalled, the feature must be disabled in Rancher, example patch command below:
++
+[source,bash]
+----
+kubectl patch feature.management.cattle.io turtles \
+  --type=merge \
+  -p '{"spec":{"value":false}}'
+----
 
-After {turtles-product-name} is uninstalled, Rancher's `embedded-cluster-api` feature must be re-enabled:
+Rancher's `embedded-cluster-api` feature must be re-enabled:
 
 . Create a `feature.yaml` file, with `embedded-cluster-api` set to true:
 +
 .feature.yaml
-[,yaml]
+[source,yaml]
 ----
 apiVersion: management.cattle.io/v3
 kind: Feature
@@ -102,7 +110,9 @@ spec:
 
 . Use `kubectl` to apply the `feature.yaml` file to the cluster:
 +
-[,bash]
+[source,bash]
 ----
 kubectl apply -f feature.yaml
 ----
+
+Lastly, restart your Rancher pod to apply the changes.

--- a/versions/v2.14/modules/en/pages/integrations/cluster-api/cluster-api.adoc
+++ b/versions/v2.14/modules/en/pages/integrations/cluster-api/cluster-api.adoc
@@ -1,6 +1,6 @@
 = {turtles-product-name}
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-07-09
+:revdate: 2026-07-21
 :page-revdate: {revdate}
 :community-path: integrations-in-rancher/cluster-api/index.adoc 
 :product-path: integrations/cluster-api/cluster-api.adoc
@@ -20,4 +20,4 @@ endif::[]
 * Import CAPI clusters into Rancher, by installing the Rancher Cluster Agent in CAPI provisioned clusters.
 * Manage the https://cluster-api-operator.sigs.k8s.io/[CAPI Operator] using the {url-cluster-api-capiprovider}[CAPIProvider] resource.
 
-The {xref-turtles-overview}[Overview] section outlines installing CAPI providers, Supply-chain Levels for Software Artifacts (SLSA) security compliance, and uninstalling {turtles-product-name}. For more details, see the {url-cluster-api-index}[{turtles-product-name} documentation].
+The {xref-turtles-overview}[Overview] section outlines installing CAPI providers and further information including Supply-chain Levels for Software Artifacts (SLSA) security compliance. For more details, see the {url-cluster-api-index}[{turtles-product-name} documentation].

--- a/versions/v2.14/modules/en/pages/integrations/cluster-api/overview.adoc
+++ b/versions/v2.14/modules/en/pages/integrations/cluster-api/overview.adoc
@@ -1,6 +1,6 @@
 = Overview
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-07-09
+:revdate: 2026-07-21
 :page-revdate: {revdate}
 :community-path: integrations-in-rancher/cluster-api/overview.adoc 
 :product-path: integrations/cluster-api/overview.adoc
@@ -37,6 +37,11 @@ As defined by https://slsa.dev/spec/v1.0/about[Supply-chain Levels for Software 
 
 With {turtles-product-name} embedded in Rancher, CAPI providers are no longer bundled by default. Providers are managed declaratively using the `CAPIProvider` custom resource. 
 
+[WARNING]
+====
+This is a required component and must be installed for cluster provisioning functionality to work. It is not recommended that you uninstall {turtles-product-name}.
+====
+
 ifeval::["{build-type}" != "community"]
 A separate providers chart for Prime users is available for installing certified providers. For more information, refer to https://documentation.suse.com/cloudnative/cluster-api/{turtles-docs-version}/en/user/providers.html[Install certified providers].
 endif::[]
@@ -56,54 +61,3 @@ spec:
 ----
 
 Refer to the {url-ref-capiprovider}[CAPIProvider reference] for the full list of configuration options.
-
-[#_uninstalling]
-== Uninstalling
-
-[CAUTION]
-====
-When installing {turtles-product-name} in your Rancher environment, the CAPI Operator cleanup is enabled by default. This includes cleaning up CAPI Operator specific webhooks and deployments that otherwise cause issues with Rancher provisioning.
-
-To simplify uninstalling {turtles-product-name} (via Rancher or Helm command), the official {turtles-product-name} Helm chart includes a `post-delete` hook that removes the following:
-
-* Deletes the `mutating-webhook-configuration` and `validating-webhook-configuration` webhooks that are no longer needed.
-* Deletes the CAPI `deployments` that are no longer needed.
-====
-
-To uninstall {turtles-product-name}:
-
-[,bash]
-----
-helm uninstall -n cattle-turtles-system rancher-turtles --cascade foreground --wait
-----
-
-This may take a few minutes to complete.
-
-[NOTE]
-====
-Remember that, if you use a different name for the installation or a different namespace, you may need to customize the command for your specific configuration.
-====
-
-
-After {turtles-product-name} is uninstalled, Rancher's `embedded-cluster-api` feature must be re-enabled:
-
-. Create a `feature.yaml` file, with `embedded-cluster-api` set to true:
-+
-.feature.yaml
-[,yaml]
-----
-apiVersion: management.cattle.io/v3
-kind: Feature
-metadata:
-  name: embedded-cluster-api
-spec:
-  value: true
-
-----
-
-. Use `kubectl` to apply the `feature.yaml` file to the cluster:
-+
-[,bash]
-----
-kubectl apply -f feature.yaml
-----

--- a/versions/v2.15/modules/en/pages/integrations/cluster-api/cluster-api.adoc
+++ b/versions/v2.15/modules/en/pages/integrations/cluster-api/cluster-api.adoc
@@ -1,6 +1,6 @@
 = {turtles-product-name}
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-07-09
+:revdate: 2026-07-21
 :page-revdate: {revdate}
 :community-path: integrations-in-rancher/cluster-api/index.adoc 
 :product-path: integrations/cluster-api/cluster-api.adoc
@@ -20,4 +20,4 @@ endif::[]
 * Import CAPI clusters into Rancher, by installing the Rancher Cluster Agent in CAPI provisioned clusters.
 * Manage the https://cluster-api-operator.sigs.k8s.io/[CAPI Operator] using the {url-cluster-api-capiprovider}[CAPIProvider] resource.
 
-The {xref-turtles-overview}[Overview] section outlines installing CAPI providers, Supply-chain Levels for Software Artifacts (SLSA) security compliance, and uninstalling {turtles-product-name}. For more details, see the {url-cluster-api-index}[{turtles-product-name} documentation].
+The {xref-turtles-overview}[Overview] section outlines installing CAPI providers and further information including Supply-chain Levels for Software Artifacts (SLSA) security compliance. For more details, see the {url-cluster-api-index}[{turtles-product-name} documentation].

--- a/versions/v2.15/modules/en/pages/integrations/cluster-api/overview.adoc
+++ b/versions/v2.15/modules/en/pages/integrations/cluster-api/overview.adoc
@@ -1,6 +1,6 @@
 = Overview
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-07-09
+:revdate: 2026-07-21
 :page-revdate: {revdate}
 :community-path: integrations-in-rancher/cluster-api/overview.adoc 
 :product-path: integrations/cluster-api/overview.adoc
@@ -37,6 +37,11 @@ As defined by https://slsa.dev/spec/v1.0/about[Supply-chain Levels for Software 
 
 With {turtles-product-name} embedded in Rancher, CAPI providers are no longer bundled by default. Providers are managed declaratively using the `CAPIProvider` custom resource. 
 
+[WARNING]
+====
+This is a required component and must be installed for cluster provisioning functionality to work. It is not recommended that you uninstall {turtles-product-name}.
+====
+
 ifeval::["{build-type}" != "community"]
 A separate providers chart for Prime users is available for installing certified providers. For more information, refer to https://documentation.suse.com/cloudnative/cluster-api/{turtles-docs-version}/en/user/providers.html[Install certified providers].
 endif::[]
@@ -56,55 +61,3 @@ spec:
 ----
 
 Refer to the {url-ref-capiprovider}[CAPIProvider reference] for the full list of configuration options.
-
-[#_uninstalling]
-== Uninstalling
-
-[CAUTION]
-====
-
-When installing {turtles-product-name} in your Rancher environment, the CAPI Operator cleanup is enabled by default. This includes cleaning up CAPI Operator specific webhooks and deployments that otherwise cause issues with Rancher provisioning.
-
-To simplify uninstalling {turtles-product-name} (via Rancher or Helm command), the official {turtles-product-name} Helm chart includes a `post-delete` hook that removes the following:
-
-* Deletes the `mutating-webhook-configuration` and `validating-webhook-configuration` webhooks that are no longer needed.
-* Deletes the CAPI `deployments` that are no longer needed.
-====
-
-To uninstall {turtles-product-name}:
-
-[,bash]
-----
-helm uninstall -n cattle-turtles-system rancher-turtles --cascade foreground --wait
-----
-
-This may take a few minutes to complete.
-
-[NOTE]
-====
-Remember that, if you use a different name for the installation or a different namespace, you may need to customize the command for your specific configuration.
-====
-
-
-After {turtles-product-name} is uninstalled, Rancher's `embedded-cluster-api` feature must be re-enabled:
-
-. Create a `feature.yaml` file, with `embedded-cluster-api` set to true:
-+
-.feature.yaml
-[,yaml]
-----
-apiVersion: management.cattle.io/v3
-kind: Feature
-metadata:
-  name: embedded-cluster-api
-spec:
-  value: true
-
-----
-
-. Use `kubectl` to apply the `feature.yaml` file to the cluster:
-+
-[,bash]
-----
-kubectl apply -f feature.yaml
-----

--- a/versions/v2.9/modules/en/pages/integrations/cluster-api/overview.adoc
+++ b/versions/v2.9/modules/en/pages/integrations/cluster-api/overview.adoc
@@ -1,6 +1,6 @@
 = Overview
 :page-languages: [en, zh]
-:revdate: 2026-07-21
+:revdate: 2025-09-22
 :page-revdate: {revdate}
 :community-path: integrations-in-rancher/cluster-api/overview.adoc 
 :product-path: integrations/cluster-api/overview.adoc
@@ -240,6 +240,7 @@ The previous commands tell Helm to ignore installing `cluster-api-operator` as a
 
 [CAUTION]
 ====
+
 When installing Rancher Turtles in your Rancher environment, by default, Rancher Turtles enables the CAPI Operator cleanup. This includes cleaning up CAPI Operator specific webhooks and deployments that otherwise cause issues with Rancher provisioning.
 
 To simplify uninstalling Rancher Turtles (via Rancher or Helm command), the official Rancher Turtles Helm chart includes a `post-delete` hook that removes the following:
@@ -251,7 +252,7 @@ To simplify uninstalling Rancher Turtles (via Rancher or Helm command), the offi
 
 To uninstall Rancher Turtles:
 
-[source,bash]
+[,bash]
 ----
 helm uninstall -n rancher-turtles-system rancher-turtles --cascade foreground --wait
 ----
@@ -260,24 +261,17 @@ This may take a few minutes to complete.
 
 [NOTE]
 ====
+
 Remember that, if you use a different name for the installation or a different namespace, you may need to customize the command for your specific configuration.
 ====
 
-After {turtles-product-name} is uninstalled, the feature must be disabled in Rancher, example patch command below:
-+
-[source,bash]
-----
-kubectl patch feature.management.cattle.io turtles \
-  --type=merge \
-  -p '{"spec":{"value":false}}'
-----
 
-Rancher's `embedded-cluster-api` feature must be re-enabled:
+After Rancher Turtles is uninstalled, Rancher's `embedded-cluster-api` feature must be re-enabled:
 
 . Create a `feature.yaml` file, with `embedded-cluster-api` set to true:
 +
 .feature.yaml
-[source,yaml]
+[,yaml]
 ----
 apiVersion: management.cattle.io/v3
 kind: Feature
@@ -290,9 +284,7 @@ spec:
 
 . Use `kubectl` to apply the `feature.yaml` file to the cluster:
 +
-[source,bash]
+[,bash]
 ----
 kubectl apply -f feature.yaml
 ----
-
-Lastly, restart your Rancher pod to apply the changes.

--- a/versions/v2.9/modules/en/pages/integrations/cluster-api/overview.adoc
+++ b/versions/v2.9/modules/en/pages/integrations/cluster-api/overview.adoc
@@ -1,6 +1,6 @@
 = Overview
 :page-languages: [en, zh]
-:revdate: 2025-09-22
+:revdate: 2026-07-21
 :page-revdate: {revdate}
 :community-path: integrations-in-rancher/cluster-api/overview.adoc 
 :product-path: integrations/cluster-api/overview.adoc
@@ -240,7 +240,6 @@ The previous commands tell Helm to ignore installing `cluster-api-operator` as a
 
 [CAUTION]
 ====
-
 When installing Rancher Turtles in your Rancher environment, by default, Rancher Turtles enables the CAPI Operator cleanup. This includes cleaning up CAPI Operator specific webhooks and deployments that otherwise cause issues with Rancher provisioning.
 
 To simplify uninstalling Rancher Turtles (via Rancher or Helm command), the official Rancher Turtles Helm chart includes a `post-delete` hook that removes the following:
@@ -252,7 +251,7 @@ To simplify uninstalling Rancher Turtles (via Rancher or Helm command), the offi
 
 To uninstall Rancher Turtles:
 
-[,bash]
+[source,bash]
 ----
 helm uninstall -n rancher-turtles-system rancher-turtles --cascade foreground --wait
 ----
@@ -261,17 +260,24 @@ This may take a few minutes to complete.
 
 [NOTE]
 ====
-
 Remember that, if you use a different name for the installation or a different namespace, you may need to customize the command for your specific configuration.
 ====
 
+After {turtles-product-name} is uninstalled, the feature must be disabled in Rancher, example patch command below:
++
+[source,bash]
+----
+kubectl patch feature.management.cattle.io turtles \
+  --type=merge \
+  -p '{"spec":{"value":false}}'
+----
 
-After Rancher Turtles is uninstalled, Rancher's `embedded-cluster-api` feature must be re-enabled:
+Rancher's `embedded-cluster-api` feature must be re-enabled:
 
 . Create a `feature.yaml` file, with `embedded-cluster-api` set to true:
 +
 .feature.yaml
-[,yaml]
+[source,yaml]
 ----
 apiVersion: management.cattle.io/v3
 kind: Feature
@@ -284,7 +290,9 @@ spec:
 
 . Use `kubectl` to apply the `feature.yaml` file to the cluster:
 +
-[,bash]
+[source,bash]
 ----
 kubectl apply -f feature.yaml
 ----
+
+Lastly, restart your Rancher pod to apply the changes.


### PR DESCRIPTION
These updates are tied to CAPI integrations page. 

Per Slack convo for versions 2.14 and later the Uninstall section has been removed and a warning placed regarding component requirement for Rancher cluster provisioning. - https://github.com/rancher/rancher-product-docs/commit/ff520d7b440ea8cca681b4839d779b28619fbc85

Versions 2.9-2.13 have the Uninstall section updated with info regarding feature disablement, and noting the Rancher pod must be restarted for changes to apply. - https://github.com/rancher/rancher-product-docs/commit/4d99170cbdf454bee7d618ff98f1baa2f7ded17f