### PR TITLE
Add Release Notes for v2.15.0

### DIFF
--- a/versions/v2.15/modules/en/pages/release-notes/v2.15.0.adoc
+++ b/versions/v2.15/modules/en/pages/release-notes/v2.15.0.adoc
@@ -105,7 +105,7 @@ endif::[]
 [#_features_and_enhancements_4]
 === Features and Enhancements
 
-* **General Availability**: Promoted support for native Cluster API (CAPI) infrastructure providers within Rancher’s V2 provisioning framework (v2prov) from Tech Preview to General Availability (GA). This provides full production support and enhanced reliability when using native CAPI infrastructure providers (e.g., CAPA and CAPV) for cluster lifecycle management. See https://github.com/rancher/rancher/issues/53777[#53777].
+* **General Availability**: Promoted support for native Cluster API (CAPI) infrastructure providers within Rancher’s V2 provisioning framework (v2prov) from Tech Preview to General Availability (GA). See https://github.com/rancher/rancher/issues/53777[#53777].
 ** If the CAPA infrastructure provider is installed, Rancher will mirror {rn-cloud-credentials}[cloud credentials] for AWS and create a corresponding `AWSClusterStaticIdentity` object that targets the `fleet-default` namespace.
 
 [#_behavior_changes_2]

--- a/versions/v2.15/modules/en/pages/release-notes/v2.15.0.adoc
+++ b/versions/v2.15/modules/en/pages/release-notes/v2.15.0.adoc
@@ -5,6 +5,7 @@
 :release-version: v2.15.0
 :rn-component-version: v2.15
 ifeval::["{build-type}" == "community"]
+:rn-fleet-webhook: https://fleet.rancher.io/next/how-tos-for-users/webhook#_3_optional_configure_a_webhook_secret
 :rn-private-registry: https://docs.k3s.io/installation/private-registry
 :rn-installation-requirements: https://ranchermanager.docs.rancher.com/{rn-component-version}/getting-started/installation-and-upgrade/installation-requirements
 :rn-aggregation-layer-is-required: https://ranchermanager.docs.rancher.com/{rn-component-version}/api/extension-apiserver#aggregation-layer-is-required
@@ -15,6 +16,7 @@ ifeval::["{build-type}" == "community"]
 :rn-install-rancher: https://ranchermanager.docs.rancher.com/{rn-component-version}/getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/install-rancher
 endif::[]
 ifeval::["{build-type}" != "community"]
+:rn-fleet-webhook: https://documentation.suse.com/cloudnative/continuous-delivery/latest/en/how-tos-for-users/webhook.html#_3_optional_configure_a_webhook_secret
 :rn-private-registry: https://documentation.suse.com/cloudnative/k3s/latest/en/installation/private-registry.html
 :rn-installation-requirements: xref:installation-and-upgrade/requirements/requirements.adoc
 :rn-aggregation-layer-is-required: xref:api/extension-apiserver.adoc#_aggregation_layer_is_required
@@ -43,6 +45,8 @@ endif::[]
 === Features and Enhancements
 
 * Rancher now supports Kubernetes v1.36. See https://github.com/rancher/rancher/issues/54303[#54303] for information on Rancher support for Kubernetes v1.36. You can view the https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.36.md[upstream Kubernetes changelog] for v1.36 for a complete list of changes.
+* Added a cap on the maximum number of public endpoint annotations (`field.cattle.io/publicEndpoints`) written for Ingress objects. This prevents workloads with extensive custom domain lists from exceeding Kubernetes’ 256 KB metadata annotation size limit and triggering API validation errors. See https://github.com/rancher/rancher/issues/42058[#42058].
+* Optimized `rancher-images.txt` to include only the latest patch release per Kubernetes minor version compatible with the target Rancher release. RC pre-releases and superseded patch/minor versions are now filtered out, significantly reducing the size of air-gapped image tarballs while ensuring `system-agent-installer` and auxiliary images remain fully up to date. See https://github.com/rancher/rancher/issues/46174[#46174].
 
 [#_behavior_changes]
 === Behavior Changes
@@ -73,10 +77,85 @@ endif::[]
 
 * Fixed an issue when Stack Preference was set to `IPv6` and **Enable Dual-Stack** was checked, the UI modal would not include the Stack Preference warning, giving users the impression that `IPv6` is a valid stack preference for a Dual-Stack cluster when they must set it as `Dual`. See https://github.com/rancher/dashboard/issues/16788[#16788].
 
+[#_authentication]
+== Authentication
+
+[#_features_and_enhancements_2]
+=== Features and Enhancements
+
+* Azure AD SSO Logout: Rancher now supports Single Logout (SLO) for the Azure AD auth provider. When enabled, logging out of Rancher also terminates the user's Azure AD session by redirecting to Azure AD's end-session endpoint. A `LogoutEndpoint` override field is available for sovereign-cloud deployments (Azure US Government, China). An optional `LogoutAllForced` flag can prevent users from bypassing SSO logout. See https://github.com/rancher/rancher/issues/54566[#54566].
+* Added the `hide-local-auth-provider` feature flag (disabled by default) to restrict local authentication usage once an External Authentication Provider (EAP) is active. When enabled, the flag hides the local login interface and removes the ability to create, edit, or delete local users from the UI. Note that password rotation for required administrative local accounts remains allowed to support emergency fallback workflows. See https://github.com/rancher/rancher/issues/46078[#46078].
+
+[#_cluster_provisioning]
+== Cluster Provisioning
+
+[#_features_and_enhancements_3]
+=== Features and Enhancements
+
+* Rancher v2.15 adds support for Cluster API (CAPI) v1.13.2. See https://github.com/rancher/rancher/issues/54304[#54304].
+* Users with the `clusters-create` role can now view the CAPIprovider resource. See https://github.com/rancher/rancher/issues/55167[#55167].
+
+[#_k3s_and_rke2_provisioning]
+== K3s and RKE2 Provisioning
+
+[#_features_and_enhancements_4]
+=== Features and Enhancements
+
+* **General Availability**: Promoted support for native Cluster API (CAPI) infrastructure providers within Rancher’s V2 provisioning framework (v2prov) from Tech Preview to General Availability (GA). This provides full production support and enhanced reliability when using native CAPI infrastructure providers (e.g., CAPA, CAPZ, CAPG) for cluster lifecycle management. See https://github.com/rancher/rancher/issues/53777[#53777].
+
+[#_known_issues]
+=== Known Issues
+
+* A known issue exists related to CAPI infrastructure providers within Rancher’s V2 provisioning framework. Editing machine pools or experiencing provisioning failures on CAPI Plug-and-Play (PnP) clusters (such as CAPA/AWS) can leave unused, orphaned infrastructure templates (e.g., `AWSMachineTemplate` or `AWSCluster`) in the management cluster. These dangling resources are no longer referenced by active `MachineDeployments` and can be safely cleaned up manually if needed. See https://github.com/rancher/rancher/issues/55752[#55752].
+
+[#_continuous_delivery_fleet]
+== Continuous Delivery (Fleet)
+
+[#_behavior_changes_2]
+=== Behavior Changes
+
+* **Deprecation**: Fleet will be deprecating support for `GitRepoRestriction` in a future release, making the use of the Policy resource for configuring multi-tenant environments the only option. See https://github.com/rancher/rancher/issues/55652[#55652].
+* **Deprecation**: Fleet support for unauthenticated webhook calls will be deprecated in a future release, making the setup of a {rn-fleet-webhook}[webhook secret] the only option. See https://github.com/rancher/rancher/issues/55633[#55633].
+
+[#_role_based_access_control_rbac]
+== Role-Based Access Control (RBAC)
+
+[#_features_and_enhancements_5]
+=== Features and Enhancements
+
+* Rancher introduces a new `inheritedNamespacedRules` field for GlobalRoles, allowing administrators to automatically grant users RBAC permissions to specific namespaces across all downstream clusters (for example, shared monitoring or logging namespaces). Rules defined in `inheritedNamespacedRules` automatically propagate to all downstream clusters managed by Rancher. If the namespace doesn't exist on a cluster no rules are added, however, if the namespace does not exist but gets created, the controller triggers and creates the rules. Please note that these inherited rules apply exclusively to downstream clusters and do not affect the local management cluster.
+** Configuring `inheritedNamespacedRules` currently requires editing the GlobalRole YAML directly or via the API, as direct UI inputs for this specific map are not yet available. Example YAML configuration for a GlobalRole with `inheritedNamespacedRules`:
++
+[source,yaml]
+----
+apiVersion: management.cattle.io/v3
+kind: GlobalRole
+metadata:
+namespace: default
+name: test-gr-1
+rules:
+- apiGroups:
+- catalog.cattle.io
+resources:
+- apps
+verbs:
+- create
+inheritedNamespacedRules:
+shared-namespace:
+    - apiGroups:
+    - catalog.cattle.io
+    resources:
+    - apps
+    verbs:
+    - edit
+----
++
+See https://github.com/rancher/rancher/issues/50663[#50663] for more information.
+
 [#_virtualization_management_harvester]
 == Virtualization Management (Harvester)
 
-[#_features_and_enhancements_2]
+[#_features_and_enhancements_6]
 === Features and Enhancements
 
 * This release adds support for the `harvester-baremetal-container-workload` feature flag, disabled by default, within Rancher's Fleet continuous delivery targeting mechanism. When enabled, the UI stops filtering out Harvester clusters, allowing Fleet bundles and applications to target and deploy container workloads directly to them. After enabling the `harvester-baremetal-container-workload` feature flag, please validate existing Fleet Bundles to ensure they now select, or don't select, the required clusters. When disabled, the UI maintains the default behavior and excludes Harvester clusters from Fleet targets. See https://github.com/rancher/dashboard/issues/12518[#12518].

--- a/versions/v2.15/modules/en/pages/release-notes/v2.15.0.adoc
+++ b/versions/v2.15/modules/en/pages/release-notes/v2.15.0.adoc
@@ -1,0 +1,254 @@
+= Release {release-version}
+:page-languages: [en, de, es, fr, ja, pt, zh]
+:revdate: 2026-07-21
+:page-revdate: {revdate}
+:release-version: v2.15.0
+:rn-component-version: v2.15
+ifeval::["{build-type}" == "community"]
+:rn-private-registry: https://docs.k3s.io/installation/private-registry
+:rn-installation-requirements: https://ranchermanager.docs.rancher.com/{rn-component-version}/getting-started/installation-and-upgrade/installation-requirements
+:rn-aggregation-layer-is-required: https://ranchermanager.docs.rancher.com/{rn-component-version}/api/extension-apiserver#aggregation-layer-is-required
+:rn-disk-space: https://ranchermanager.docs.rancher.com/{rn-component-version}/how-to-guides/advanced-user-guides/ui-server-side-pagination#disk-space
+:rn-viewing-api-audit-logs: https://ranchermanager.docs.rancher.com/{rn-component-version}/how-to-guides/advanced-user-guides/enable-api-audit-log#viewing-api-audit-logs:~:text=Description-,AUDIT_LOG_ENABLED,-false%20%2D%20Disables%20the
+:rn-enable-api-audit-log: https://ranchermanager.docs.rancher.com/{rn-component-version}/how-to-guides/advanced-user-guides/enable-api-audit-log
+:rn-back-up-rancher: https://ranchermanager.docs.rancher.com/{rn-component-version}/how-to-guides/new-user-guides/backup-restore-and-disaster-recovery/back-up-rancher
+:rn-install-rancher: https://ranchermanager.docs.rancher.com/{rn-component-version}/getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/install-rancher
+endif::[]
+ifeval::["{build-type}" != "community"]
+:rn-private-registry: https://documentation.suse.com/cloudnative/k3s/latest/en/installation/private-registry.html
+:rn-installation-requirements: xref:installation-and-upgrade/requirements/requirements.adoc
+:rn-aggregation-layer-is-required: xref:api/extension-apiserver.adoc#_aggregation_layer_is_required
+:rn-disk-space: xref:rancher-admin/global-configuration/ui-server-side-pagination.adoc#_disk_space
+:rn-viewing-api-audit-logs: xref:observability/logging/enable-api-audit-log.adoc#_api_audit_log_options
+:rn-enable-api-audit-log: xref:observability/logging/enable-api-audit-log.adoc
+:rn-back-up-rancher: xref:rancher-admin/back-up-restore-and-disaster-recovery/back-up.adoc
+:rn-install-rancher: xref:installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.adoc
+endif::[]
+
+[IMPORTANT]
+====
+* If you are using Active Directory Federation Service (AD FS), upgrading to Rancher v2.10.1 or later may cause issues with authentication, requiring manual intervention. These issues are due to the AD FS Relying Party Trust not being able to pick up a signature verification certificate from the metadata. For more information, see https://github.com/rancher/rancher/issues/48655[#48655]. These issues can be corrected by either of two methods:
+** Updating the Relying Party Trust information from federation metadata (Relying Party Trust -> Update from Federation Metadata...).
+** Directly adding the certificate (Relying Party Trust -> Properties -> Signature tab -> Add -> Select the certificate).
+====
+
+ifeval::["{build-type}" == "community"]
+Rancher {release-version} is the latest minor release of Rancher. This is a Community version release that introduces new features, enhancements, and various updates.
+endif::[]
+
+[#_rancher_general]
+== Rancher General
+
+[#_features_and_enhancements]
+=== Features and Enhancements
+
+* Rancher now supports Kubernetes v1.36. See https://github.com/rancher/rancher/issues/54303[#54303] for information on Rancher support for Kubernetes v1.36. You can view the https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.36.md[upstream Kubernetes changelog] for v1.36 for a complete list of changes.
+
+[#_behavior_changes]
+=== Behavior Changes
+
+* Rancher v2.15 removes support for Kubernetes 1.33. See https://github.com/rancher/rancher/issues/55306[#55306].
+
+[#_major_bug_fixes]
+=== Major Bug Fixes
+
+* Fixed an issue where `rancher-save-images.sh` failed to pull OCI-based Helm charts when the local Docker daemon was configured to use the `overlay2` storage driver. See https://github.com/rancher/rancher/issues/55068[#55068].
+
+[#_rancher_app_global_ui]
+== Rancher App (Global UI)
+
+[#_features_and_enhancements_1]
+=== Features and Enhancements
+
+* The Rancher Dashboard replaces the legacy all-in-one Workloads list with a new **Workloads Overview** UI view to solve major performance and scalability issues when viewing workload resources. See https://github.com/rancher/dashboard/issues/11513[#11513].
+
+[#_behavior_changes_1]
+=== Behavior Changes
+
+* The option to disable the feature flag `ui-sql-cache` / Vai / Server-Side Pagination (SSP) in the Rancher UI has been removed in preparation for Rancher v2.16, where the feature will always be enabled. See https://github.com/rancher/dashboard/issues/16822[#16822].
+* **Removal**: Support for UI Plugins based on Ember, deprecated since Rancher v2.11.0, regarding cluster and node drivers are **removed** in Rancher v2.15.0. If you still need these plugins, they will need to be migrated to the https://extensions.rancher.io/extensions/next/home[UI Extensions framework]. See https://github.com/rancher/dashboard/issues/14005[#14005] for more information.
+
+[#_major_bug_fixes_1]
+=== Major Bug Fixes
+
+* Fixed an issue when Stack Preference was set to `IPv6` and **Enable Dual-Stack** was checked, the UI modal would not include the Stack Preference warning, giving users the impression that `IPv6` is a valid stack preference for a Dual-Stack cluster when they must set it as `Dual`. See https://github.com/rancher/dashboard/issues/16788[#16788].
+
+[#_virtualization_management_harvester]
+== Virtualization Management (Harvester)
+
+[#_features_and_enhancements_2]
+=== Features and Enhancements
+
+* This release adds support for the `harvester-baremetal-container-workload` feature flag, disabled by default, within Rancher's Fleet continuous delivery targeting mechanism. When enabled, the UI stops filtering out Harvester clusters, allowing Fleet bundles and applications to target and deploy container workloads directly to them. After enabling the `harvester-baremetal-container-workload` feature flag, please validate existing Fleet Bundles to ensure they now select, or don't select, the required clusters. When disabled, the UI maintains the default behavior and excludes Harvester clusters from Fleet targets. See https://github.com/rancher/dashboard/issues/12518[#12518].
+
+[#_long_standing_known_issues]
+
+[#_install_upgrade_notes]
+== Install/Upgrade Notes
+
+If you're installing Rancher for the first time, your environment must fulfill the {rn-installation-requirements}[installation requirements].
+
+[IMPORTANT]
+====
+ifeval::["{build-type}" != "community"]
+* Chart name change for Rancher Prime.
+** The chart name change introduced in Rancher Prime v2.13.1 has been reverted. The chart name `rancher` should be used for all installations and upgrades. As an example, the installation command is now `helm install rancher rancher-prime/rancher`.
+endif::[]
+* Rancher now requires the cluster it runs on to have the https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation/[Kubernetes API Aggregation Layer] enabled. This is because Rancher extends Kubernetes with additional APIs by registering its own extension API server. Please note that all versions of Kubernetes supported in this Rancher versions K8s distributions (RKE2/K3s) will have the aggregation layer configured and enabled by default.
+** Refer to the {rn-aggregation-layer-is-required}[Extension API Server documentation] and https://github.com/rancher/rancher/issues/50400[#50400] for more information.
+* Rancher Kubernetes Engine (RKE/RKE1) has reached end of life as of *July 31, 2025*. Rancher versions 2.12.0 and later no longer support provisioning or managing downstream RKE1 clusters. We recommend replatforming RKE1 clusters to RKE2 to ensure continued support and security updates. Learn more about the transition https://www.suse.com/support/kb/doc/?id=000021518[here].
+** Rancher now has a pre-upgrade validation check for RKE1 resources which fails and lists the RKE1 resources if present. Refer to https://github.com/rancher/rancher/issues/50286[#50286] for more information.
+* It is crucial that you review the available disk space on your nodes and plan accordingly before upgrading to Rancher v2.12.0 and later to avoid potential disk pressure and pod eviction issues.
+** For additional information, refer to the {rn-disk-space}[UI Server Side Pagination - Disk Space documentation].
+* Rancher now has an enablement option called {rn-viewing-api-audit-logs}[`AUDIT_LOG_ENABLED`] for API Audit Logs for a Rancher installation.
+** In Rancher versions 2.11.x and earlier, only the `AUDIT_LEVEL` could be set and the default log level (`0`) would disable the audit log. In Rancher versions 2.12.x and later, the default log level (`0`) now only contains the log request and response metadata, and can be set when configuring `AUDIT_LOG_ENABLED`. If installing or upgrading via Helm you can enable the API Audit Logs and specify the log level by applying the following setting to your Helm command: `--set auditLog.enabled=true --set auditLog.level=0`. See the {rn-enable-api-audit-log}[Enabling the API Audit Log to Record System Events] documentation and https://github.com/rancher/rancher/issues/48941[#48941].
+====
+
+[#_changes_in_image_artifacts]
+== Changes in Image Artifacts
+
+Image artifact digests are renamed in Rancher v2.12.0, v2.11.4 and v2.10.8. Up until this change, separate image digests files for each operating system and architecture have been maintained for compatibility reasons. With this change, only one file for each operating system is to be provided:
+
+* The `rancher-images-digests-linux-amd64.txt` and `rancher-images-digests-linux-arm64.txt` files are to be renamed to `rancher-images-digests-linux.txt`.
+* The `rancher-images-digests-windows-ltsc2019.txt` and `rancher-images-digests-windows-ltsc2022.txt` files are to be renamed to `rancher-images-digests-windows.txt`.
+
+[#_upgrade_requirements]
+== Upgrade Requirements
+
+* *Creating backups:* {rn-back-up-rancher}[Create a backup] before you upgrade Rancher. To roll back Rancher after an upgrade, you must first back up and restore Rancher to the previous Rancher version. Because Rancher will be restored to the same state as when the backup was created, any changes post-upgrade will not be included after the restore.
+* *Helm version requirements:*
+** To manage Rancher 2.12.x and later, you must upgrade your Helm client to version 3.18 or newer.
+** This change is required to reflect the addition of Kubernetes 1.33 support with this release.
+** Currently, the official https://helm.sh/docs/topics/version_skew/[Helm Version Support Policy] dictates that only Helm 3.18 supports the proper Kubernetes version range for Rancher 2.12.
+* *CNI requirements:*
+** For Kubernetes v1.19 and later, disable firewalld as it's incompatible with various CNI plugins. See https://github.com/rancher/rancher/issues/28840[#28840].
+** When upgrading or installing a Linux distribution that uses nf_tables as the backend packet filter, such as SLES 15, RHEL 8, Ubuntu 20.10, Debian 10, or later, upgrade to RKE v1.19.2 or later to get Flannel v0.13.0. Flannel v0.13.0 supports nf_tables. See Flannel https://github.com/flannel-io/flannel/issues/1317[#1317].
+* *Requirements for air-gapped environments:*
+** When using a proxy in front of an air-gapped Rancher instance, you must pass additional parameters to `NO_PROXY`. See the {rn-install-rancher}[documentation] and issue https://github.com/rancher/docs/issues/2725#issuecomment-702454584[#2725].
+** When installing Rancher with Docker in an air-gapped environment, you must supply a custom `registries.yaml` file to the `docker run` command, as shown in the {rn-private-registry}[K3s documentation]. If the registry has certificates, then you'll also need to supply those. See https://github.com/rancher/rancher/issues/28969#issuecomment-694474229[#28969].
+
+[#_versions]
+== Versions
+
+[#_images]
+=== Images
+
+* rancher/rancher:{release-version}
+
+[#_tools]
+=== Tools
+
+* CLI - https://github.com/rancher/cli/releases/tag/{release-version}[{release-version}]
+
+[#_kubernetes_versions_for_rke2_k3s]
+=== Kubernetes Versions for RKE2/K3s
+
+* v1.36.1 (Default)
+* v1.35.6
+* v1.34.9
+
+=== Rancher Helm Chart Versions
+
+In Rancher v2.6.0 and later, in the *Apps & Marketplace* UI, many Rancher Helm charts are named with a major version that starts with _100_. This avoids simultaneous upstream changes and Rancher changes from causing conflicting version increments. This also complies with semantic versioning (SemVer), which is a requirement for Helm. You can see the upstream version number of a chart in the build metadata, for example: `100.0.0+up2.1.0`. See https://github.com/rancher/rancher/issues/32294[#32294].
+
+[#_future_rancher_behavior_changes]
+== Future Rancher Behavior Changes
+
+[#_retention_policy_for_rancher_app_charts]
+=== Retention Policy for Rancher App Charts
+
+To improve repository performance, Rancher is introducing a lifecycle management policy for charts available in the Apps feature of Rancher, specifically in the "Rancher" repository.
+
+* *The Policy:* Rancher will transition from a cumulative model (retaining all historical versions forever) to a retention model that preserves chart versions for the *seven (7) most recent Rancher minor releases* (approximately a 2.5-year window).
+* *Timeline - Rancher v2.13 & v2.14:* Legacy chart versions (older than the 7-version window) remain available.
+* *Rancher v2.15:* This will be the first version to enforce the policy. Versions falling outside the 7-version window and older than two years will no longer be available.
+
+*Impact:* This change is non-destructive for existing Rancher installations. Historical versions will remain accessible but will not be available in newer release branches once they age out of the 7-version window. You are advised to upgrade your applications before upgrading to Rancher v2.15. Uninstallation after v2.15, and replacement with an updated version, will still be possible.
+
+[#_long_standing_known_issues]
+== Long-standing Known Issues
+
+// Apply same headers as "Major Bug Fixes" but with "Long-standing Known Issues" suffix instead
+
+[#_long_standing_known_issues_cluster_provisioning]
+=== Long-standing Known Issues - Cluster Provisioning
+
+* Not all cluster tools can be installed on a hardened cluster.
+// no issue number available
+
+* *Rancher v2.8.1:*
+** When you  attempt to register a new etcd/controlplane node in a CAPR-managed cluster after a failed etcd snapshot restoration, the node can become stuck in a perpetual paused state, displaying the error message `[ERROR]  000 received while downloading Rancher connection information. Sleeping for 5 seconds and trying again`. As a workaround, you can unpause the cluster by running `kubectl edit clusters.cluster clustername -n fleet-default` and set `spec.unpaused` to `false`.  See https://github.com/rancher/rancher/issues/43735[#43735].
+
+[#_long_standing_known_issues_rke2_provisioning]
+=== Long-standing Known Issues - RKE2 Provisioning
+// hostbusters
+
+* *Rancher v2.7.7:*
+** Due to the backoff logic in various components, downstream provisioned K3s and RKE2 clusters may take longer to re-achieve *Active* status after a migration. If you see that a downstream cluster is still updating or in an error state immediately after a migration, please let it attempt to resolve itself. This might take up to an hour to complete. See https://github.com/rancher/rancher/issues/34518[#34518] and https://github.com/rancher/rancher/issues/42834[#42834].
+* *Rancher v2.7.6:*
+** Provisioning RKE2/K3s clusters with added (not built-in) custom node drivers causes provisioning to fail. As a workaround, https://github.com/rancher/rancher/issues/37074#issuecomment-1664722305[fix] the added node drivers after activating. See https://github.com/rancher/rancher/issues/37074[#37074].
+
+[#_long_standing_known_issues_k3s_provisioning]
+=== Long-standing Known Issues - K3s Provisioning
+// hostbusters
+
+* *Rancher v2.7.6:*
+** Provisioning RKE2/K3s clusters with added (not built-in) custom node drivers causes provisioning to fail. As a workaround, https://github.com/rancher/rancher/issues/37074#issuecomment-1664722305[fix] the added node drivers after activating. See https://github.com/rancher/rancher/issues/37074[#37074].
+* *Rancher v2.7.2:*
+** Clusters remain in an `Updating` state even when they contain nodes in an `Error` state. See https://github.com/rancher/rancher/issues/39164[#39164].
+
+[#_long_standing_known_issues_rancher_app_global_ui]
+=== Long-standing Known Issues - Rancher App (Global UI)
+
+* *Rancher v2.10.0:*
+** After deleting a Namespace or Project in the Rancher UI, the Namespace or Project remains visible. As a workaround, refresh the page. See https://github.com/rancher/dashboard/issues/12220[#12220].
+* *Rancher v2.9.2:*
+** Although system mode node pools must have at least one node, the Rancher UI allows a minimum node count of zero. Inputting a zero minimum node count through the UI can cause cluster creation to fail due to an invalid parameter error. To prevent this error from occurring, enter a minimum node count at least equal to the node count. See https://github.com/rancher/dashboard/issues/11922[#11922].
+* *Rancher v2.7.7:*
+** When creating a cluster in the Rancher UI it does not allow the use of an underscore `_` in the `Cluster Name` field. See https://github.com/rancher/dashboard/issues/9416[#9416].
+* *Rancher v2.6.4:*
+** Deployment securityContext section is missing when a new workload is created. This prevents pods from starting when Pod Security Policy Support is enabled. See https://github.com/rancher/dashboard/issues/4815[#4815].
+
+[#_long_standing_known_issues_eks]
+=== Long-standing Known Issues - EKS
+
+* *Rancher v2.7.0:*
+** EKS clusters on Kubernetes v1.21 or below on Rancher v2.7 cannot be upgraded. See https://github.com/rancher/rancher/issues/39392[#39392].
+
+[#_long_standing_known_issues_authentication]
+=== Long-standing Known Issues - Authentication
+// night's watch
+
+* *Rancher v2.9.0:*
+** There are some known issues with the OpenID Connect provider support:
+*** When the generic OIDC auth provider is enabled, and you attempt to add auth provider users to a cluster or project, users are not populated in the dropdown search bar. This is expected behavior as the OIDC auth provider alone is not searchable. See https://github.com/rancher/rancher/issues/46104[#46104].
+*** When the generic OIDC auth provider is enabled, auth provider users that are added to a cluster/project by their username are not able to access resources upon logging in. A user will only have access to resources upon login if the user is added by their userID.  See https://github.com/rancher/rancher/issues/46105[#46105].
+*** When the generic OIDC auth provider is enabled and an auth provider user in a nested group is logged into Rancher, the user will see the following error when they attempt to create a Project: `http://projectroletemplatebindings.management.cattle.io/[projectroletemplatebindings.management.cattle.io] is forbidden: User "u-gcxatwsnku" cannot create resource "projectroletemplatebindings" in API group "http://management.cattle.io/[management.cattle.io]" in the namespace "p-9t5pg"`. However, the project is still created. See https://github.com/rancher/rancher/issues/46106[#46106].
+
+[#_long_standing_known_issues_rancher_webhook]
+=== Long-standing Known Issues - Rancher Webhook
+// neo
+
+* *Rancher v2.7.2:*
+** A webhook is installed in all downstream clusters. There are several issues that users may encounter with this functionality:
+*** If you rollback from a version of Rancher v2.7.2 or later, to a Rancher version earlier than v2.7.2, the webhooks will remain in downstream clusters. Since the webhook is designed to be 1:1 compatible with specific versions of Rancher, this can cause unexpected behaviors to occur downstream. The Rancher team has developed a https://github.com/rancher/webhook/wiki/Remove-Webhook-from-downstream-clusters[script] which should be used after rollback is complete (meaning after a Rancher version earlier than v2.7.2 is running). This removes the webhook from affected downstream clusters. See https://github.com/rancher/rancher/issues/40816[#40816].
+
+[#_long_standing_known_issues_virtualization_management_harvester]
+=== Long-standing Known Issues - Virtualization Management (Harvester)
+
+* *Rancher v2.13.1:*
+** When upgrading to Rancher v2.13.1 or higher while using Harvester v1.6.1, users may encounter an issue with their Load Balancers in downstream clusters using the Harvester Cloud Provider, and must perform the following https://docs.harvesterhci.io/latest/troubleshooting/rancher#guest-cluster-loadbalancer-ip-is-not-reachable[workaround] to instruct Calico to not use any of the IP/interface managed by `kube-vip`. See https://github.com/harvester/harvester/issues/9767[#9767].
+* *Rancher v2.7.2:*
+** If you're using Rancher v2.7.2 with Harvester v1.1.1 clusters, you won't be able to select the Harvester cloud provider when deploying or updating guest clusters. The https://github.com/harvester/release-notes/blob/main/v1.1.2.md#important-information-about-rancher-support[Harvester release notes] contain instructions on how to resolve this. See https://github.com/harvester/harvester/issues/3750[#3750].
+
+[#_long_standing_known_issues_backup_restore]
+=== Long-standing Known Issues - Backup/Restore
+// night's watch
+
+* When migrating to a cluster with the Rancher Backup feature, the server-url cannot be changed to a different location. It must continue to use the same URL.
+// no issue number
+
+* *Rancher v2.13.0:*
+** When performing a rollback from Rancher v2.13.0 to v2.12.3 using the backup and restore operator (BRO), the restore does not complete successfully. See https://github.com/rancher/backup-restore-operator/issues/844[#844]. To work around this issue, you must scale down your Rancher deployment and uninstall the Webhook chart before performing the restore. For details, refer to this https://support.scc.suse.com/s/kb/Rolling-back-from-Rancher-v2-13-0-to-v2-12-3?language=en_US[Knowledge Base article].
+* *Rancher v2.7.7:*
+** Due to the backoff logic in various components, downstream provisioned K3s and RKE2 clusters may take longer to re-achieve *Active* status after a migration. If you see that a downstream cluster is still updating or in an error state immediately after a migration, please let it attempt to resolve itself. This might take up to an hour to complete. See https://github.com/rancher/rancher/issues/34518[#34518] and https://github.com/rancher/rancher/issues/42834[#42834].

--- a/versions/v2.15/modules/en/pages/release-notes/v2.15.0.adoc
+++ b/versions/v2.15/modules/en/pages/release-notes/v2.15.0.adoc
@@ -5,6 +5,7 @@
 :release-version: v2.15.0
 :rn-component-version: v2.15
 ifeval::["{build-type}" == "community"]
+:rn-cloud-credentials: https://ranchermanager.docs.rancher.com/{rn-component-version}/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/global-permissions
 :rn-fleet-webhook: https://fleet.rancher.io/next/how-tos-for-users/webhook#_3_optional_configure_a_webhook_secret
 :rn-private-registry: https://docs.k3s.io/installation/private-registry
 :rn-installation-requirements: https://ranchermanager.docs.rancher.com/{rn-component-version}/getting-started/installation-and-upgrade/installation-requirements
@@ -16,6 +17,7 @@ ifeval::["{build-type}" == "community"]
 :rn-install-rancher: https://ranchermanager.docs.rancher.com/{rn-component-version}/getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/install-rancher
 endif::[]
 ifeval::["{build-type}" != "community"]
+:rn-cloud-credentials: xref:rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/global-permissions.adoc
 :rn-fleet-webhook: https://documentation.suse.com/cloudnative/continuous-delivery/latest/en/how-tos-for-users/webhook.html#_3_optional_configure_a_webhook_secret
 :rn-private-registry: https://documentation.suse.com/cloudnative/k3s/latest/en/installation/private-registry.html
 :rn-installation-requirements: xref:installation-and-upgrade/requirements/requirements.adoc
@@ -102,6 +104,7 @@ endif::[]
 === Features and Enhancements
 
 * **General Availability**: Promoted support for native Cluster API (CAPI) infrastructure providers within Rancher’s V2 provisioning framework (v2prov) from Tech Preview to General Availability (GA). This provides full production support and enhanced reliability when using native CAPI infrastructure providers (e.g., CAPA and CAPV) for cluster lifecycle management. See https://github.com/rancher/rancher/issues/53777[#53777].
+** If the CAPA infrastructure provider is installed, Rancher will mirror {rn-cloud-credentials}[cloud credentials] for AWS and create a corresponding `AWSClusterStaticIdentity` object that targets the `fleet-default` namespace.
 
 [#_known_issues]
 === Known Issues

--- a/versions/v2.15/modules/en/pages/release-notes/v2.15.0.adoc
+++ b/versions/v2.15/modules/en/pages/release-notes/v2.15.0.adoc
@@ -5,7 +5,8 @@
 :release-version: v2.15.0
 :rn-component-version: v2.15
 ifeval::["{build-type}" == "community"]
-:rn-cloud-credentials: https://ranchermanager.docs.rancher.com/{rn-component-version}/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/global-permissions
+:rn-global-permissions: https://ranchermanager.docs.rancher.com/{rn-component-version}/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/global-permissions
+:rn-cloud-credentials: https://ranchermanager.docs.rancher.com/{rn-component-version}/reference-guides/user-settings/manage-cloud-credentials
 :rn-fleet-webhook: https://fleet.rancher.io/next/how-tos-for-users/webhook#_3_optional_configure_a_webhook_secret
 :rn-private-registry: https://docs.k3s.io/installation/private-registry
 :rn-installation-requirements: https://ranchermanager.docs.rancher.com/{rn-component-version}/getting-started/installation-and-upgrade/installation-requirements
@@ -17,7 +18,8 @@ ifeval::["{build-type}" == "community"]
 :rn-install-rancher: https://ranchermanager.docs.rancher.com/{rn-component-version}/getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/install-rancher
 endif::[]
 ifeval::["{build-type}" != "community"]
-:rn-cloud-credentials: xref:rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/global-permissions.adoc
+:rn-global-permissions: xref:rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/global-permissions.adoc
+:rn-cloud-credentials: xref:rancher-admin/users/settings/manage-cloud-credentials.adoc
 :rn-fleet-webhook: https://documentation.suse.com/cloudnative/continuous-delivery/latest/en/how-tos-for-users/webhook.html#_3_optional_configure_a_webhook_secret
 :rn-private-registry: https://documentation.suse.com/cloudnative/k3s/latest/en/installation/private-registry.html
 :rn-installation-requirements: xref:installation-and-upgrade/requirements/requirements.adoc
@@ -106,6 +108,12 @@ endif::[]
 * **General Availability**: Promoted support for native Cluster API (CAPI) infrastructure providers within Rancher’s V2 provisioning framework (v2prov) from Tech Preview to General Availability (GA). This provides full production support and enhanced reliability when using native CAPI infrastructure providers (e.g., CAPA and CAPV) for cluster lifecycle management. See https://github.com/rancher/rancher/issues/53777[#53777].
 ** If the CAPA infrastructure provider is installed, Rancher will mirror {rn-cloud-credentials}[cloud credentials] for AWS and create a corresponding `AWSClusterStaticIdentity` object that targets the `fleet-default` namespace.
 
+[#_behavior_changes_2]
+=== Behavior Changes
+
+* By default, the `Standard User` and `Create Clusters` {rn-global-permissions}[global permissions] now allow creating and then updating CAPI infrastructure objects in the `fleet-default` namespace. Note that manually created infrastructure provider identity objects, such as `AWSClusterStaticIdentity` or `VSphereClusterIdentity`, that target the `fleet-default` namespace can be used through CAPI infrastructure objects such as `AWSCluster` or `VsphereCluster`. See https://github.com/rancher/rancher/issues/53777[#53777].
+* When using native CAPI infrastructure providers with v2prov, Rancher will now generate the bootstrap cloud-config in the https://docs.cloud-init.io/en/latest/explanation/format/jinja.html[Jinja format]. User-data for regular node drivers with v2prov is unaffected. See https://github.com/rancher/rancher/issues/53777[#53777].
+
 [#_known_issues]
 === Known Issues
 
@@ -114,7 +122,7 @@ endif::[]
 [#_continuous_delivery_fleet]
 == Continuous Delivery (Fleet)
 
-[#_behavior_changes_2]
+[#_behavior_changes_3]
 === Behavior Changes
 
 * **Deprecation**: Fleet will be deprecating support for `GitRepoRestriction` in a future release, making the use of the Policy resource for configuring multi-tenant environments the only option. See https://github.com/rancher/rancher/issues/55652[#55652].

--- a/versions/v2.15/modules/en/pages/release-notes/v2.15.0.adoc
+++ b/versions/v2.15/modules/en/pages/release-notes/v2.15.0.adoc
@@ -101,12 +101,12 @@ endif::[]
 [#_features_and_enhancements_4]
 === Features and Enhancements
 
-* **General Availability**: Promoted support for native Cluster API (CAPI) infrastructure providers within Rancher’s V2 provisioning framework (v2prov) from Tech Preview to General Availability (GA). This provides full production support and enhanced reliability when using native CAPI infrastructure providers (e.g., CAPA, CAPZ, CAPG) for cluster lifecycle management. See https://github.com/rancher/rancher/issues/53777[#53777].
+* **General Availability**: Promoted support for native Cluster API (CAPI) infrastructure providers within Rancher’s V2 provisioning framework (v2prov) from Tech Preview to General Availability (GA). This provides full production support and enhanced reliability when using native CAPI infrastructure providers (e.g., CAPA and CAPV) for cluster lifecycle management. See https://github.com/rancher/rancher/issues/53777[#53777].
 
 [#_known_issues]
 === Known Issues
 
-* A known issue exists related to CAPI infrastructure providers within Rancher’s V2 provisioning framework. Editing machine pools or experiencing provisioning failures on CAPI Plug-and-Play (PnP) clusters (such as CAPA/AWS) can leave unused, orphaned infrastructure templates (e.g., `AWSMachineTemplate` or `AWSCluster`) in the management cluster. These dangling resources are no longer referenced by active `MachineDeployments` and can be safely cleaned up manually if needed. See https://github.com/rancher/rancher/issues/55752[#55752].
+* A known issue exists related to CAPI infrastructure providers within Rancher’s V2 provisioning framework. Creating or editing v2prov clusters with native infrastructure providers (such as CAPA or CAPV) from the UI can under some failure conditions leave unused, orphaned infrastructure resources (e.g., `AWSMachineTemplate` or `AWSCluster`) in the management cluster which need to be cleaned up manually. See https://github.com/rancher/rancher/issues/55752[#55752].
 
 [#_continuous_delivery_fleet]
 == Continuous Delivery (Fleet)

--- a/versions/v2.15/modules/en/pages/release-notes/v2.15.0.adoc
+++ b/versions/v2.15/modules/en/pages/release-notes/v2.15.0.adoc
@@ -50,7 +50,7 @@ endif::[]
 
 * Rancher now supports Kubernetes v1.36. See https://github.com/rancher/rancher/issues/54303[#54303] for information on Rancher support for Kubernetes v1.36. You can view the https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.36.md[upstream Kubernetes changelog] for v1.36 for a complete list of changes.
 * Added a cap on the maximum number of public endpoint annotations (`field.cattle.io/publicEndpoints`) written for Ingress objects. This prevents workloads with extensive custom domain lists from exceeding Kubernetes’ 256 KB metadata annotation size limit and triggering API validation errors. See https://github.com/rancher/rancher/issues/42058[#42058].
-* Optimized `rancher-images.txt` to include only the latest patch release per Kubernetes minor version compatible with the target Rancher release. RC pre-releases and superseded patch/minor versions are now filtered out, significantly reducing the size of air-gapped image tarballs while ensuring `system-agent-installer` and auxiliary images remain fully up to date. See https://github.com/rancher/rancher/issues/46174[#46174].
+* Optimized `rancher-images.txt` to include only the latest patch release per Kubernetes minor version compatible with the target Rancher release. Release Candidate (RC) pre-releases and superseded patch/minor versions are now filtered out, significantly reducing the size of air-gapped image tarballs while ensuring `system-agent-installer` and auxiliary images remain fully up to date. See https://github.com/rancher/rancher/issues/46174[#46174].
 
 [#_behavior_changes]
 === Behavior Changes
@@ -73,13 +73,13 @@ endif::[]
 [#_behavior_changes_1]
 === Behavior Changes
 
-* The option to disable the feature flag `ui-sql-cache` / Vai / Server-Side Pagination (SSP) in the Rancher UI has been removed in preparation for Rancher v2.16, where the feature will always be enabled. See https://github.com/rancher/dashboard/issues/16822[#16822].
-* **Removal**: Support for UI Plugins based on Ember, deprecated since Rancher v2.11.0, regarding cluster and node drivers are **removed** in Rancher v2.15.0. If you still need these plugins, they will need to be migrated to the https://extensions.rancher.io/extensions/next/home[UI Extensions framework]. See https://github.com/rancher/dashboard/issues/14005[#14005] for more information.
+* The option to disable the feature flag `ui-sql-cache` / Vai / Server-Side Pagination (SSP) in the Rancher UI has been removed in preparation for Rancher v2.16, where the feature will be enabled by default. See https://github.com/rancher/dashboard/issues/16822[#16822].
+* **Removal**: Support for Ember-based UI plugins for cluster and node drivers (deprecated since Rancher v2.11.0) is removed in Rancher v2.15.0. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see https://github.com/rancher/dashboard/issues/14005[issue #14005].
 
 [#_major_bug_fixes_1]
 === Major Bug Fixes
 
-* Fixed an issue when Stack Preference was set to `IPv6` and **Enable Dual-Stack** was checked, the UI modal would not include the Stack Preference warning, giving users the impression that `IPv6` is a valid stack preference for a Dual-Stack cluster when they must set it as `Dual`. See https://github.com/rancher/dashboard/issues/16788[#16788].
+* Fixed an issue where selecting *Enable Dual-Stack* with *Stack Preference* set to *IPv6* omitted the required UI warning. Dual-stack clusters require the *Stack Preference* option to be set to *Dual*. For details, see https://github.com/rancher/dashboard/issues/16788[issue #16788].
 
 [#_authentication]
 == Authentication
@@ -134,7 +134,7 @@ endif::[]
 [#_features_and_enhancements_5]
 === Features and Enhancements
 
-* Rancher introduces a new `inheritedNamespacedRules` field for GlobalRoles, allowing administrators to automatically grant users RBAC permissions to specific namespaces across all downstream clusters (for example, shared monitoring or logging namespaces). Rules defined in `inheritedNamespacedRules` automatically propagate to all downstream clusters managed by Rancher. If the namespace doesn't exist on a cluster no rules are added, however, if the namespace does not exist but gets created, the controller triggers and creates the rules. Please note that these inherited rules apply exclusively to downstream clusters and do not affect the local management cluster.
+* Rancher introduces a new `inheritedNamespacedRules` field for GlobalRoles, allowing administrators to automatically grant users RBAC permissions to specific namespaces across all downstream clusters (for example, shared monitoring or logging namespaces). Rules defined in `inheritedNamespacedRules` automatically propagate to all downstream clusters managed by Rancher. If the namespace doesn't exist on a cluster no rules are added. However, if the namespace does not exist but gets created, the controller triggers and creates the rules. Please note that these inherited rules apply exclusively to downstream clusters and do not affect the local management cluster.
 ** Configuring `inheritedNamespacedRules` currently requires editing the GlobalRole YAML directly or via the API, as direct UI inputs for this specific map are not yet available. Example YAML configuration for a GlobalRole with `inheritedNamespacedRules`:
 +
 [source,yaml]

--- a/versions/v2.15/modules/en/pages/release-notes/v2.15.0.adoc
+++ b/versions/v2.15/modules/en/pages/release-notes/v2.15.0.adoc
@@ -66,7 +66,7 @@ To improve repository performance, Rancher is introducing a lifecycle management
 * *Timeline - Rancher v2.13 & v2.14:* Legacy chart versions (older than the 7-version window) remain available.
 * *Rancher v2.15:* This release is the first version to enforce the policy. Versions falling outside the 7-version window and older than two years will no longer be available.
 
-*Impact:* This change is non-destructive for existing Rancher installations. Historical versions will remain accessible but will not be available in newer release branches once they age out of the 7-version window. You are advised to upgrade your applications before upgrading to Rancher v2.15. Uninstallation after v2.15, and replacement with an updated version, will still be possible.
+*Impact:* This change is non-destructive for existing Rancher installations. Historical versions will remain accessible but will not be available in newer release branches once they age out of the 7-version window. You are advised to upgrade your applications before upgrading to Rancher v2.15. Uninstallation after v2.15 and replacement with an updated version will still be possible.
 
 [#_major_bug_fixes_rancher_general]
 === Major Bug Fixes
@@ -90,7 +90,7 @@ To improve repository performance, Rancher is introducing a lifecycle management
 [#_major_bug_fixes_rancher_app_global_ui]
 === Major Bug Fixes
 
-* Fixed an issue where selecting *Enable Dual-Stack* with *Stack Preference* set to *IPv6* omitted the required UI warning. Dual-stack clusters require the *Stack Preference* option to be set to *Dual*. For details, see https://github.com/rancher/dashboard/issues/16788[issue #16788].
+* Fixed an issue where selecting *Enable Dual-Stack* with *Stack Preference* set to *IPv6* omitted the required UI warning. Dual-stack clusters require the *Stack Preference* option to be set to *Dual*. For details, see https://github.com/rancher/dashboard/issues/16788[#16788].
 
 [#_authentication]
 == Authentication
@@ -98,7 +98,7 @@ To improve repository performance, Rancher is introducing a lifecycle management
 [#_features_and_enhancements_authentication]
 === Features and Enhancements
 
-* Azure AD SSO Logout: Rancher now supports Single Logout (SLO) for the Azure AD auth provider. When enabled, logging out of Rancher also terminates the user's Azure AD session by redirecting to Azure AD's end-session endpoint. A `LogoutEndpoint` override field is available for sovereign-cloud deployments (Azure US Government, China). An optional `LogoutAllForced` flag can prevent users from bypassing SSO logout. See https://github.com/rancher/rancher/issues/54566[#54566].
+* *Azure AD SSO Logout*: Rancher now supports Single Logout (SLO) for the Azure AD auth provider. When enabled, logging out of Rancher also terminates the user's Azure AD session by redirecting to Azure AD's end-session endpoint. A `LogoutEndpoint` override field is available for sovereign-cloud deployments (Azure US Government, China). An optional `LogoutAllForced` flag can prevent users from bypassing SSO logout. See https://github.com/rancher/rancher/issues/54566[#54566].
 * Added the `hide-local-auth-provider` feature flag (disabled by default) to restrict local authentication usage once an External Authentication Provider (EAP) is active. When enabled, the flag hides the local login interface and removes the ability to create, edit, or delete local users from the UI. Note that password rotation for required administrative local accounts remains allowed to support emergency fallback workflows. See https://github.com/rancher/rancher/issues/46078[#46078].
 
 [#_cluster_provisioning]

--- a/versions/v2.15/modules/en/pages/release-notes/v2.15.0.adoc
+++ b/versions/v2.15/modules/en/pages/release-notes/v2.15.0.adoc
@@ -57,6 +57,17 @@ endif::[]
 
 * Rancher v2.15 removes support for Kubernetes 1.33. See https://github.com/rancher/rancher/issues/55306[#55306].
 
+[#_retention_policy_for_rancher_app_charts]
+==== Retention Policy for Rancher App Charts
+
+To improve repository performance, Rancher is introducing a lifecycle management policy for charts available in the Apps feature of Rancher, specifically in the "Rancher" repository.
+
+* *The Policy:* Rancher will transition from a cumulative model (retaining all historical versions forever) to a retention model that preserves chart versions for the *seven (7) most recent Rancher minor releases* (approximately a 2.5-year window).
+* *Timeline - Rancher v2.13 & v2.14:* Legacy chart versions (older than the 7-version window) remain available.
+* *Rancher v2.15:* This release is the first version to enforce the policy. Versions falling outside the 7-version window and older than two years will no longer be available.
+
+*Impact:* This change is non-destructive for existing Rancher installations. Historical versions will remain accessible but will not be available in newer release branches once they age out of the 7-version window. You are advised to upgrade your applications before upgrading to Rancher v2.15. Uninstallation after v2.15, and replacement with an updated version, will still be possible.
+
 [#_major_bug_fixes_rancher_general]
 === Major Bug Fixes
 
@@ -240,20 +251,6 @@ Image artifact digests are renamed in Rancher v2.12.0, v2.11.4 and v2.10.8. Up u
 === Rancher Helm Chart Versions
 
 In Rancher v2.6.0 and later, in the *Apps & Marketplace* UI, many Rancher Helm charts are named with a major version that starts with _100_. This avoids simultaneous upstream changes and Rancher changes from causing conflicting version increments. This also complies with semantic versioning (SemVer), which is a requirement for Helm. You can see the upstream version number of a chart in the build metadata, for example: `100.0.0+up2.1.0`. See https://github.com/rancher/rancher/issues/32294[#32294].
-
-[#_future_rancher_behavior_changes]
-== Future Rancher Behavior Changes
-
-[#_retention_policy_for_rancher_app_charts]
-=== Retention Policy for Rancher App Charts
-
-To improve repository performance, Rancher is introducing a lifecycle management policy for charts available in the Apps feature of Rancher, specifically in the "Rancher" repository.
-
-* *The Policy:* Rancher will transition from a cumulative model (retaining all historical versions forever) to a retention model that preserves chart versions for the *seven (7) most recent Rancher minor releases* (approximately a 2.5-year window).
-* *Timeline - Rancher v2.13 & v2.14:* Legacy chart versions (older than the 7-version window) remain available.
-* *Rancher v2.15:* This will be the first version to enforce the policy. Versions falling outside the 7-version window and older than two years will no longer be available.
-
-*Impact:* This change is non-destructive for existing Rancher installations. Historical versions will remain accessible but will not be available in newer release branches once they age out of the 7-version window. You are advised to upgrade your applications before upgrading to Rancher v2.15. Uninstallation after v2.15, and replacement with an updated version, will still be possible.
 
 [#_long_standing_known_issues]
 == Long-standing Known Issues

--- a/versions/v2.15/modules/en/pages/release-notes/v2.15.0.adoc
+++ b/versions/v2.15/modules/en/pages/release-notes/v2.15.0.adoc
@@ -45,19 +45,19 @@ endif::[]
 [#_rancher_general]
 == Rancher General
 
-[#_features_and_enhancements]
+[#_features_and_enhancements_rancher_general]
 === Features and Enhancements
 
 * Rancher now supports Kubernetes v1.36. See https://github.com/rancher/rancher/issues/54303[#54303] for information on Rancher support for Kubernetes v1.36. You can view the https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.36.md[upstream Kubernetes changelog] for v1.36 for a complete list of changes.
 * Added a cap on the maximum number of public endpoint annotations (`field.cattle.io/publicEndpoints`) written for Ingress objects. This prevents workloads with extensive custom domain lists from exceeding Kubernetes’ 256 KB metadata annotation size limit and triggering API validation errors. See https://github.com/rancher/rancher/issues/42058[#42058].
 * Optimized `rancher-images.txt` to include only the latest patch release per Kubernetes minor version compatible with the target Rancher release. Release Candidate (RC) pre-releases and superseded patch/minor versions are now filtered out, significantly reducing the size of air-gapped image tarballs while ensuring `system-agent-installer` and auxiliary images remain fully up to date. See https://github.com/rancher/rancher/issues/46174[#46174].
 
-[#_behavior_changes]
+[#_behavior_changes_rancher_general]
 === Behavior Changes
 
 * Rancher v2.15 removes support for Kubernetes 1.33. See https://github.com/rancher/rancher/issues/55306[#55306].
 
-[#_major_bug_fixes]
+[#_major_bug_fixes_rancher_general]
 === Major Bug Fixes
 
 * Fixed an issue where `rancher-save-images.sh` failed to pull OCI-based Helm charts when the local Docker daemon was configured to use the `overlay2` storage driver. See https://github.com/rancher/rancher/issues/55068[#55068].
@@ -65,18 +65,18 @@ endif::[]
 [#_rancher_app_global_ui]
 == Rancher App (Global UI)
 
-[#_features_and_enhancements_1]
+[#_features_and_enhancements_rancher_app_global_ui]
 === Features and Enhancements
 
 * The Rancher Dashboard replaces the legacy all-in-one Workloads list with a new **Workloads Overview** UI view to solve major performance and scalability issues when viewing workload resources. See https://github.com/rancher/dashboard/issues/11513[#11513].
 
-[#_behavior_changes_1]
+[#_behavior_changes_rancher_app_global_ui]
 === Behavior Changes
 
 * The option to disable the feature flag `ui-sql-cache` / Vai / Server-Side Pagination (SSP) in the Rancher UI has been removed in preparation for Rancher v2.16, where the feature will always be enabled. See https://github.com/rancher/dashboard/issues/16822[#16822].
 * **Removal**: Support for Ember-based UI plugins for cluster and node drivers (deprecated since Rancher v2.11.0) is removed in Rancher v2.15.0. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see https://github.com/rancher/dashboard/issues/14005[issue #14005].
 
-[#_major_bug_fixes_1]
+[#_major_bug_fixes_rancher_app_global_ui]
 === Major Bug Fixes
 
 * Fixed an issue where selecting *Enable Dual-Stack* with *Stack Preference* set to *IPv6* omitted the required UI warning. Dual-stack clusters require the *Stack Preference* option to be set to *Dual*. For details, see https://github.com/rancher/dashboard/issues/16788[issue #16788].
@@ -84,7 +84,7 @@ endif::[]
 [#_authentication]
 == Authentication
 
-[#_features_and_enhancements_2]
+[#_features_and_enhancements_authentication]
 === Features and Enhancements
 
 * Azure AD SSO Logout: Rancher now supports Single Logout (SLO) for the Azure AD auth provider. When enabled, logging out of Rancher also terminates the user's Azure AD session by redirecting to Azure AD's end-session endpoint. A `LogoutEndpoint` override field is available for sovereign-cloud deployments (Azure US Government, China). An optional `LogoutAllForced` flag can prevent users from bypassing SSO logout. See https://github.com/rancher/rancher/issues/54566[#54566].
@@ -93,7 +93,7 @@ endif::[]
 [#_cluster_provisioning]
 == Cluster Provisioning
 
-[#_features_and_enhancements_3]
+[#_features_and_enhancements_cluster_provisioning]
 === Features and Enhancements
 
 * Rancher v2.15 adds support for Cluster API (CAPI) v1.13.2. See https://github.com/rancher/rancher/issues/54304[#54304].
@@ -102,19 +102,19 @@ endif::[]
 [#_k3s_and_rke2_provisioning]
 == K3s and RKE2 Provisioning
 
-[#_features_and_enhancements_4]
+[#_features_and_enhancements_k3s_and_rke2_provisioning]
 === Features and Enhancements
 
 * **General Availability**: Promoted support for native Cluster API (CAPI) infrastructure providers within Rancher’s V2 provisioning framework (v2prov) from Tech Preview to General Availability (GA). See https://github.com/rancher/rancher/issues/53777[#53777].
 ** If the CAPA infrastructure provider is installed, Rancher will mirror {rn-cloud-credentials}[cloud credentials] for AWS and create a corresponding `AWSClusterStaticIdentity` object that targets the `fleet-default` namespace.
 
-[#_behavior_changes_2]
+[#_behavior_changes_k3s_and_rke2_provisioning]
 === Behavior Changes
 
 * By default, the `Standard User` and `Create Clusters` {rn-global-permissions}[global permissions] now allow creating and then updating CAPI infrastructure objects in the `fleet-default` namespace. Note that manually created infrastructure provider identity objects, such as `AWSClusterStaticIdentity` or `VSphereClusterIdentity`, that target the `fleet-default` namespace can be used through CAPI infrastructure objects such as `AWSCluster` or `VsphereCluster`. See https://github.com/rancher/rancher/issues/53777[#53777].
 * When using native CAPI infrastructure providers with v2prov, Rancher will now generate the bootstrap cloud-config in the https://docs.cloud-init.io/en/latest/explanation/format/jinja.html[Jinja format]. User-data for regular node drivers with v2prov is unaffected. See https://github.com/rancher/rancher/issues/53777[#53777].
 
-[#_known_issues]
+[#_known_issues_k3s_and_rke2_provisioning]
 === Known Issues
 
 * A known issue exists related to CAPI infrastructure providers within Rancher’s V2 provisioning framework. Creating or editing v2prov clusters with native infrastructure providers (such as CAPA or CAPV) from the UI can under some failure conditions leave unused, orphaned infrastructure resources (e.g., `AWSMachineTemplate` or `AWSCluster`) in the management cluster which need to be cleaned up manually. See https://github.com/rancher/rancher/issues/55752[#55752].
@@ -122,7 +122,7 @@ endif::[]
 [#_continuous_delivery_fleet]
 == Continuous Delivery (Fleet)
 
-[#_behavior_changes_3]
+[#_behavior_changes_continuous_delivery_fleet]
 === Behavior Changes
 
 * **Deprecation**: Fleet will be removing support for `GitRepoRestriction` in a future release, making the use of the Policy resource for configuring multi-tenant environments the only option. See https://github.com/rancher/rancher/issues/55652[#55652].
@@ -131,7 +131,7 @@ endif::[]
 [#_role_based_access_control_rbac]
 == Role-Based Access Control (RBAC)
 
-[#_features_and_enhancements_5]
+[#_features_and_enhancements_role_based_access_control_rbac]
 === Features and Enhancements
 
 * Rancher introduces a new `inheritedNamespacedRules` field for GlobalRoles, allowing administrators to automatically grant users RBAC permissions to specific namespaces across all downstream clusters (for example, shared monitoring or logging namespaces). Rules defined in `inheritedNamespacedRules` automatically propagate to all downstream clusters managed by Rancher. If the namespace doesn't exist on a cluster no rules are added. However, if the namespace does not exist but gets created, the controller triggers and creates the rules. Please note that these inherited rules apply exclusively to downstream clusters and do not affect the local management cluster.
@@ -166,7 +166,7 @@ See https://github.com/rancher/rancher/issues/50663[#50663] for more information
 [#_virtualization_management_harvester]
 == Virtualization Management (Harvester)
 
-[#_features_and_enhancements_6]
+[#_features_and_enhancements_virtualization_management_harvester]
 === Features and Enhancements
 
 * This release adds support for the `harvester-baremetal-container-workload` feature flag, disabled by default, within Rancher's Fleet continuous delivery targeting mechanism. When enabled, the UI stops filtering out Harvester clusters, allowing Fleet bundles and applications to target and deploy container workloads directly to them. After enabling the `harvester-baremetal-container-workload` feature flag, please validate existing Fleet Bundles to ensure they now select, or don't select, the required clusters. When disabled, the UI maintains the default behavior and excludes Harvester clusters from Fleet targets. See https://github.com/rancher/dashboard/issues/12518[#12518].

--- a/versions/v2.15/modules/en/pages/release-notes/v2.15.0.adoc
+++ b/versions/v2.15/modules/en/pages/release-notes/v2.15.0.adoc
@@ -244,8 +244,8 @@ Image artifact digests are renamed in Rancher v2.12.0, v2.11.4 and v2.10.8. Up u
 [#_kubernetes_versions_for_rke2_k3s]
 === Kubernetes Versions for RKE2/K3s
 
-* v1.36.1 (Default)
-* v1.35.6
+* v1.36.3 (Default)
+* v1.35.7
 * v1.34.9
 
 === Rancher Helm Chart Versions

--- a/versions/v2.15/modules/en/pages/release-notes/v2.15.0.adoc
+++ b/versions/v2.15/modules/en/pages/release-notes/v2.15.0.adoc
@@ -55,7 +55,7 @@ endif::[]
 [#_behavior_changes_rancher_general]
 === Behavior Changes
 
-* Rancher v2.15 removes support for Kubernetes 1.33. See https://github.com/rancher/rancher/issues/55306[#55306].
+* Rancher v2.15 removes support for Kubernetes v1.33. See https://github.com/rancher/rancher/issues/55306[#55306].
 
 [#_retention_policy_for_rancher_app_charts]
 ==== Retention Policy for Rancher App Charts
@@ -85,7 +85,7 @@ To improve repository performance, Rancher is introducing a lifecycle management
 === Behavior Changes
 
 * The option to disable the feature flag `ui-sql-cache` / Vai / Server-Side Pagination (SSP) in the Rancher UI has been removed in preparation for Rancher v2.16, where the feature will always be enabled. See https://github.com/rancher/dashboard/issues/16822[#16822].
-* **Removal**: Support for Ember-based UI plugins for cluster and node drivers (deprecated since Rancher v2.11.0) is removed in Rancher v2.15.0. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see https://github.com/rancher/dashboard/issues/14005[issue #14005].
+* **Removal**: Support for Ember-based UI plugins for cluster and node drivers (deprecated since Rancher v2.11.0) is removed in Rancher v2.15.0. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see https://github.com/rancher/dashboard/issues/14005[#14005].
 
 [#_major_bug_fixes_rancher_app_global_ui]
 === Major Bug Fixes

--- a/versions/v2.15/modules/en/pages/release-notes/v2.15.0.adoc
+++ b/versions/v2.15/modules/en/pages/release-notes/v2.15.0.adoc
@@ -73,7 +73,7 @@ endif::[]
 [#_behavior_changes_1]
 === Behavior Changes
 
-* The option to disable the feature flag `ui-sql-cache` / Vai / Server-Side Pagination (SSP) in the Rancher UI has been removed in preparation for Rancher v2.16, where the feature will be enabled by default. See https://github.com/rancher/dashboard/issues/16822[#16822].
+* The option to disable the feature flag `ui-sql-cache` / Vai / Server-Side Pagination (SSP) in the Rancher UI has been removed in preparation for Rancher v2.16, where the feature will always be enabled. See https://github.com/rancher/dashboard/issues/16822[#16822].
 * **Removal**: Support for Ember-based UI plugins for cluster and node drivers (deprecated since Rancher v2.11.0) is removed in Rancher v2.15.0. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see https://github.com/rancher/dashboard/issues/14005[issue #14005].
 
 [#_major_bug_fixes_1]

--- a/versions/v2.15/modules/en/pages/release-notes/v2.15.0.adoc
+++ b/versions/v2.15/modules/en/pages/release-notes/v2.15.0.adoc
@@ -125,8 +125,8 @@ endif::[]
 [#_behavior_changes_3]
 === Behavior Changes
 
-* **Deprecation**: Fleet will be deprecating support for `GitRepoRestriction` in a future release, making the use of the Policy resource for configuring multi-tenant environments the only option. See https://github.com/rancher/rancher/issues/55652[#55652].
-* **Deprecation**: Fleet support for unauthenticated webhook calls will be deprecated in a future release, making the setup of a {rn-fleet-webhook}[webhook secret] the only option. See https://github.com/rancher/rancher/issues/55633[#55633].
+* **Deprecation**: Fleet will be removing support for `GitRepoRestriction` in a future release, making the use of the Policy resource for configuring multi-tenant environments the only option. See https://github.com/rancher/rancher/issues/55652[#55652].
+* **Deprecation**: Fleet support for unauthenticated webhook calls will be removed in a future release, making the setup of a {rn-fleet-webhook}[webhook secret] the only option. See https://github.com/rancher/rancher/issues/55633[#55633].
 
 [#_role_based_access_control_rbac]
 == Role-Based Access Control (RBAC)


### PR DESCRIPTION
- [x] Remove the old info, issues listed as Bug Fixes and Features, moved previous 'Known Issues' and 'Behavior Changes' to 'Long-standing Known Issues' and 'Previous Rancher Behavior Changes' section.
- [x] New issues for 2.15.0 (last checked: 07/21/26):
  - [x] [rancher/rancher-prime](https://github.com/rancher/rancher-prime/issues?q=state%3Aclosed%20label%3A%22release-note%22%20milestone%3Av2.15.0) (Open: 0, Closed: 0)
    - [rancher/rancher Prime-only](https://github.com/rancher/rancher/issues?q=is%3Aissue%20state%3Aopen%20milestone%3Av2.15.0%20label%3Arelease-note-prime) (Open: 1, Closed: 1)
    - Fleet issue relevant for community, RKE2 Prime issue not relevant until 2.15.1 prime release
    - [rancher/rancher](https://github.com/rancher/rancher/issues?q=is%3Aissue%20state%3Aopen%20milestone%3Av2.15.0%20label%3Arelease-note) (Open: 6, Closed: 12)
  - [x] [rancher/dashboard](https://github.com/rancher/dashboard/issues?q=is%3Aissue%20state%3Aclosed%20milestone%3Av2.15.0%20label%3Arelease-note) (Open: 0, Closed: 10)
  - [x] [rancher/backup-restore-operator](https://github.com/rancher/backup-restore-operator/issues?q=is%3Aissue%20state%3Aopen%20label%3Arelease-note%20milestone%3Av2.15.0) (Open: 0, Closed: 0)
 - [x] Existing Known Issues (last verified: 07/21/26)
- [x] Updated tool/k8s versions