### PR TITLE
[v2.15.0] Add deprecation notice for Ember-based UI plugins for cluster and node drivers

### DIFF
--- a/versions/v2.11/modules/en/pages/rancher-admin/global-configuration/provisioning-drivers/provisioning-drivers.adoc
+++ b/versions/v2.11/modules/en/pages/rancher-admin/global-configuration/provisioning-drivers/provisioning-drivers.adoc
@@ -31,7 +31,7 @@ endif::[]
 
 [IMPORTANT]
 ====
-Starting in Rancher v2.11.0, Ember-based UI plugins for cluster and node drivers are deprecated and will be removed in a future release. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see:
+Starting in Rancher v2.11, Ember-based UI plugins for cluster and node drivers are deprecated and will be removed in a future release. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see:
 
 * https://extensions.rancher.io/extensions/provisioning/hosted-provider/overview[Custom Hosted Provider (Cluster Drivers) UI]
 * https://extensions.rancher.io/extensions/provisioning/node-driver/overview[Custom Node Drivers UI]
@@ -52,7 +52,7 @@ There are two types of drivers within Rancher:
 
 [IMPORTANT]
 ====
-Starting in Rancher v2.11.0, Ember-based UI plugins for cluster drivers are deprecated and will be removed in a future release. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see https://extensions.rancher.io/extensions/provisioning/hosted-provider/overview[Custom Hosted Provider (Cluster Drivers) UI].
+Starting in Rancher v2.11, Ember-based UI plugins for cluster drivers are deprecated and will be removed in a future release. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see https://extensions.rancher.io/extensions/provisioning/hosted-provider/overview[Custom Hosted Provider (Cluster Drivers) UI].
 ====
 
 Cluster drivers are used to provision {xref-hosted-k8s-clusters}[hosted Kubernetes clusters], such as GKE, EKS, AKS, etc.. The availability of which cluster driver to display when creating a cluster is defined based on the cluster driver's status. Only `active` cluster drivers will be displayed as an option for creating clusters for hosted Kubernetes clusters. By default, Rancher is packaged with several existing cluster drivers, but you can also create custom cluster drivers to add to Rancher.
@@ -67,7 +67,7 @@ By default, Rancher has activated several hosted Kubernetes cloud providers incl
 
 [IMPORTANT]
 ====
-Starting in Rancher v2.11.0, Ember-based UI plugins for node drivers are deprecated and will be removed in a future release. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see https://extensions.rancher.io/extensions/provisioning/node-driver/overview[Custom Node Drivers UI].
+Starting in Rancher v2.11, Ember-based UI plugins for node drivers are deprecated and will be removed in a future release. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see https://extensions.rancher.io/extensions/provisioning/node-driver/overview[Custom Node Drivers UI].
 ====
 
 Node drivers are used to provision hosts, which Rancher uses to launch and manage Kubernetes clusters. A node driver is the same as a https://github.com/docker/docs/blob/vnext-engine/machine/drivers/index.md[Docker Machine driver]. The availability of which node driver to display when creating node templates is defined based on the node driver's status. Only `active` node drivers will be displayed as an option for creating node templates. By default, Rancher is packaged with many existing Docker Machine drivers, but you can also create custom node drivers to add to Rancher.

--- a/versions/v2.11/modules/en/pages/rancher-admin/global-configuration/provisioning-drivers/provisioning-drivers.adoc
+++ b/versions/v2.11/modules/en/pages/rancher-admin/global-configuration/provisioning-drivers/provisioning-drivers.adoc
@@ -1,6 +1,6 @@
 = About Provisioning Drivers
 :page-languages: [en, zh]
-:revdate: 2025-06-20
+:revdate: 2026-07-28
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/index.adoc 
 :product-path: rancher-admin/global-configuration/provisioning-drivers/provisioning-drivers.adoc
@@ -29,6 +29,14 @@ ifeval::["{build-type}" == "community"]
 :xref-infra-vsphere: xref:how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/index.adoc
 endif::[]
 
+[IMPORTANT]
+====
+Starting in Rancher v2.11.0, Ember-based UI plugins for cluster and node drivers are deprecated and will be removed in a future release. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see:
+
+* https://extensions.rancher.io/extensions/provisioning/hosted-provider/overview[Custom Hosted Provider (Cluster Drivers) UI]
+* https://extensions.rancher.io/extensions/provisioning/node-driver/overview[Custom Node Drivers UI]
+====
+
 Drivers in Rancher allow you to manage which providers can be used to deploy {xref-hosted-k8s-clusters}[hosted Kubernetes clusters] or {xref-infra-providers}[nodes in an infrastructure provider] to allow Rancher to deploy and manage Kubernetes.
 
 == Rancher Drivers
@@ -42,6 +50,11 @@ There are two types of drivers within Rancher:
 
 == Cluster Drivers
 
+[IMPORTANT]
+====
+Starting in Rancher v2.11.0, Ember-based UI plugins for cluster drivers are deprecated and will be removed in a future release. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see https://extensions.rancher.io/extensions/provisioning/hosted-provider/overview[Custom Hosted Provider (Cluster Drivers) UI].
+====
+
 Cluster drivers are used to provision {xref-hosted-k8s-clusters}[hosted Kubernetes clusters], such as GKE, EKS, AKS, etc.. The availability of which cluster driver to display when creating a cluster is defined based on the cluster driver's status. Only `active` cluster drivers will be displayed as an option for creating clusters for hosted Kubernetes clusters. By default, Rancher is packaged with several existing cluster drivers, but you can also create custom cluster drivers to add to Rancher.
 
 By default, Rancher has activated several hosted Kubernetes cloud providers including:
@@ -51,6 +64,11 @@ By default, Rancher has activated several hosted Kubernetes cloud providers incl
 * {xref-deploy-aks}[Azure AKS]
 
 == Node Drivers
+
+[IMPORTANT]
+====
+Starting in Rancher v2.11.0, Ember-based UI plugins for node drivers are deprecated and will be removed in a future release. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see https://extensions.rancher.io/extensions/provisioning/node-driver/overview[Custom Node Drivers UI].
+====
 
 Node drivers are used to provision hosts, which Rancher uses to launch and manage Kubernetes clusters. A node driver is the same as a https://github.com/docker/docs/blob/vnext-engine/machine/drivers/index.md[Docker Machine driver]. The availability of which node driver to display when creating node templates is defined based on the node driver's status. Only `active` node drivers will be displayed as an option for creating node templates. By default, Rancher is packaged with many existing Docker Machine drivers, but you can also create custom node drivers to add to Rancher.
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/global-configuration/provisioning-drivers/provisioning-drivers.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/global-configuration/provisioning-drivers/provisioning-drivers.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-26
+:revdate: 2026-07-28
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/index.adoc 
 :product-path: rancher-admin/global-configuration/provisioning-drivers/provisioning-drivers.adoc
@@ -33,6 +33,14 @@ ifeval::["{build-type}" == "community"]
 :xref-infra-vsphere: xref:how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/index.adoc
 endif::[]
 
+[IMPORTANT]
+====
+Starting in Rancher v2.11.0, Ember-based UI plugins for cluster and node drivers are deprecated and will be removed in a future release. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see:
+
+* https://extensions.rancher.io/extensions/provisioning/hosted-provider/overview[Custom Hosted Provider (Cluster Drivers) UI]
+* https://extensions.rancher.io/extensions/provisioning/node-driver/overview[Custom Node Drivers UI]
+====
+
 Drivers in Rancher allow you to manage which providers can be used to deploy {xref-hosted-k8s-clusters}[hosted Kubernetes clusters] or {xref-infra-providers}[nodes in an infrastructure provider] to allow Rancher to deploy and manage Kubernetes.
 
 == Rancher Drivers
@@ -46,6 +54,11 @@ There are two types of drivers within Rancher:
 
 == Cluster Drivers
 
+[IMPORTANT]
+====
+Starting in Rancher v2.11.0, Ember-based UI plugins for cluster drivers are deprecated and will be removed in a future release. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see https://extensions.rancher.io/extensions/provisioning/hosted-provider/overview[Custom Hosted Provider (Cluster Drivers) UI].
+====
+
 Cluster drivers are used to provision {xref-hosted-k8s-clusters}[hosted Kubernetes clusters], such as GKE, EKS, AKS, etc.. The availability of which cluster driver to display when creating a cluster is defined based on the cluster driver's status. Only `active` cluster drivers will be displayed as an option for creating clusters for hosted Kubernetes clusters. By default, Rancher is packaged with several existing cluster drivers, but you can also create custom cluster drivers to add to Rancher.
 
 By default, Rancher has activated several hosted Kubernetes cloud providers including:
@@ -55,6 +68,11 @@ By default, Rancher has activated several hosted Kubernetes cloud providers incl
 * {xref-deploy-aks}[Azure AKS]
 
 == Node Drivers
+
+[IMPORTANT]
+====
+Starting in Rancher v2.11.0, Ember-based UI plugins for node drivers are deprecated and will be removed in a future release. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see https://extensions.rancher.io/extensions/provisioning/node-driver/overview[Custom Node Drivers UI].
+====
 
 Node drivers are used to provision hosts, which Rancher uses to launch and manage Kubernetes clusters. A node driver is the same as a https://github.com/docker/docs/blob/vnext-engine/machine/drivers/index.md[Docker Machine driver]. The availability of which node driver to display when creating node templates is defined based on the node driver's status. Only `active` node drivers will be displayed as an option for creating node templates. By default, Rancher is packaged with many existing Docker Machine drivers, but you can also create custom node drivers to add to Rancher.
 

--- a/versions/v2.12/modules/en/pages/rancher-admin/global-configuration/provisioning-drivers/provisioning-drivers.adoc
+++ b/versions/v2.12/modules/en/pages/rancher-admin/global-configuration/provisioning-drivers/provisioning-drivers.adoc
@@ -35,7 +35,7 @@ endif::[]
 
 [IMPORTANT]
 ====
-Starting in Rancher v2.11.0, Ember-based UI plugins for cluster and node drivers are deprecated and will be removed in a future release. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see:
+Starting in Rancher v2.11, Ember-based UI plugins for cluster and node drivers are deprecated and will be removed in a future release. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see:
 
 * https://extensions.rancher.io/extensions/provisioning/hosted-provider/overview[Custom Hosted Provider (Cluster Drivers) UI]
 * https://extensions.rancher.io/extensions/provisioning/node-driver/overview[Custom Node Drivers UI]
@@ -56,7 +56,7 @@ There are two types of drivers within Rancher:
 
 [IMPORTANT]
 ====
-Starting in Rancher v2.11.0, Ember-based UI plugins for cluster drivers are deprecated and will be removed in a future release. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see https://extensions.rancher.io/extensions/provisioning/hosted-provider/overview[Custom Hosted Provider (Cluster Drivers) UI].
+Starting in Rancher v2.11, Ember-based UI plugins for cluster drivers are deprecated and will be removed in a future release. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see https://extensions.rancher.io/extensions/provisioning/hosted-provider/overview[Custom Hosted Provider (Cluster Drivers) UI].
 ====
 
 Cluster drivers are used to provision {xref-hosted-k8s-clusters}[hosted Kubernetes clusters], such as GKE, EKS, AKS, etc.. The availability of which cluster driver to display when creating a cluster is defined based on the cluster driver's status. Only `active` cluster drivers will be displayed as an option for creating clusters for hosted Kubernetes clusters. By default, Rancher is packaged with several existing cluster drivers, but you can also create custom cluster drivers to add to Rancher.
@@ -71,7 +71,7 @@ By default, Rancher has activated several hosted Kubernetes cloud providers incl
 
 [IMPORTANT]
 ====
-Starting in Rancher v2.11.0, Ember-based UI plugins for node drivers are deprecated and will be removed in a future release. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see https://extensions.rancher.io/extensions/provisioning/node-driver/overview[Custom Node Drivers UI].
+Starting in Rancher v2.11, Ember-based UI plugins for node drivers are deprecated and will be removed in a future release. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see https://extensions.rancher.io/extensions/provisioning/node-driver/overview[Custom Node Drivers UI].
 ====
 
 Node drivers are used to provision hosts, which Rancher uses to launch and manage Kubernetes clusters. A node driver is the same as a https://github.com/docker/docs/blob/vnext-engine/machine/drivers/index.md[Docker Machine driver]. The availability of which node driver to display when creating node templates is defined based on the node driver's status. Only `active` node drivers will be displayed as an option for creating node templates. By default, Rancher is packaged with many existing Docker Machine drivers, but you can also create custom node drivers to add to Rancher.

--- a/versions/v2.13/modules/en/pages/rancher-admin/global-configuration/provisioning-drivers/provisioning-drivers.adoc
+++ b/versions/v2.13/modules/en/pages/rancher-admin/global-configuration/provisioning-drivers/provisioning-drivers.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-08-26
+:revdate: 2026-07-28
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/index.adoc 
 :product-path: rancher-admin/global-configuration/provisioning-drivers/provisioning-drivers.adoc
@@ -33,6 +33,14 @@ ifeval::["{build-type}" == "community"]
 :xref-infra-vsphere: xref:how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/index.adoc
 endif::[]
 
+[IMPORTANT]
+====
+Starting in Rancher v2.11.0, Ember-based UI plugins for cluster and node drivers are deprecated and will be removed in a future release. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see:
+
+* https://extensions.rancher.io/extensions/provisioning/hosted-provider/overview[Custom Hosted Provider (Cluster Drivers) UI]
+* https://extensions.rancher.io/extensions/provisioning/node-driver/overview[Custom Node Drivers UI]
+====
+
 Drivers in Rancher allow you to manage which providers can be used to deploy {xref-hosted-k8s-clusters}[hosted Kubernetes clusters] or {xref-infra-providers}[nodes in an infrastructure provider] to allow Rancher to deploy and manage Kubernetes.
 
 == Rancher Drivers
@@ -46,6 +54,11 @@ There are two types of drivers within Rancher:
 
 == Cluster Drivers
 
+[IMPORTANT]
+====
+Starting in Rancher v2.11.0, Ember-based UI plugins for cluster drivers are deprecated and will be removed in a future release. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see https://extensions.rancher.io/extensions/provisioning/hosted-provider/overview[Custom Hosted Provider (Cluster Drivers) UI].
+====
+
 Cluster drivers are used to provision {xref-hosted-k8s-clusters}[hosted Kubernetes clusters], such as GKE, EKS, AKS, etc.. The availability of which cluster driver to display when creating a cluster is defined based on the cluster driver's status. Only `active` cluster drivers will be displayed as an option for creating clusters for hosted Kubernetes clusters. By default, Rancher is packaged with several existing cluster drivers, but you can also create custom cluster drivers to add to Rancher.
 
 By default, Rancher has activated several hosted Kubernetes cloud providers including:
@@ -55,6 +68,11 @@ By default, Rancher has activated several hosted Kubernetes cloud providers incl
 * {xref-deploy-aks}[Azure AKS]
 
 == Node Drivers
+
+[IMPORTANT]
+====
+Starting in Rancher v2.11.0, Ember-based UI plugins for node drivers are deprecated and will be removed in a future release. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see https://extensions.rancher.io/extensions/provisioning/node-driver/overview[Custom Node Drivers UI].
+====
 
 Node drivers are used to provision hosts, which Rancher uses to launch and manage Kubernetes clusters. A node driver is the same as a https://github.com/docker/docs/blob/vnext-engine/machine/drivers/index.md[Docker Machine driver]. The availability of which node driver to display when creating node templates is defined based on the node driver's status. Only `active` node drivers will be displayed as an option for creating node templates. By default, Rancher is packaged with many existing Docker Machine drivers, but you can also create custom node drivers to add to Rancher.
 

--- a/versions/v2.13/modules/en/pages/rancher-admin/global-configuration/provisioning-drivers/provisioning-drivers.adoc
+++ b/versions/v2.13/modules/en/pages/rancher-admin/global-configuration/provisioning-drivers/provisioning-drivers.adoc
@@ -35,7 +35,7 @@ endif::[]
 
 [IMPORTANT]
 ====
-Starting in Rancher v2.11.0, Ember-based UI plugins for cluster and node drivers are deprecated and will be removed in a future release. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see:
+Starting in Rancher v2.11, Ember-based UI plugins for cluster and node drivers are deprecated and will be removed in a future release. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see:
 
 * https://extensions.rancher.io/extensions/provisioning/hosted-provider/overview[Custom Hosted Provider (Cluster Drivers) UI]
 * https://extensions.rancher.io/extensions/provisioning/node-driver/overview[Custom Node Drivers UI]
@@ -56,7 +56,7 @@ There are two types of drivers within Rancher:
 
 [IMPORTANT]
 ====
-Starting in Rancher v2.11.0, Ember-based UI plugins for cluster drivers are deprecated and will be removed in a future release. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see https://extensions.rancher.io/extensions/provisioning/hosted-provider/overview[Custom Hosted Provider (Cluster Drivers) UI].
+Starting in Rancher v2.11, Ember-based UI plugins for cluster drivers are deprecated and will be removed in a future release. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see https://extensions.rancher.io/extensions/provisioning/hosted-provider/overview[Custom Hosted Provider (Cluster Drivers) UI].
 ====
 
 Cluster drivers are used to provision {xref-hosted-k8s-clusters}[hosted Kubernetes clusters], such as GKE, EKS, AKS, etc.. The availability of which cluster driver to display when creating a cluster is defined based on the cluster driver's status. Only `active` cluster drivers will be displayed as an option for creating clusters for hosted Kubernetes clusters. By default, Rancher is packaged with several existing cluster drivers, but you can also create custom cluster drivers to add to Rancher.
@@ -71,7 +71,7 @@ By default, Rancher has activated several hosted Kubernetes cloud providers incl
 
 [IMPORTANT]
 ====
-Starting in Rancher v2.11.0, Ember-based UI plugins for node drivers are deprecated and will be removed in a future release. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see https://extensions.rancher.io/extensions/provisioning/node-driver/overview[Custom Node Drivers UI].
+Starting in Rancher v2.11, Ember-based UI plugins for node drivers are deprecated and will be removed in a future release. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see https://extensions.rancher.io/extensions/provisioning/node-driver/overview[Custom Node Drivers UI].
 ====
 
 Node drivers are used to provision hosts, which Rancher uses to launch and manage Kubernetes clusters. A node driver is the same as a https://github.com/docker/docs/blob/vnext-engine/machine/drivers/index.md[Docker Machine driver]. The availability of which node driver to display when creating node templates is defined based on the node driver's status. Only `active` node drivers will be displayed as an option for creating node templates. By default, Rancher is packaged with many existing Docker Machine drivers, but you can also create custom node drivers to add to Rancher.

--- a/versions/v2.14/modules/en/pages/rancher-admin/global-configuration/provisioning-drivers/provisioning-drivers.adoc
+++ b/versions/v2.14/modules/en/pages/rancher-admin/global-configuration/provisioning-drivers/provisioning-drivers.adoc
@@ -1,6 +1,6 @@
 = About Provisioning Drivers
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2025-08-26
+:revdate: 2026-07-28
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/index.adoc 
 :product-path: rancher-admin/global-configuration/provisioning-drivers/provisioning-drivers.adoc
@@ -31,6 +31,14 @@ ifeval::["{build-type}" == "community"]
 :xref-infra-vsphere: xref:how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/index.adoc
 endif::[]
 
+[IMPORTANT]
+====
+Starting in Rancher v2.11.0, Ember-based UI plugins for cluster and node drivers are deprecated and will be removed in a future release. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see:
+
+* https://extensions.rancher.io/extensions/provisioning/hosted-provider/overview[Custom Hosted Provider (Cluster Drivers) UI]
+* https://extensions.rancher.io/extensions/provisioning/node-driver/overview[Custom Node Drivers UI]
+====
+
 Drivers in Rancher allow you to manage which providers can be used to deploy {xref-hosted-k8s-clusters}[hosted Kubernetes clusters] or {xref-infra-providers}[nodes in an infrastructure provider] to allow Rancher to deploy and manage Kubernetes.
 
 [#_rancher_drivers]
@@ -46,6 +54,11 @@ There are two types of drivers within Rancher:
 [#_cluster_drivers]
 == Cluster Drivers
 
+[IMPORTANT]
+====
+Starting in Rancher v2.11.0, Ember-based UI plugins for cluster drivers are deprecated and will be removed in a future release. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see https://extensions.rancher.io/extensions/provisioning/hosted-provider/overview[Custom Hosted Provider (Cluster Drivers) UI].
+====
+
 Cluster drivers are used to provision {xref-hosted-k8s-clusters}[hosted Kubernetes clusters], such as GKE, EKS, AKS, etc.. The availability of which cluster driver to display when creating a cluster is defined based on the cluster driver's status. Only `active` cluster drivers will be displayed as an option for creating clusters for hosted Kubernetes clusters. By default, Rancher is packaged with several existing cluster drivers, but you can also create custom cluster drivers to add to Rancher.
 
 By default, Rancher has activated several hosted Kubernetes cloud providers including:
@@ -56,6 +69,11 @@ By default, Rancher has activated several hosted Kubernetes cloud providers incl
 
 [#_node_drivers]
 == Node Drivers
+
+[IMPORTANT]
+====
+Starting in Rancher v2.11.0, Ember-based UI plugins for node drivers are deprecated and will be removed in a future release. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see https://extensions.rancher.io/extensions/provisioning/node-driver/overview[Custom Node Drivers UI].
+====
 
 Node drivers are used to provision hosts, which Rancher uses to launch and manage Kubernetes clusters. A node driver is the same as a https://github.com/docker/docs/blob/vnext-engine/machine/drivers/index.md[Docker Machine driver]. The availability of which node driver to display when creating node templates is defined based on the node driver's status. Only `active` node drivers will be displayed as an option for creating node templates. By default, Rancher is packaged with many existing Docker Machine drivers, but you can also create custom node drivers to add to Rancher.
 

--- a/versions/v2.14/modules/en/pages/rancher-admin/global-configuration/provisioning-drivers/provisioning-drivers.adoc
+++ b/versions/v2.14/modules/en/pages/rancher-admin/global-configuration/provisioning-drivers/provisioning-drivers.adoc
@@ -33,7 +33,7 @@ endif::[]
 
 [IMPORTANT]
 ====
-Starting in Rancher v2.11.0, Ember-based UI plugins for cluster and node drivers are deprecated and will be removed in a future release. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see:
+Starting in Rancher v2.11, Ember-based UI plugins for cluster and node drivers are deprecated and will be removed in a future release. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see:
 
 * https://extensions.rancher.io/extensions/provisioning/hosted-provider/overview[Custom Hosted Provider (Cluster Drivers) UI]
 * https://extensions.rancher.io/extensions/provisioning/node-driver/overview[Custom Node Drivers UI]
@@ -56,7 +56,7 @@ There are two types of drivers within Rancher:
 
 [IMPORTANT]
 ====
-Starting in Rancher v2.11.0, Ember-based UI plugins for cluster drivers are deprecated and will be removed in a future release. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see https://extensions.rancher.io/extensions/provisioning/hosted-provider/overview[Custom Hosted Provider (Cluster Drivers) UI].
+Starting in Rancher v2.11, Ember-based UI plugins for cluster drivers are deprecated and will be removed in a future release. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see https://extensions.rancher.io/extensions/provisioning/hosted-provider/overview[Custom Hosted Provider (Cluster Drivers) UI].
 ====
 
 Cluster drivers are used to provision {xref-hosted-k8s-clusters}[hosted Kubernetes clusters], such as GKE, EKS, AKS, etc.. The availability of which cluster driver to display when creating a cluster is defined based on the cluster driver's status. Only `active` cluster drivers will be displayed as an option for creating clusters for hosted Kubernetes clusters. By default, Rancher is packaged with several existing cluster drivers, but you can also create custom cluster drivers to add to Rancher.
@@ -72,7 +72,7 @@ By default, Rancher has activated several hosted Kubernetes cloud providers incl
 
 [IMPORTANT]
 ====
-Starting in Rancher v2.11.0, Ember-based UI plugins for node drivers are deprecated and will be removed in a future release. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see https://extensions.rancher.io/extensions/provisioning/node-driver/overview[Custom Node Drivers UI].
+Starting in Rancher v2.11, Ember-based UI plugins for node drivers are deprecated and will be removed in a future release. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see https://extensions.rancher.io/extensions/provisioning/node-driver/overview[Custom Node Drivers UI].
 ====
 
 Node drivers are used to provision hosts, which Rancher uses to launch and manage Kubernetes clusters. A node driver is the same as a https://github.com/docker/docs/blob/vnext-engine/machine/drivers/index.md[Docker Machine driver]. The availability of which node driver to display when creating node templates is defined based on the node driver's status. Only `active` node drivers will be displayed as an option for creating node templates. By default, Rancher is packaged with many existing Docker Machine drivers, but you can also create custom node drivers to add to Rancher.

--- a/versions/v2.15/modules/en/pages/rancher-admin/global-configuration/provisioning-drivers/provisioning-drivers.adoc
+++ b/versions/v2.15/modules/en/pages/rancher-admin/global-configuration/provisioning-drivers/provisioning-drivers.adoc
@@ -31,6 +31,14 @@ ifeval::["{build-type}" == "community"]
 :xref-infra-vsphere: xref:how-to-guides/new-user-guides/launch-kubernetes-with-rancher/use-new-nodes-in-an-infra-provider/vsphere/index.adoc
 endif::[]
 
+[IMPORTANT]
+====
+Starting in Rancher v2.11.0, Ember-based UI plugins for cluster and node drivers are deprecated and will be removed in a future release. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see:
+
+* https://extensions.rancher.io/extensions/provisioning/hosted-provider/overview[Custom Hosted Provider (Cluster Drivers) UI]
+* https://extensions.rancher.io/extensions/provisioning/node-driver/overview[Custom Node Drivers UI]
+====
+
 Drivers in Rancher allow you to manage which providers can be used to deploy {xref-hosted-k8s-clusters}[hosted Kubernetes clusters] or {xref-infra-providers}[nodes in an infrastructure provider] to allow Rancher to deploy and manage Kubernetes.
 
 [#_rancher_drivers]
@@ -46,6 +54,11 @@ There are two types of drivers within Rancher:
 [#_cluster_drivers]
 == Cluster Drivers
 
+[IMPORTANT]
+====
+Starting in Rancher v2.11.0, Ember-based UI plugins for cluster drivers are deprecated and will be removed in a future release. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see https://extensions.rancher.io/extensions/provisioning/hosted-provider/overview[Custom Hosted Provider (Cluster Drivers) UI].
+====
+
 Cluster drivers are used to provision {xref-hosted-k8s-clusters}[hosted Kubernetes clusters], such as GKE, EKS, AKS, etc.. The availability of which cluster driver to display when creating a cluster is defined based on the cluster driver's status. Only `active` cluster drivers will be displayed as an option for creating clusters for hosted Kubernetes clusters. By default, Rancher is packaged with several existing cluster drivers, but you can also create custom cluster drivers to add to Rancher.
 
 By default, Rancher has activated several hosted Kubernetes cloud providers including:
@@ -56,6 +69,11 @@ By default, Rancher has activated several hosted Kubernetes cloud providers incl
 
 [#_node_drivers]
 == Node Drivers
+
+[IMPORTANT]
+====
+Starting in Rancher v2.11.0, Ember-based UI plugins for node drivers are deprecated and will be removed in a future release. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see https://extensions.rancher.io/extensions/provisioning/node-driver/overview[Custom Node Drivers UI].
+====
 
 Node drivers are used to provision hosts, which Rancher uses to launch and manage Kubernetes clusters. A node driver is the same as a https://github.com/docker/docs/blob/vnext-engine/machine/drivers/index.md[Docker Machine driver]. The availability of which node driver to display when creating node templates is defined based on the node driver's status. Only `active` node drivers will be displayed as an option for creating node templates. By default, Rancher is packaged with many existing Docker Machine drivers, but you can also create custom node drivers to add to Rancher.
 

--- a/versions/v2.15/modules/en/pages/rancher-admin/global-configuration/provisioning-drivers/provisioning-drivers.adoc
+++ b/versions/v2.15/modules/en/pages/rancher-admin/global-configuration/provisioning-drivers/provisioning-drivers.adoc
@@ -1,6 +1,6 @@
 = About Provisioning Drivers
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2025-08-26
+:revdate: 2026-07-28
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/about-provisioning-drivers/index.adoc 
 :product-path: rancher-admin/global-configuration/provisioning-drivers/provisioning-drivers.adoc

--- a/versions/v2.15/modules/en/pages/rancher-admin/global-configuration/provisioning-drivers/provisioning-drivers.adoc
+++ b/versions/v2.15/modules/en/pages/rancher-admin/global-configuration/provisioning-drivers/provisioning-drivers.adoc
@@ -33,7 +33,7 @@ endif::[]
 
 [IMPORTANT]
 ====
-Starting in Rancher v2.11.0, Ember-based UI plugins for cluster and node drivers are deprecated and will be removed in a future release. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see:
+In Rancher v2.11 Ember-based UI plugins for cluster and node drivers were deprecated. They have been removed as of v2.15. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see:
 
 * https://extensions.rancher.io/extensions/provisioning/hosted-provider/overview[Custom Hosted Provider (Cluster Drivers) UI]
 * https://extensions.rancher.io/extensions/provisioning/node-driver/overview[Custom Node Drivers UI]
@@ -56,7 +56,7 @@ There are two types of drivers within Rancher:
 
 [IMPORTANT]
 ====
-Starting in Rancher v2.11.0, Ember-based UI plugins for cluster drivers are deprecated and will be removed in a future release. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see https://extensions.rancher.io/extensions/provisioning/hosted-provider/overview[Custom Hosted Provider (Cluster Drivers) UI].
+In Rancher v2.11 Ember-based UI plugins for cluster and node drivers were deprecated. They have been removed as of v2.15. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see https://extensions.rancher.io/extensions/provisioning/hosted-provider/overview[Custom Hosted Provider (Cluster Drivers) UI].
 ====
 
 Cluster drivers are used to provision {xref-hosted-k8s-clusters}[hosted Kubernetes clusters], such as GKE, EKS, AKS, etc.. The availability of which cluster driver to display when creating a cluster is defined based on the cluster driver's status. Only `active` cluster drivers will be displayed as an option for creating clusters for hosted Kubernetes clusters. By default, Rancher is packaged with several existing cluster drivers, but you can also create custom cluster drivers to add to Rancher.
@@ -72,7 +72,7 @@ By default, Rancher has activated several hosted Kubernetes cloud providers incl
 
 [IMPORTANT]
 ====
-Starting in Rancher v2.11.0, Ember-based UI plugins for node drivers are deprecated and will be removed in a future release. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see https://extensions.rancher.io/extensions/provisioning/node-driver/overview[Custom Node Drivers UI].
+In Rancher v2.11 Ember-based UI plugins for cluster and node drivers were deprecated. They have been removed as of v2.15. Migrate your plugins to the https://extensions.rancher.io/[UI Extensions Framework]. For details, see https://extensions.rancher.io/extensions/provisioning/node-driver/overview[Custom Node Drivers UI].
 ====
 
 Node drivers are used to provision hosts, which Rancher uses to launch and manage Kubernetes clusters. A node driver is the same as a https://github.com/docker/docs/blob/vnext-engine/machine/drivers/index.md[Docker Machine driver]. The availability of which node driver to display when creating node templates is defined based on the node driver's status. Only `active` node drivers will be displayed as an option for creating node templates. By default, Rancher is packaged with many existing Docker Machine drivers, but you can also create custom node drivers to add to Rancher.


### PR DESCRIPTION
- Related to https://github.com/rancher/rancher-product-docs/issues/1232. 
- Add deprecation notice for Ember-based UI plugins for cluster and node drivers / point to [UI Extension docs](https://extensions.rancher.io/extensions/next/home)