### PR TITLE
[2.15.0] Day 2 ops imported RKE2/K3s clusters

### DIFF
--- a/versions/v2.15/modules/en/pages/cluster-deployment/register-existing-clusters.adoc
+++ b/versions/v2.15/modules/en/pages/cluster-deployment/register-existing-clusters.adoc
@@ -1,6 +1,6 @@
 = Registering Existing Clusters
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-07-15
+:revdate: 2026-07-24
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.adoc 
 :product-path: cluster-deployment/register-existing-clusters.adoc
@@ -225,6 +225,112 @@ When you create an EKS cluster in Rancher and then delete it, Rancher destroys t
 endif::[]
 
 See {xref-cluster-deployment}[Cluster Management Capabilities by Cluster Type] for more information about what features are available for managing registered clusters.
+
+== Day 2 Operations for Imported RKE2 and K3s Clusters
+
+Rancher allows you to perform essential Day 2 operations, such as encryption key rotation and etcd snapshot management on imported RKE2 and K3s clusters directly from the Rancher UI or API without re-provisioning the cluster. The functionality is available for imported clusters that have the `imported-day-2-ops` feature flag enabled and is disabled by default.
+
+Imported RKE2 and K3s clusters are initially registered with Rancher Manager for workload monitoring and management. Enabling Day 2 operations extends Rancher's lifecycle control over the underlying infrastructure, allowing administrators to centrally perform critical maintenance such as encryption key rotation and etcd snapshot/restore operations, directly from the UI. This eliminates the need for direct SSH node access, automates multi-node execution to prevent human error, and ensures consistent governance and disaster recovery across all managed clusters.
+
+=== Prerequisites
+
+Before attempting Day 2 operations on an imported RKE2 or K3s cluster, ensure the following requirements are met:
+
+* *Rancher Version:* Rancher v2.15 or later.
+* *Feature Flag:* The `imported-day-2-ops` feature flag must be **enabled**. Configuration can be managed globally once enabled via *Global Settings* > *Settings* and setting `imported-cluster-day2-ops-enabled` to true for all new clusters created or overridden per cluster using the `field.cattle.io/ops-enabled` annotation.
+* *Permissions:* Your user account in Rancher must have *Cluster Owner* or *Manage Clusters* permissions.
+
+=== Enabling the `imported-day-2-ops` Feature Flag
+
+The `imported-day-2-ops` feature flag is **disabled by default**. You can enable it using either the Rancher UI or via Helm values during installation or upgrade.
+
+==== Enabling via the Rancher UI
+
+. Log in to Rancher Manager as an administrator.
+. Navigate to *Global Settings* > *Feature Flags*.
+. Locate *`imported-day-2-ops`* in the list.
+. Click *⋮ > Activate*.
+. Confirm the action when prompted.
+
+==== Enabling via Helm Configuration
+
+If you manage Rancher Manager using Helm, update your `values.yaml` or pass the flag during upgrade:
+
+[source,bash]
+----
+helm upgrade rancher rancher-latest/rancher \
+  --namespace cattle-system \
+  --set extraEnv[0].name=CATTLE_FEATURES \
+  --set extraEnv[0].value="imported-day-2-ops=true"
+----
+
+=== Encryption Key Rotation
+
+For imported RKE2 and K3s clusters with secrets encryption enabled at the distribution level, Rancher provides an automated workflow to rotate the underlying encryption keys across all control plane nodes.
+
+==== Steps to Rotate Encryption Keys
+
+[IMPORTANT]
+====
+An existing etcd backup of the cluster must exist before proceeding.
+====
+
+. In the Rancher UI, navigate to *Cluster Management*.
+. Locate your imported RKE2 or K3s cluster in the list.
+. Click *⋮ > Rotate Encryption Keys* (or open the cluster details page and select *Rotate Encryption Keys* in the top-right action menu).
+. Review the confirmation prompt indicating that an existing etcd backup of the cluster must exist before proceeding.
+. Click *Rotate*.
+
+[WARNING]
+====
+Monitor the cluster status during key rotation. Avoid making simultaneous cluster configuration changes until the cluster state returns to *Active*.
+====
+
+=== Managing etcd Snapshots and Restores
+
+==== Taking an etcd Snapshot
+
+. Go to *Cluster Management* and select your imported cluster.
+. Navigate to the *Snapshots* tab or click *⋮ > Take Snapshot*.
+. (Optional) Provide a descriptive name or tag for the snapshot.
+. Click *Create*.
+. Verify that the snapshot appears in the list view with status as *Successful*, this may take a few moments.
+
+==== Viewing Existing Snapshots
+
+To inspect all available etcd snapshots for an imported cluster:
+
+. Navigate to *Cluster Management*.
+. Click the name of your imported RKE2 or K3s cluster to open its details view.
+. Select the *Snapshots* tab.
+. The table displays all local and target S3/remote snapshots associated with the cluster, including details such as:
+
+* *State:* Displays snapshot creation state.
+* *Name:* The snapshot identifier or filename.
+* *Size:* File size of the snapshot archive.
+* *Age:* Timestamp when the snapshot was generated.
+
+==== Restoring an etcd Snapshot
+
+[IMPORTANT]
+====
+An existing etcd backup of the cluster must exist before proceeding.
+====
+
+. In *Cluster Management*, click on your imported cluster name.
+. Navigate to the *Snapshots* tab.
+. Locate the target snapshot you want to restore and click *⋮ > Restore*.
+. Click *Restore*.
+. Verify successful restoration by monitoring the cluster status.
+
+==== Deleting an etcd Snapshot
+
+Deleting unused or obsolete snapshots helps reclaim storage space on downstream control plane nodes or S3 targets.
+
+. In *Cluster Management*, select your imported cluster name and click the *Snapshots* tab.
+. Locate the snapshot you want to remove.
+. Click *⋮ > Delete*.
+. Confirm the deletion when prompted.
 
 [#_configuring_version_management_for_rke2_and_k3s_clusters]
 == Configuring Version Management for {rke2-product-name} and {k3s-product-name} Clusters

--- a/versions/v2.15/modules/en/pages/cluster-deployment/register-existing-clusters.adoc
+++ b/versions/v2.15/modules/en/pages/cluster-deployment/register-existing-clusters.adoc
@@ -226,12 +226,14 @@ endif::[]
 
 See {xref-cluster-deployment}[Cluster Management Capabilities by Cluster Type] for more information about what features are available for managing registered clusters.
 
+[#_day_2_operations_for_imported_rke2_and_k3s_clusters]
 == Day 2 Operations for Imported RKE2 and K3s Clusters
 
 Rancher allows you to perform essential Day 2 operations, such as encryption key rotation and etcd snapshot management on imported RKE2 and K3s clusters directly from the Rancher UI or API without re-provisioning the cluster. The functionality is available for imported clusters that have the `imported-day-2-ops` feature flag enabled and is disabled by default.
 
 Imported RKE2 and K3s clusters are initially registered with Rancher Manager for workload monitoring and management. Enabling Day 2 operations extends Rancher's lifecycle control over the underlying infrastructure, allowing administrators to centrally perform critical maintenance such as encryption key rotation and etcd snapshot/restore operations, directly from the UI. This eliminates the need for direct SSH node access, automates multi-node execution to prevent human error, and ensures consistent governance and disaster recovery across all managed clusters.
 
+[#_prerequisites_2]
 === Prerequisites
 
 Before attempting Day 2 operations on an imported RKE2 or K3s cluster, ensure the following requirements are met:
@@ -240,10 +242,12 @@ Before attempting Day 2 operations on an imported RKE2 or K3s cluster, ensure th
 * *Feature Flag:* The `imported-day-2-ops` feature flag must be **enabled**. Configuration can be managed globally once enabled via *Global Settings* > *Settings* and setting `imported-cluster-day2-ops-enabled` to true for all new clusters created or overridden per cluster using the `field.cattle.io/ops-enabled` annotation.
 * *Permissions:* Your user account in Rancher must have *Cluster Owner* or *Manage Clusters* permissions.
 
+[#_enabling_the_imported-day-2-ops_feature_flag]
 === Enabling the `imported-day-2-ops` Feature Flag
 
 The `imported-day-2-ops` feature flag is **disabled by default**. You can enable it using either the Rancher UI or via Helm values during installation or upgrade.
 
+[#_enabling_via_the_rancher_ui]
 ==== Enabling via the Rancher UI
 
 . Log in to Rancher Manager as an administrator.
@@ -252,6 +256,7 @@ The `imported-day-2-ops` feature flag is **disabled by default**. You can enable
 . Click *⋮ > Activate*.
 . Confirm the action when prompted.
 
+[#_enabling_via_helm_configuration]
 ==== Enabling via Helm Configuration
 
 If you manage Rancher Manager using Helm, update your `values.yaml` or pass the flag during upgrade:
@@ -264,10 +269,12 @@ helm upgrade rancher rancher-latest/rancher \
   --set extraEnv[0].value="imported-day-2-ops=true"
 ----
 
+[#_encryption_key_rotation]
 === Encryption Key Rotation
 
 For imported RKE2 and K3s clusters with secrets encryption enabled at the distribution level, Rancher provides an automated workflow to rotate the underlying encryption keys across all control plane nodes.
 
+[#_steps_to_rotate_encryption_keys]
 ==== Steps to Rotate Encryption Keys
 
 [IMPORTANT]
@@ -286,8 +293,10 @@ An existing etcd backup of the cluster must exist before proceeding.
 Monitor the cluster status during key rotation. Avoid making simultaneous cluster configuration changes until the cluster state returns to *Active*.
 ====
 
+[#_managing_etcd_snapshots_and_restores]
 === Managing etcd Snapshots and Restores
 
+[#_taking_an_etcd_snapshot]
 ==== Taking an etcd Snapshot
 
 . Go to *Cluster Management* and select your imported cluster.
@@ -296,6 +305,7 @@ Monitor the cluster status during key rotation. Avoid making simultaneous cluste
 . Click *Create*.
 . Verify that the snapshot appears in the list view with status as *Successful*, this may take a few moments.
 
+[#_viewing_existing_snapshots]
 ==== Viewing Existing Snapshots
 
 To inspect all available etcd snapshots for an imported cluster:
@@ -310,6 +320,7 @@ To inspect all available etcd snapshots for an imported cluster:
 * *Size:* File size of the snapshot archive.
 * *Age:* Timestamp when the snapshot was generated.
 
+[#_restoring_an_etcd_snapshot]
 ==== Restoring an etcd Snapshot
 
 [IMPORTANT]
@@ -323,6 +334,7 @@ An existing etcd backup of the cluster must exist before proceeding.
 . Click *Restore*.
 . Verify successful restoration by monitoring the cluster status.
 
+[#_deleting_an_etcd_snapshot]
 ==== Deleting an etcd Snapshot
 
 Deleting unused or obsolete snapshots helps reclaim storage space on downstream control plane nodes or S3 targets.

--- a/versions/v2.15/modules/en/pages/cluster-deployment/register-existing-clusters.adoc
+++ b/versions/v2.15/modules/en/pages/cluster-deployment/register-existing-clusters.adoc
@@ -244,7 +244,7 @@ Before attempting Day 2 operations on an imported RKE2 or K3s cluster, ensure th
 * *Feature Flag:* The `imported-day-2-ops` feature flag must be **enabled**. To apply this setting globally to all new clusters, select *Global Settings > Settings* and set `imported-cluster-day2-ops-enabled` to `true`. You can also override this setting for an individual cluster using the `field.cattle.io/ops-enabled` annotation.
 * *Permissions:* Your Rancher account must have *Cluster Owner* or *Manage Clusters* permissions.
 
-[#_enabling_the_imported-day-2-ops_feature_flag]
+[#_enabling_the_imported_day_2_ops_feature_flag]
 === Enabling the `imported-day-2-ops` Feature Flag
 
 The `imported-day-2-ops` feature flag is **disabled by default**. You can enable it using either the Rancher UI or via Helm values during installation or upgrade.
@@ -265,7 +265,7 @@ If you manage Rancher using Helm, update your `values.yaml` or pass the flag dur
 
 [source,bash]
 ----
-helm upgrade rancher rancher-latest/rancher \
+helm upgrade rancher {rancher-helm-repo}/rancher \
   --namespace cattle-system \
   --set extraEnv[0].name=CATTLE_FEATURES \
   --set extraEnv[0].value="imported-day-2-ops=true"

--- a/versions/v2.15/modules/en/pages/cluster-deployment/register-existing-clusters.adoc
+++ b/versions/v2.15/modules/en/pages/cluster-deployment/register-existing-clusters.adoc
@@ -229,18 +229,20 @@ See {xref-cluster-deployment}[Cluster Management Capabilities by Cluster Type] f
 [#_day_2_operations_for_imported_rke2_and_k3s_clusters]
 == Day 2 Operations for Imported RKE2 and K3s Clusters
 
-Rancher allows you to perform essential Day 2 operations, such as encryption key rotation and etcd snapshot management on imported RKE2 and K3s clusters directly from the Rancher UI or API without re-provisioning the cluster. The functionality is available for imported clusters that have the `imported-day-2-ops` feature flag enabled and is disabled by default.
+You can perform Day 2 operations on imported RKE2 and K3s clusters directly from the Rancher UI or API without re-provisioning the cluster. Key operations include encryption key rotation and `etcd` snapshot management.
+	
+This feature is disabled by default and requires enabling the `imported-day-2-ops` feature flag.
 
-Imported RKE2 and K3s clusters are initially registered with Rancher Manager for workload monitoring and management. Enabling Day 2 operations extends Rancher's lifecycle control over the underlying infrastructure, allowing administrators to centrally perform critical maintenance such as encryption key rotation and etcd snapshot/restore operations, directly from the UI. This eliminates the need for direct SSH node access, automates multi-node execution to prevent human error, and ensures consistent governance and disaster recovery across all managed clusters.
+Imported RKE2 and K3s clusters are initially registered with Rancher for workload monitoring and management. Enabling Day 2 operations extends Rancher lifecycle control over the underlying infrastructure. Administrators can centrally perform maintenance tasks, such as encryption key rotation and `etcd` snapshot and restore operations, from the Rancher UI. This capability eliminates direct SSH node access, automates multi-node execution, and ensures consistent disaster recovery across managed clusters.
 
 [#_prerequisites_2]
 === Prerequisites
 
 Before attempting Day 2 operations on an imported RKE2 or K3s cluster, ensure the following requirements are met:
-
+	
 * *Rancher Version:* Rancher v2.15 or later.
-* *Feature Flag:* The `imported-day-2-ops` feature flag must be **enabled**. Configuration can be managed globally once enabled via *Global Settings* > *Settings* and setting `imported-cluster-day2-ops-enabled` to true for all new clusters created or overridden per cluster using the `field.cattle.io/ops-enabled` annotation.
-* *Permissions:* Your user account in Rancher must have *Cluster Owner* or *Manage Clusters* permissions.
+* *Feature Flag:* The `imported-day-2-ops` feature flag must be **enabled**. To apply this setting globally to all new clusters, select *Global Settings > Settings* and set `imported-cluster-day2-ops-enabled` to `true`. You can also override this setting for an individual cluster using the `field.cattle.io/ops-enabled` annotation.
+* *Permissions:* Your Rancher account must have *Cluster Owner* or *Manage Clusters* permissions.
 
 [#_enabling_the_imported-day-2-ops_feature_flag]
 === Enabling the `imported-day-2-ops` Feature Flag
@@ -250,7 +252,7 @@ The `imported-day-2-ops` feature flag is **disabled by default**. You can enable
 [#_enabling_via_the_rancher_ui]
 ==== Enabling via the Rancher UI
 
-. Log in to Rancher Manager as an administrator.
+. Log in to Rancher as an administrator.
 . Navigate to *Global Settings* > *Feature Flags*.
 . Locate *`imported-day-2-ops`* in the list.
 . Click *⋮ > Activate*.
@@ -259,7 +261,7 @@ The `imported-day-2-ops` feature flag is **disabled by default**. You can enable
 [#_enabling_via_helm_configuration]
 ==== Enabling via Helm Configuration
 
-If you manage Rancher Manager using Helm, update your `values.yaml` or pass the flag during upgrade:
+If you manage Rancher using Helm, update your `values.yaml` or pass the flag during upgrade:
 
 [source,bash]
 ----
@@ -279,13 +281,13 @@ For imported RKE2 and K3s clusters with secrets encryption enabled at the distri
 
 [IMPORTANT]
 ====
-An existing etcd backup of the cluster must exist before proceeding.
+An existing `etcd` backup of the cluster must exist before proceeding.
 ====
 
-. In the Rancher UI, navigate to *Cluster Management*.
+. Navigate to *Cluster Management*.
 . Locate your imported RKE2 or K3s cluster in the list.
 . Click *⋮ > Rotate Encryption Keys* (or open the cluster details page and select *Rotate Encryption Keys* in the top-right action menu).
-. Review the confirmation prompt indicating that an existing etcd backup of the cluster must exist before proceeding.
+. Review the confirmation prompt indicating that an existing `etcd` backup of the cluster must exist before proceeding.
 . Click *Rotate*.
 
 [WARNING]
@@ -294,10 +296,10 @@ Monitor the cluster status during key rotation. Avoid making simultaneous cluste
 ====
 
 [#_managing_etcd_snapshots_and_restores]
-=== Managing etcd Snapshots and Restores
+=== Managing `etcd` Snapshots and Restores
 
 [#_taking_an_etcd_snapshot]
-==== Taking an etcd Snapshot
+==== Taking an `etcd` Snapshot
 
 . Go to *Cluster Management* and select your imported cluster.
 . Navigate to the *Snapshots* tab or click *⋮ > Take Snapshot*.
@@ -306,9 +308,9 @@ Monitor the cluster status during key rotation. Avoid making simultaneous cluste
 . Verify that the snapshot appears in the list view with status as *Successful*, this may take a few moments.
 
 [#_viewing_existing_snapshots]
-==== Viewing Existing Snapshots
+==== Viewing Existing `etcd` Snapshots
 
-To inspect all available etcd snapshots for an imported cluster:
+To inspect all available `etcd` snapshots for an imported cluster:
 
 . Navigate to *Cluster Management*.
 . Click the name of your imported RKE2 or K3s cluster to open its details view.
@@ -321,11 +323,11 @@ To inspect all available etcd snapshots for an imported cluster:
 * *Age:* Timestamp when the snapshot was generated.
 
 [#_restoring_an_etcd_snapshot]
-==== Restoring an etcd Snapshot
+==== Restoring an `etcd` Snapshot
 
 [IMPORTANT]
 ====
-An existing etcd backup of the cluster must exist before proceeding.
+An existing `etcd` backup of the cluster must exist before proceeding.
 ====
 
 . In *Cluster Management*, click on your imported cluster name.
@@ -335,11 +337,12 @@ An existing etcd backup of the cluster must exist before proceeding.
 . Verify successful restoration by monitoring the cluster status.
 
 [#_deleting_an_etcd_snapshot]
-==== Deleting an etcd Snapshot
+==== Deleting an `etcd` Snapshot
 
 Deleting unused or obsolete snapshots helps reclaim storage space on downstream control plane nodes or S3 targets.
 
-. In *Cluster Management*, select your imported cluster name and click the *Snapshots* tab.
+. In *Cluster Management*, select your imported cluster name.
+. Navigate to the *Snapshots* tab.
 . Locate the snapshot you want to remove.
 . Click *⋮ > Delete*.
 . Confirm the deletion when prompted.

--- a/versions/v2.15/modules/en/pages/installation-and-upgrade/references/feature-flags.adoc
+++ b/versions/v2.15/modules/en/pages/installation-and-upgrade/references/feature-flags.adoc
@@ -1,10 +1,11 @@
 = Feature Flags
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-07-13
+:revdate: 2026-07-24
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/installation-references/feature-flags.adoc 
 :product-path: installation-and-upgrade/references/feature-flags.adoc
 ifeval::["{build-type}" != "community"]
+:xref-cluster-deployment-register-existing-clusters: xref:cluster-deployment/register-existing-clusters.adoc
 :xref-experimental-features: xref:rancher-admin/experimental-features/experimental-features.adoc
 :xref-cluster-project-roles: xref:rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/cluster-and-project-roles.adoc
 :xref-harvester-overview: xref:integrations/harvester/overview.adoc
@@ -17,6 +18,7 @@ ifeval::["{build-type}" != "community"]
 :xref-continuous-delivery: xref:rancher-admin/experimental-features/continuous-delivery.adoc
 endif::[]
 ifeval::["{build-type}" == "community"]
+:xref-cluster-deployment-register-existing-clusters: xref:how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/register-existing-clusters.adoc
 :xref-experimental-features: xref:how-to-guides/advanced-user-guides/enable-experimental-features/index.adoc
 :xref-cluster-project-roles: xref:how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/manage-role-based-access-control-rbac/cluster-and-project-roles.adoc
 :xref-harvester-overview: xref:integrations-in-rancher/harvester/overview.adoc
@@ -138,6 +140,12 @@ The following table shows the availability and default values for some feature f
 | GA
 | v2.11.0
 |
+
+| `imported-day-2-ops`
+| `Disabled`
+| GA
+| v2.15.0
+| Enable day 2 ops for imported clusters. Refer to the {xref-cluster-deployment-register-existing-clusters}#_day_2_operations_for_imported_rke2_and_k3s_clusters[Day 2 Operations for Imported RKE2 and K3s Clusters] section for more information.
 
 | `legacy`
 | `Disabled` for new installs, `Active` for upgrades


### PR DESCRIPTION
Fixes https://github.com/rancher/rancher-product-docs/issues/1225

Adding information for Day 2 operations for imported RKE2 and K3s clusters including etcd snapshot/restore and encryption key rotation, general information and prerequisites. Added new feature flag to ff page and pointed to added content. - https://github.com/rancher/rancher-product-docs/pull/1288/commits/83aa1adffc26ae681364a12c95cc7c162dddd21e