### PR TITLE
fix(docs): convert HTML lists to AsciiDoc in tables (#1242)

### DIFF
--- a/versions/v2.10/modules/en/pages/installation-and-upgrade/requirements/port-requirements.adoc
+++ b/versions/v2.10/modules/en/pages/installation-and-upgrade/requirements/port-requirements.adoc
@@ -75,7 +75,9 @@ The following tables break down the port requirements for inbound and outbound t
 
 | TCP
 | 443
-| <ul><li>server nodes</li><li>agent nodes</li><li>hosted/registered Kubernetes</li><li>any source that needs to be able to use the Rancher UI or API</li></ul>
+a| * K3s server and agent nodes
+* Hosted/Registered Kubernetes
+* Any source that needs to be able to use the Rancher UI or API
 | Rancher agent, Rancher UI/API, kubectl
 
 | TCP
@@ -296,7 +298,8 @@ The VXLAN port on nodes should not be exposed to the world as it opens up your c
 
 | HTTPS
 | 443
-| <ul><li>hosted/registered Kubernetes</li><li>any source that needs to be able to use the Rancher UI or API</li></ul>
+a| * Hosted/Registered Kubernetes
+* Any source that needs to be able to use the Rancher UI or API
 | Rancher agent, Rancher UI/API, kubectl. Not needed if you have a load balancer doing TLS termination.
 |===
 
@@ -321,7 +324,8 @@ The following tables break down the port requirements for Rancher nodes, for inb
 
 | TCP
 | 443
-| <ul><li>hosted/registered Kubernetes</li><li>any source that needs to be able to use the Rancher UI or API</li></ul>
+a| * Hosted/Registered Kubernetes
+* Any source that needs to be able to use the Rancher UI or API
 | Rancher agent, Rancher UI/API, kubectl
 |===
 

--- a/versions/v2.10/modules/en/pages/observability/istio/rbac.adoc
+++ b/versions/v2.10/modules/en/pages/observability/istio/rbac.adoc
@@ -48,20 +48,41 @@ Istio creates three `ClusterRoles` and adds Istio CRD access to the following de
 
 Rancher will continue to use cluster-owner, cluster-member, project-owner, project-member, etc as role names, but will utilize default roles to determine access. For each default K8s `ClusterRole` there are different Istio CRD permissions and K8s actions (Create ( C ), Get ( G ), List ( L ), Watch ( W ), Update ( U ), Patch ( P ), Delete( D ), All ( * )) that can be performed.
 
+[cols="2,1,1,1"]
 |===
 | CRDs | Admin | Edit | View
 
-| <ul><li>``config.istio.io``</li><ul><li>``adapters``</li><li>``attributemanifests``</li><li>``handlers``</li><li>``httpapispecbindings``</li><li>``httpapispecs``</li><li>``instances``</li><li>``quotaspecbindings``</li><li>``quotaspecs``</li><li>``rules``</li><li>``templates``</li></ul></ul>
+a| * ``config.istio.io``
+** ``adapters``
+** ``attributemanifests``
+** ``handlers``
+** ``httpapispecbindings``
+** ``httpapispecs``
+** ``instances``
+** ``quotaspecbindings``
+** ``quotaspecs``
+** ``rules``
+** ``templates``
 | GLW
 | GLW
 | GLW
 
-| <ul><li>``networking.istio.io``</li><ul><li>``destinationrules``</li><li>``envoyfilters``</li><li>``gateways``</li><li>``serviceentries``</li><li>``sidecars``</li><li>``virtualservices``</li><li>``workloadentries``</li></ul></ul>
+a| * ``networking.istio.io``
+** ``destinationrules``
+** ``envoyfilters``
+** ``gateways``
+** ``serviceentries``
+** ``sidecars``
+** ``virtualservices``
+** ``workloadentries``
 | *
 | *
 | GLW
 
-| <ul><li>``security.istio.io``</li><ul><li>``authorizationpolicies``</li><li>``peerauthentications``</li><li>``requestauthentications``</li></ul></ul>
+a| * ``security.istio.io``
+** ``authorizationpolicies``
+** ``peerauthentications``
+** ``requestauthentications``
 | *
 | *
 | GLW

--- a/versions/v2.10/modules/en/pages/observability/monitoring-and-dashboards/rbac-for-monitoring.adoc
+++ b/versions/v2.10/modules/en/pages/observability/monitoring-and-dashboards/rbac-for-monitoring.adoc
@@ -32,7 +32,7 @@ The `rancher-monitoring` chart installs the following three `ClusterRoles`. By d
 | `edit`
 
 | `monitoring-view`
-| `view `
+| `view`
 |===
 
 These `ClusterRoles` provide different levels of access to the Monitoring CRDs based on the actions that can be performed:
@@ -40,12 +40,15 @@ These `ClusterRoles` provide different levels of access to the Monitoring CRDs b
 |===
 | CRDs (monitoring.coreos.com) | Admin | Edit | View
 
-| <ul><li>``prometheuses``</li><li>``alertmanagers``</li></ul>
+a| * ``prometheuses``
+* ``alertmanagers``
 | Get, List, Watch
 | Get, List, Watch
 | Get, List, Watch
 
-| <ul><li>``servicemonitors``</li><li>``podmonitors``</li><li>``prometheusrules``</li></ul>
+a| * ``servicemonitors``
+* ``podmonitors``
+* ``prometheusrules``
 | *
 | *
 | Get, List, Watch
@@ -315,7 +318,8 @@ If cluster-admins would like to provide additional admin/edit access to users ou
 | No
 | User will be able to define the configuration of new cluster-level Alertmanager deployments that should be created in the cluster. Note: if you just want to allow users to configure settings like Routes and Receivers, you should just provide access to the Alertmanager Config Secret instead.
 
-| <ul><li>``servicemonitors``</li><li>``podmonitors``</li></ul>
+a| * ``servicemonitors``
+* ``podmonitors``
 | No, not by default; this is configurable via `ignoreNamespaceSelectors` on the Prometheus CR.
 | User will be able to set up scrapes by Prometheus on endpoints exposed by Services / Pods within the namespace they are given this permission in.
 
@@ -327,12 +331,14 @@ If cluster-admins would like to provide additional admin/edit access to users ou
 |===
 | k8s Resources | Namespace | Can it cause impact outside of a namespace / project? | Impact
 
-| <ul><li>``secrets``</li><li>``configmaps``</li></ul>
+a| * ``secrets``
+* ``configmaps``
 | `cattle-monitoring-system`
 | Yes, Configs and Secrets in this namespace can impact the entire monitoring / alerting pipeline.
 | User will be able to create or edit Secrets / ConfigMaps such as the Alertmanager Config, Prometheus Adapter Config, TLS secrets, additional Grafana datasources, etc. This can have broad impact on all cluster monitoring / alerting.
 
-| <ul><li>``secrets``</li><li>``configmaps``</li></ul>
+a| * ``secrets``
+* ``configmaps``
 | `cattle-dashboards`
 | Yes, Configs and Secrets in this namespace can create dashboards that make queries on all metrics collected at a cluster-level.
 | User will be able to create Secrets / ConfigMaps that persist new Grafana Dashboards only.

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/requirements/port-requirements.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/requirements/port-requirements.adoc
@@ -75,7 +75,9 @@ The following tables break down the port requirements for inbound and outbound t
 
 | TCP
 | 443
-| <ul><li>server nodes</li><li>agent nodes</li><li>hosted/registered Kubernetes</li><li>any source that needs to be able to use the Rancher UI or API</li></ul>
+a| * K3s server and agent nodes
+* Hosted/Registered Kubernetes
+* Any source that needs to be able to use the Rancher UI or API
 | Rancher agent, Rancher UI/API, kubectl
 
 | TCP
@@ -296,7 +298,8 @@ The VXLAN port on nodes should not be exposed to the world as it opens up your c
 
 | HTTPS
 | 443
-| <ul><li>hosted/registered Kubernetes</li><li>any source that needs to be able to use the Rancher UI or API</li></ul>
+a| * Hosted/Registered Kubernetes
+* Any source that needs to be able to use the Rancher UI or API
 | Rancher agent, Rancher UI/API, kubectl. Not needed if you have a load balancer doing TLS termination.
 |===
 
@@ -321,7 +324,8 @@ The following tables break down the port requirements for Rancher nodes, for inb
 
 | TCP
 | 443
-| <ul><li>hosted/registered Kubernetes</li><li>any source that needs to be able to use the Rancher UI or API</li></ul>
+a| * Hosted/Registered Kubernetes
+* Any source that needs to be able to use the Rancher UI or API
 | Rancher agent, Rancher UI/API, kubectl
 |===
 

--- a/versions/v2.11/modules/en/pages/observability/istio/rbac.adoc
+++ b/versions/v2.11/modules/en/pages/observability/istio/rbac.adoc
@@ -54,20 +54,41 @@ Istio creates three `ClusterRoles` and adds Istio CRD access to the following de
 
 Rancher will continue to use cluster-owner, cluster-member, project-owner, project-member, etc as role names, but will utilize default roles to determine access. For each default K8s `ClusterRole` there are different Istio CRD permissions and K8s actions (Create ( C ), Get ( G ), List ( L ), Watch ( W ), Update ( U ), Patch ( P ), Delete( D ), All ( * )) that can be performed.
 
+[cols="2,1,1,1"]
 |===
 | CRDs | Admin | Edit | View
 
-| <ul><li>``config.istio.io``</li><ul><li>``adapters``</li><li>``attributemanifests``</li><li>``handlers``</li><li>``httpapispecbindings``</li><li>``httpapispecs``</li><li>``instances``</li><li>``quotaspecbindings``</li><li>``quotaspecs``</li><li>``rules``</li><li>``templates``</li></ul></ul>
+a| * ``config.istio.io``
+** ``adapters``
+** ``attributemanifests``
+** ``handlers``
+** ``httpapispecbindings``
+** ``httpapispecs``
+** ``instances``
+** ``quotaspecbindings``
+** ``quotaspecs``
+** ``rules``
+** ``templates``
 | GLW
 | GLW
 | GLW
 
-| <ul><li>``networking.istio.io``</li><ul><li>``destinationrules``</li><li>``envoyfilters``</li><li>``gateways``</li><li>``serviceentries``</li><li>``sidecars``</li><li>``virtualservices``</li><li>``workloadentries``</li></ul></ul>
+a| * ``networking.istio.io``
+** ``destinationrules``
+** ``envoyfilters``
+** ``gateways``
+** ``serviceentries``
+** ``sidecars``
+** ``virtualservices``
+** ``workloadentries``
 | *
 | *
 | GLW
 
-| <ul><li>``security.istio.io``</li><ul><li>``authorizationpolicies``</li><li>``peerauthentications``</li><li>``requestauthentications``</li></ul></ul>
+a| * ``security.istio.io``
+** ``authorizationpolicies``
+** ``peerauthentications``
+** ``requestauthentications``
 | *
 | *
 | GLW

--- a/versions/v2.11/modules/en/pages/observability/monitoring-and-dashboards/rbac-for-monitoring.adoc
+++ b/versions/v2.11/modules/en/pages/observability/monitoring-and-dashboards/rbac-for-monitoring.adoc
@@ -32,7 +32,7 @@ The `rancher-monitoring` chart installs the following three `ClusterRoles`. By d
 | `edit`
 
 | `monitoring-view`
-| `view `
+| `view`
 |===
 
 These `ClusterRoles` provide different levels of access to the Monitoring CRDs based on the actions that can be performed:
@@ -40,12 +40,15 @@ These `ClusterRoles` provide different levels of access to the Monitoring CRDs b
 |===
 | CRDs (monitoring.coreos.com) | Admin | Edit | View
 
-| <ul><li>``prometheuses``</li><li>``alertmanagers``</li></ul>
+a| * ``prometheuses``
+* ``alertmanagers``
 | Get, List, Watch
 | Get, List, Watch
 | Get, List, Watch
 
-| <ul><li>``servicemonitors``</li><li>``podmonitors``</li><li>``prometheusrules``</li></ul>
+a| * ``servicemonitors``
+* ``podmonitors``
+* ``prometheusrules``
 | *
 | *
 | Get, List, Watch
@@ -315,7 +318,8 @@ If cluster-admins would like to provide additional admin/edit access to users ou
 | No
 | User will be able to define the configuration of new cluster-level Alertmanager deployments that should be created in the cluster. Note: if you just want to allow users to configure settings like Routes and Receivers, you should just provide access to the Alertmanager Config Secret instead.
 
-| <ul><li>``servicemonitors``</li><li>``podmonitors``</li></ul>
+a| * ``servicemonitors``
+* ``podmonitors``
 | No, not by default; this is configurable via `ignoreNamespaceSelectors` on the Prometheus CR.
 | User will be able to set up scrapes by Prometheus on endpoints exposed by Services / Pods within the namespace they are given this permission in.
 
@@ -327,12 +331,14 @@ If cluster-admins would like to provide additional admin/edit access to users ou
 |===
 | k8s Resources | Namespace | Can it cause impact outside of a namespace / project? | Impact
 
-| <ul><li>``secrets``</li><li>``configmaps``</li></ul>
+a| * ``secrets``
+* ``configmaps``
 | `cattle-monitoring-system`
 | Yes, Configs and Secrets in this namespace can impact the entire monitoring / alerting pipeline.
 | User will be able to create or edit Secrets / ConfigMaps such as the Alertmanager Config, Prometheus Adapter Config, TLS secrets, additional Grafana datasources, etc. This can have broad impact on all cluster monitoring / alerting.
 
-| <ul><li>``secrets``</li><li>``configmaps``</li></ul>
+a| * ``secrets``
+* ``configmaps``
 | `cattle-dashboards`
 | Yes, Configs and Secrets in this namespace can create dashboards that make queries on all metrics collected at a cluster-level.
 | User will be able to create Secrets / ConfigMaps that persist new Grafana Dashboards only.

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/requirements/port-requirements.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/requirements/port-requirements.adoc
@@ -77,7 +77,9 @@ The following tables break down the port requirements for inbound and outbound t
 
 | TCP
 | 443
-| <ul><li>server nodes</li><li>agent nodes</li><li>hosted/registered Kubernetes</li><li>any source that needs to be able to use the Rancher UI or API</li></ul>
+a| * K3s server and agent nodes
+* Hosted/Registered Kubernetes
+* Any source that needs to be able to use the Rancher UI or API
 | Rancher agent, Rancher UI/API, kubectl
 
 | TCP
@@ -190,7 +192,8 @@ The VXLAN port on nodes should not be exposed to the world as it opens up your c
 
 | HTTPS
 | 443
-| <ul><li>hosted/registered Kubernetes</li><li>any source that needs to be able to use the Rancher UI or API</li></ul>
+a| * Hosted/Registered Kubernetes
+* Any source that needs to be able to use the Rancher UI or API
 | Rancher agent, Rancher UI/API, kubectl. Not needed if you have a load balancer doing TLS termination.
 |===
 
@@ -215,7 +218,8 @@ The following tables break down the port requirements for Rancher nodes, for inb
 
 | TCP
 | 443
-| <ul><li>hosted/registered Kubernetes</li><li>any source that needs to be able to use the Rancher UI or API</li></ul>
+a| * Hosted/Registered Kubernetes
+* Any source that needs to be able to use the Rancher UI or API
 | Rancher agent, Rancher UI/API, kubectl
 |===
 

--- a/versions/v2.12/modules/en/pages/observability/istio/rbac.adoc
+++ b/versions/v2.12/modules/en/pages/observability/istio/rbac.adoc
@@ -56,20 +56,41 @@ Istio creates three `ClusterRoles` and adds Istio CRD access to the following de
 
 Rancher will continue to use cluster-owner, cluster-member, project-owner, project-member, etc as role names, but will utilize default roles to determine access. For each default K8s `ClusterRole` there are different Istio CRD permissions and K8s actions (Create ( C ), Get ( G ), List ( L ), Watch ( W ), Update ( U ), Patch ( P ), Delete( D ), All ( * )) that can be performed.
 
+[cols="2,1,1,1"]
 |===
 | CRDs | Admin | Edit | View
 
-| <ul><li>``config.istio.io``</li><ul><li>``adapters``</li><li>``attributemanifests``</li><li>``handlers``</li><li>``httpapispecbindings``</li><li>``httpapispecs``</li><li>``instances``</li><li>``quotaspecbindings``</li><li>``quotaspecs``</li><li>``rules``</li><li>``templates``</li></ul></ul>
+a| * ``config.istio.io``
+** ``adapters``
+** ``attributemanifests``
+** ``handlers``
+** ``httpapispecbindings``
+** ``httpapispecs``
+** ``instances``
+** ``quotaspecbindings``
+** ``quotaspecs``
+** ``rules``
+** ``templates``
 | GLW
 | GLW
 | GLW
 
-| <ul><li>``networking.istio.io``</li><ul><li>``destinationrules``</li><li>``envoyfilters``</li><li>``gateways``</li><li>``serviceentries``</li><li>``sidecars``</li><li>``virtualservices``</li><li>``workloadentries``</li></ul></ul>
+a| * ``networking.istio.io``
+** ``destinationrules``
+** ``envoyfilters``
+** ``gateways``
+** ``serviceentries``
+** ``sidecars``
+** ``virtualservices``
+** ``workloadentries``
 | *
 | *
 | GLW
 
-| <ul><li>``security.istio.io``</li><ul><li>``authorizationpolicies``</li><li>``peerauthentications``</li><li>``requestauthentications``</li></ul></ul>
+a| * ``security.istio.io``
+** ``authorizationpolicies``
+** ``peerauthentications``
+** ``requestauthentications``
 | *
 | *
 | GLW

--- a/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/rbac-for-monitoring.adoc
+++ b/versions/v2.12/modules/en/pages/observability/monitoring-and-dashboards/rbac-for-monitoring.adoc
@@ -34,7 +34,7 @@ The `rancher-monitoring` chart installs the following three `ClusterRoles`. By d
 | `edit`
 
 | `monitoring-view`
-| `view `
+| `view`
 |===
 
 These `ClusterRoles` provide different levels of access to the Monitoring CRDs based on the actions that can be performed:
@@ -42,12 +42,15 @@ These `ClusterRoles` provide different levels of access to the Monitoring CRDs b
 |===
 | CRDs (monitoring.coreos.com) | Admin | Edit | View
 
-| <ul><li>``prometheuses``</li><li>``alertmanagers``</li></ul>
+a| * ``prometheuses``
+* ``alertmanagers``
 | Get, List, Watch
 | Get, List, Watch
 | Get, List, Watch
 
-| <ul><li>``servicemonitors``</li><li>``podmonitors``</li><li>``prometheusrules``</li></ul>
+a| * ``servicemonitors``
+* ``podmonitors``
+* ``prometheusrules``
 | *
 | *
 | Get, List, Watch
@@ -317,7 +320,8 @@ If cluster-admins would like to provide additional admin/edit access to users ou
 | No
 | User will be able to define the configuration of new cluster-level Alertmanager deployments that should be created in the cluster. Note: if you just want to allow users to configure settings like Routes and Receivers, you should just provide access to the Alertmanager Config Secret instead.
 
-| <ul><li>``servicemonitors``</li><li>``podmonitors``</li></ul>
+a| * ``servicemonitors``
+* ``podmonitors``
 | No, not by default; this is configurable via `ignoreNamespaceSelectors` on the Prometheus CR.
 | User will be able to set up scrapes by Prometheus on endpoints exposed by Services / Pods within the namespace they are given this permission in.
 
@@ -329,12 +333,14 @@ If cluster-admins would like to provide additional admin/edit access to users ou
 |===
 | k8s Resources | Namespace | Can it cause impact outside of a namespace / project? | Impact
 
-| <ul><li>``secrets``</li><li>``configmaps``</li></ul>
+a| * ``secrets``
+* ``configmaps``
 | `cattle-monitoring-system`
 | Yes, Configs and Secrets in this namespace can impact the entire monitoring / alerting pipeline.
 | User will be able to create or edit Secrets / ConfigMaps such as the Alertmanager Config, Prometheus Adapter Config, TLS secrets, additional Grafana datasources, etc. This can have broad impact on all cluster monitoring / alerting.
 
-| <ul><li>``secrets``</li><li>``configmaps``</li></ul>
+a| * ``secrets``
+* ``configmaps``
 | `cattle-dashboards`
 | Yes, Configs and Secrets in this namespace can create dashboards that make queries on all metrics collected at a cluster-level.
 | User will be able to create Secrets / ConfigMaps that persist new Grafana Dashboards only.

--- a/versions/v2.12/modules/en/pages/security/compliance-scans/rbac-for-compliance-scans.adoc
+++ b/versions/v2.12/modules/en/pages/security/compliance-scans/rbac-for-compliance-scans.adoc
@@ -42,7 +42,7 @@ The rancher-compliance creates three `ClusterRoles` and adds the Compliance Benc
 | Ability to CRUD clusterscanbenchmarks, clusterscanprofiles, clusterscans, clusterscanreports CR
 
 | `compliance-view`
-| `view `
+| `view`
 | Ability to List(R) clusterscanbenchmarks, clusterscanprofiles, clusterscans, clusterscanreports CR
 |===
 

--- a/versions/v2.13/modules/en/pages/installation-and-upgrade/requirements/port-requirements.adoc
+++ b/versions/v2.13/modules/en/pages/installation-and-upgrade/requirements/port-requirements.adoc
@@ -77,7 +77,9 @@ The following tables break down the port requirements for inbound and outbound t
 
 | TCP
 | 443
-| <ul><li>server nodes</li><li>agent nodes</li><li>hosted/registered Kubernetes</li><li>any source that needs to be able to use the Rancher UI or API</li></ul>
+a| * K3s server and agent nodes
+* Hosted/Registered Kubernetes
+* Any source that needs to be able to use the Rancher UI or API
 | Rancher agent, Rancher UI/API, kubectl
 
 | TCP
@@ -190,7 +192,8 @@ The VXLAN port on nodes should not be exposed to the world as it opens up your c
 
 | HTTPS
 | 443
-| <ul><li>hosted/registered Kubernetes</li><li>any source that needs to be able to use the Rancher UI or API</li></ul>
+a| * Hosted/Registered Kubernetes
+* Any source that needs to be able to use the Rancher UI or API
 | Rancher agent, Rancher UI/API, kubectl. Not needed if you have a load balancer doing TLS termination.
 |===
 
@@ -215,7 +218,8 @@ The following tables break down the port requirements for Rancher nodes, for inb
 
 | TCP
 | 443
-| <ul><li>hosted/registered Kubernetes</li><li>any source that needs to be able to use the Rancher UI or API</li></ul>
+a| * Hosted/Registered Kubernetes
+* Any source that needs to be able to use the Rancher UI or API
 | Rancher agent, Rancher UI/API, kubectl
 |===
 

--- a/versions/v2.13/modules/en/pages/observability/istio/rbac.adoc
+++ b/versions/v2.13/modules/en/pages/observability/istio/rbac.adoc
@@ -56,20 +56,41 @@ Istio creates three `ClusterRoles` and adds Istio CRD access to the following de
 
 Rancher will continue to use cluster-owner, cluster-member, project-owner, project-member, etc as role names, but will utilize default roles to determine access. For each default K8s `ClusterRole` there are different Istio CRD permissions and K8s actions (Create ( C ), Get ( G ), List ( L ), Watch ( W ), Update ( U ), Patch ( P ), Delete( D ), All ( * )) that can be performed.
 
+[cols="2,1,1,1"]
 |===
 | CRDs | Admin | Edit | View
 
-| <ul><li>``config.istio.io``</li><ul><li>``adapters``</li><li>``attributemanifests``</li><li>``handlers``</li><li>``httpapispecbindings``</li><li>``httpapispecs``</li><li>``instances``</li><li>``quotaspecbindings``</li><li>``quotaspecs``</li><li>``rules``</li><li>``templates``</li></ul></ul>
+a| * ``config.istio.io``
+** ``adapters``
+** ``attributemanifests``
+** ``handlers``
+** ``httpapispecbindings``
+** ``httpapispecs``
+** ``instances``
+** ``quotaspecbindings``
+** ``quotaspecs``
+** ``rules``
+** ``templates``
 | GLW
 | GLW
 | GLW
 
-| <ul><li>``networking.istio.io``</li><ul><li>``destinationrules``</li><li>``envoyfilters``</li><li>``gateways``</li><li>``serviceentries``</li><li>``sidecars``</li><li>``virtualservices``</li><li>``workloadentries``</li></ul></ul>
+a| * ``networking.istio.io``
+** ``destinationrules``
+** ``envoyfilters``
+** ``gateways``
+** ``serviceentries``
+** ``sidecars``
+** ``virtualservices``
+** ``workloadentries``
 | *
 | *
 | GLW
 
-| <ul><li>``security.istio.io``</li><ul><li>``authorizationpolicies``</li><li>``peerauthentications``</li><li>``requestauthentications``</li></ul></ul>
+a| * ``security.istio.io``
+** ``authorizationpolicies``
+** ``peerauthentications``
+** ``requestauthentications``
 | *
 | *
 | GLW

--- a/versions/v2.13/modules/en/pages/observability/monitoring-and-dashboards/rbac-for-monitoring.adoc
+++ b/versions/v2.13/modules/en/pages/observability/monitoring-and-dashboards/rbac-for-monitoring.adoc
@@ -34,7 +34,7 @@ The `rancher-monitoring` chart installs the following three `ClusterRoles`. By d
 | `edit`
 
 | `monitoring-view`
-| `view `
+| `view`
 |===
 
 These `ClusterRoles` provide different levels of access to the Monitoring CRDs based on the actions that can be performed:
@@ -42,12 +42,15 @@ These `ClusterRoles` provide different levels of access to the Monitoring CRDs b
 |===
 | CRDs (monitoring.coreos.com) | Admin | Edit | View
 
-| <ul><li>``prometheuses``</li><li>``alertmanagers``</li></ul>
+a| * ``prometheuses``
+* ``alertmanagers``
 | Get, List, Watch
 | Get, List, Watch
 | Get, List, Watch
 
-| <ul><li>``servicemonitors``</li><li>``podmonitors``</li><li>``prometheusrules``</li></ul>
+a| * ``servicemonitors``
+* ``podmonitors``
+* ``prometheusrules``
 | *
 | *
 | Get, List, Watch
@@ -317,7 +320,8 @@ If cluster-admins would like to provide additional admin/edit access to users ou
 | No
 | User will be able to define the configuration of new cluster-level Alertmanager deployments that should be created in the cluster. Note: if you just want to allow users to configure settings like Routes and Receivers, you should just provide access to the Alertmanager Config Secret instead.
 
-| <ul><li>``servicemonitors``</li><li>``podmonitors``</li></ul>
+a| * ``servicemonitors``
+* ``podmonitors``
 | No, not by default; this is configurable via `ignoreNamespaceSelectors` on the Prometheus CR.
 | User will be able to set up scrapes by Prometheus on endpoints exposed by Services / Pods within the namespace they are given this permission in.
 
@@ -329,12 +333,14 @@ If cluster-admins would like to provide additional admin/edit access to users ou
 |===
 | k8s Resources | Namespace | Can it cause impact outside of a namespace / project? | Impact
 
-| <ul><li>``secrets``</li><li>``configmaps``</li></ul>
+a| * ``secrets``
+* ``configmaps``
 | `cattle-monitoring-system`
 | Yes, Configs and Secrets in this namespace can impact the entire monitoring / alerting pipeline.
 | User will be able to create or edit Secrets / ConfigMaps such as the Alertmanager Config, Prometheus Adapter Config, TLS secrets, additional Grafana datasources, etc. This can have broad impact on all cluster monitoring / alerting.
 
-| <ul><li>``secrets``</li><li>``configmaps``</li></ul>
+a| * ``secrets``
+* ``configmaps``
 | `cattle-dashboards`
 | Yes, Configs and Secrets in this namespace can create dashboards that make queries on all metrics collected at a cluster-level.
 | User will be able to create Secrets / ConfigMaps that persist new Grafana Dashboards only.

--- a/versions/v2.13/modules/en/pages/security/compliance-scans/rbac-for-compliance-scans.adoc
+++ b/versions/v2.13/modules/en/pages/security/compliance-scans/rbac-for-compliance-scans.adoc
@@ -42,7 +42,7 @@ The rancher-compliance creates three `ClusterRoles` and adds the Compliance Benc
 | Ability to CRUD clusterscanbenchmarks, clusterscanprofiles, clusterscans, clusterscanreports CR
 
 | `compliance-view`
-| `view `
+| `view`
 | Ability to List(R) clusterscanbenchmarks, clusterscanprofiles, clusterscans, clusterscanreports CR
 |===
 

--- a/versions/v2.14/modules/en/pages/installation-and-upgrade/requirements/port-requirements.adoc
+++ b/versions/v2.14/modules/en/pages/installation-and-upgrade/requirements/port-requirements.adoc
@@ -77,7 +77,9 @@ The following tables break down the port requirements for inbound and outbound t
 
 | TCP
 | 443
-| <ul><li>server nodes</li><li>agent nodes</li><li>hosted/registered Kubernetes</li><li>any source that needs to be able to use the Rancher UI or API</li></ul>
+a| * K3s server and agent nodes
+* Hosted/Registered Kubernetes
+* Any source that needs to be able to use the Rancher UI or API
 | Rancher agent, Rancher UI/API, kubectl
 
 | TCP
@@ -191,7 +193,8 @@ The VXLAN port on nodes should not be exposed to the world as it opens up your c
 
 | HTTPS
 | 443
-| <ul><li>hosted/registered Kubernetes</li><li>any source that needs to be able to use the Rancher UI or API</li></ul>
+a| * Hosted/Registered Kubernetes
+* Any source that needs to be able to use the Rancher UI or API
 | Rancher agent, Rancher UI/API, kubectl. Not needed if you have a load balancer doing TLS termination.
 |===
 
@@ -217,7 +220,8 @@ The following tables break down the port requirements for Rancher nodes, for inb
 
 | TCP
 | 443
-| <ul><li>hosted/registered Kubernetes</li><li>any source that needs to be able to use the Rancher UI or API</li></ul>
+a| * Hosted/Registered Kubernetes
+* Any source that needs to be able to use the Rancher UI or API
 | Rancher agent, Rancher UI/API, kubectl
 |===
 

--- a/versions/v2.14/modules/en/pages/observability/istio/rbac.adoc
+++ b/versions/v2.14/modules/en/pages/observability/istio/rbac.adoc
@@ -57,20 +57,41 @@ Istio creates three `ClusterRoles` and adds Istio CRD access to the following de
 
 Rancher will continue to use cluster-owner, cluster-member, project-owner, project-member, etc as role names, but will utilize default roles to determine access. For each default K8s `ClusterRole` there are different Istio CRD permissions and K8s actions (Create ( C ), Get ( G ), List ( L ), Watch ( W ), Update ( U ), Patch ( P ), Delete( D ), All ( * )) that can be performed.
 
+[cols="2,1,1,1"]
 |===
 | CRDs | Admin | Edit | View
 
-| <ul><li>``config.istio.io``</li><ul><li>``adapters``</li><li>``attributemanifests``</li><li>``handlers``</li><li>``httpapispecbindings``</li><li>``httpapispecs``</li><li>``instances``</li><li>``quotaspecbindings``</li><li>``quotaspecs``</li><li>``rules``</li><li>``templates``</li></ul></ul>
+a| * ``config.istio.io``
+** ``adapters``
+** ``attributemanifests``
+** ``handlers``
+** ``httpapispecbindings``
+** ``httpapispecs``
+** ``instances``
+** ``quotaspecbindings``
+** ``quotaspecs``
+** ``rules``
+** ``templates``
 | GLW
 | GLW
 | GLW
 
-| <ul><li>``networking.istio.io``</li><ul><li>``destinationrules``</li><li>``envoyfilters``</li><li>``gateways``</li><li>``serviceentries``</li><li>``sidecars``</li><li>``virtualservices``</li><li>``workloadentries``</li></ul></ul>
+a| * ``networking.istio.io``
+** ``destinationrules``
+** ``envoyfilters``
+** ``gateways``
+** ``serviceentries``
+** ``sidecars``
+** ``virtualservices``
+** ``workloadentries``
 | *
 | *
 | GLW
 
-| <ul><li>``security.istio.io``</li><ul><li>``authorizationpolicies``</li><li>``peerauthentications``</li><li>``requestauthentications``</li></ul></ul>
+a| * ``security.istio.io``
+** ``authorizationpolicies``
+** ``peerauthentications``
+** ``requestauthentications``
 | *
 | *
 | GLW

--- a/versions/v2.14/modules/en/pages/observability/monitoring-and-dashboards/rbac-for-monitoring.adoc
+++ b/versions/v2.14/modules/en/pages/observability/monitoring-and-dashboards/rbac-for-monitoring.adoc
@@ -34,7 +34,7 @@ The `rancher-monitoring` chart installs the following three `ClusterRoles`. By d
 | `edit`
 
 | `monitoring-view`
-| `view `
+| `view`
 |===
 
 These `ClusterRoles` provide different levels of access to the Monitoring CRDs based on the actions that can be performed:
@@ -42,12 +42,15 @@ These `ClusterRoles` provide different levels of access to the Monitoring CRDs b
 |===
 | CRDs (monitoring.coreos.com) | Admin | Edit | View
 
-| <ul><li>``prometheuses``</li><li>``alertmanagers``</li></ul>
+a| * ``prometheuses``
+* ``alertmanagers``
 | Get, List, Watch
 | Get, List, Watch
 | Get, List, Watch
 
-| <ul><li>``servicemonitors``</li><li>``podmonitors``</li><li>``prometheusrules``</li></ul>
+a| * ``servicemonitors``
+* ``podmonitors``
+* ``prometheusrules``
 | *
 | *
 | Get, List, Watch
@@ -328,7 +331,8 @@ If cluster-admins would like to provide additional admin/edit access to users ou
 | No
 | User will be able to define the configuration of new cluster-level Alertmanager deployments that should be created in the cluster. Note: if you just want to allow users to configure settings like Routes and Receivers, you should just provide access to the Alertmanager Config Secret instead.
 
-| <ul><li>``servicemonitors``</li><li>``podmonitors``</li></ul>
+a| * ``servicemonitors``
+* ``podmonitors``
 | No, not by default; this is configurable via `ignoreNamespaceSelectors` on the Prometheus CR.
 | User will be able to set up scrapes by Prometheus on endpoints exposed by Services / Pods within the namespace they are given this permission in.
 
@@ -340,12 +344,14 @@ If cluster-admins would like to provide additional admin/edit access to users ou
 |===
 | k8s Resources | Namespace | Can it cause impact outside of a namespace / project? | Impact
 
-| <ul><li>``secrets``</li><li>``configmaps``</li></ul>
+a| * ``secrets``
+* ``configmaps``
 | `cattle-monitoring-system`
 | Yes, Configs and Secrets in this namespace can impact the entire monitoring / alerting pipeline.
 | User will be able to create or edit Secrets / ConfigMaps such as the Alertmanager Config, Prometheus Adapter Config, TLS secrets, additional Grafana datasources, etc. This can have broad impact on all cluster monitoring / alerting.
 
-| <ul><li>``secrets``</li><li>``configmaps``</li></ul>
+a| * ``secrets``
+* ``configmaps``
 | `cattle-dashboards`
 | Yes, Configs and Secrets in this namespace can create dashboards that make queries on all metrics collected at a cluster-level.
 | User will be able to create Secrets / ConfigMaps that persist new Grafana Dashboards only.

--- a/versions/v2.14/modules/en/pages/security/compliance-scans/rbac-for-compliance-scans.adoc
+++ b/versions/v2.14/modules/en/pages/security/compliance-scans/rbac-for-compliance-scans.adoc
@@ -42,7 +42,7 @@ The rancher-compliance creates three `ClusterRoles` and adds the Compliance Benc
 | Ability to CRUD clusterscanbenchmarks, clusterscanprofiles, clusterscans, clusterscanreports CR
 
 | `compliance-view`
-| `view `
+| `view`
 | Ability to List(R) clusterscanbenchmarks, clusterscanprofiles, clusterscans, clusterscanreports CR
 |===
 

--- a/versions/v2.15/modules/en/pages/installation-and-upgrade/requirements/port-requirements.adoc
+++ b/versions/v2.15/modules/en/pages/installation-and-upgrade/requirements/port-requirements.adoc
@@ -77,7 +77,9 @@ The following tables break down the port requirements for inbound and outbound t
 
 | TCP
 | 443
-| <ul><li>server nodes</li><li>agent nodes</li><li>hosted/registered Kubernetes</li><li>any source that needs to be able to use the Rancher UI or API</li></ul>
+a| * K3s server and agent nodes
+* Hosted/Registered Kubernetes
+* Any source that needs to be able to use the Rancher UI or API
 | Rancher agent, Rancher UI/API, kubectl
 
 | TCP
@@ -191,7 +193,8 @@ The VXLAN port on nodes should not be exposed to the world as it opens up your c
 
 | HTTPS
 | 443
-| <ul><li>hosted/registered Kubernetes</li><li>any source that needs to be able to use the Rancher UI or API</li></ul>
+a| * Hosted/Registered Kubernetes
+* Any source that needs to be able to use the Rancher UI or API
 | Rancher agent, Rancher UI/API, kubectl. Not needed if you have a load balancer doing TLS termination.
 |===
 
@@ -217,7 +220,8 @@ The following tables break down the port requirements for Rancher nodes, for inb
 
 | TCP
 | 443
-| <ul><li>hosted/registered Kubernetes</li><li>any source that needs to be able to use the Rancher UI or API</li></ul>
+a| * Hosted/Registered Kubernetes
+* Any source that needs to be able to use the Rancher UI or API
 | Rancher agent, Rancher UI/API, kubectl
 |===
 

--- a/versions/v2.15/modules/en/pages/observability/istio/rbac.adoc
+++ b/versions/v2.15/modules/en/pages/observability/istio/rbac.adoc
@@ -57,20 +57,41 @@ Istio creates three `ClusterRoles` and adds Istio CRD access to the following de
 
 Rancher will continue to use cluster-owner, cluster-member, project-owner, project-member, etc as role names, but will utilize default roles to determine access. For each default K8s `ClusterRole` there are different Istio CRD permissions and K8s actions (Create ( C ), Get ( G ), List ( L ), Watch ( W ), Update ( U ), Patch ( P ), Delete( D ), All ( * )) that can be performed.
 
+[cols="2,1,1,1"]
 |===
 | CRDs | Admin | Edit | View
 
-| <ul><li>``config.istio.io``</li><ul><li>``adapters``</li><li>``attributemanifests``</li><li>``handlers``</li><li>``httpapispecbindings``</li><li>``httpapispecs``</li><li>``instances``</li><li>``quotaspecbindings``</li><li>``quotaspecs``</li><li>``rules``</li><li>``templates``</li></ul></ul>
+a| * ``config.istio.io``
+** ``adapters``
+** ``attributemanifests``
+** ``handlers``
+** ``httpapispecbindings``
+** ``httpapispecs``
+** ``instances``
+** ``quotaspecbindings``
+** ``quotaspecs``
+** ``rules``
+** ``templates``
 | GLW
 | GLW
 | GLW
 
-| <ul><li>``networking.istio.io``</li><ul><li>``destinationrules``</li><li>``envoyfilters``</li><li>``gateways``</li><li>``serviceentries``</li><li>``sidecars``</li><li>``virtualservices``</li><li>``workloadentries``</li></ul></ul>
+a| * ``networking.istio.io``
+** ``destinationrules``
+** ``envoyfilters``
+** ``gateways``
+** ``serviceentries``
+** ``sidecars``
+** ``virtualservices``
+** ``workloadentries``
 | *
 | *
 | GLW
 
-| <ul><li>``security.istio.io``</li><ul><li>``authorizationpolicies``</li><li>``peerauthentications``</li><li>``requestauthentications``</li></ul></ul>
+a| * ``security.istio.io``
+** ``authorizationpolicies``
+** ``peerauthentications``
+** ``requestauthentications``
 | *
 | *
 | GLW

--- a/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/rbac-for-monitoring.adoc
+++ b/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/rbac-for-monitoring.adoc
@@ -34,7 +34,7 @@ The `rancher-monitoring` chart installs the following three `ClusterRoles`. By d
 | `edit`
 
 | `monitoring-view`
-| `view `
+| `view`
 |===
 
 These `ClusterRoles` provide different levels of access to the Monitoring CRDs based on the actions that can be performed:
@@ -42,12 +42,15 @@ These `ClusterRoles` provide different levels of access to the Monitoring CRDs b
 |===
 | CRDs (monitoring.coreos.com) | Admin | Edit | View
 
-| <ul><li>``prometheuses``</li><li>``alertmanagers``</li></ul>
+a| * ``prometheuses``
+* ``alertmanagers``
 | Get, List, Watch
 | Get, List, Watch
 | Get, List, Watch
 
-| <ul><li>``servicemonitors``</li><li>``podmonitors``</li><li>``prometheusrules``</li></ul>
+a| * ``servicemonitors``
+* ``podmonitors``
+* ``prometheusrules``
 | *
 | *
 | Get, List, Watch
@@ -328,7 +331,8 @@ If cluster-admins would like to provide additional admin/edit access to users ou
 | No
 | User will be able to define the configuration of new cluster-level Alertmanager deployments that should be created in the cluster. Note: if you just want to allow users to configure settings like Routes and Receivers, you should just provide access to the Alertmanager Config Secret instead.
 
-| <ul><li>``servicemonitors``</li><li>``podmonitors``</li></ul>
+a| * ``servicemonitors``
+* ``podmonitors``
 | No, not by default; this is configurable via `ignoreNamespaceSelectors` on the Prometheus CR.
 | User will be able to set up scrapes by Prometheus on endpoints exposed by Services / Pods within the namespace they are given this permission in.
 
@@ -340,12 +344,14 @@ If cluster-admins would like to provide additional admin/edit access to users ou
 |===
 | k8s Resources | Namespace | Can it cause impact outside of a namespace / project? | Impact
 
-| <ul><li>``secrets``</li><li>``configmaps``</li></ul>
+a| * ``secrets``
+* ``configmaps``
 | `cattle-monitoring-system`
 | Yes, Configs and Secrets in this namespace can impact the entire monitoring / alerting pipeline.
 | User will be able to create or edit Secrets / ConfigMaps such as the Alertmanager Config, Prometheus Adapter Config, TLS secrets, additional Grafana datasources, etc. This can have broad impact on all cluster monitoring / alerting.
 
-| <ul><li>``secrets``</li><li>``configmaps``</li></ul>
+a| * ``secrets``
+* ``configmaps``
 | `cattle-dashboards`
 | Yes, Configs and Secrets in this namespace can create dashboards that make queries on all metrics collected at a cluster-level.
 | User will be able to create Secrets / ConfigMaps that persist new Grafana Dashboards only.

--- a/versions/v2.15/modules/en/pages/security/compliance-scans/rbac-for-compliance-scans.adoc
+++ b/versions/v2.15/modules/en/pages/security/compliance-scans/rbac-for-compliance-scans.adoc
@@ -42,7 +42,7 @@ The rancher-compliance creates three `ClusterRoles` and adds the Compliance Benc
 | Ability to CRUD clusterscanbenchmarks, clusterscanprofiles, clusterscans, clusterscanreports CR
 
 | `compliance-view`
-| `view `
+| `view`
 | Ability to List(R) clusterscanbenchmarks, clusterscanprofiles, clusterscans, clusterscanreports CR
 |===
 

--- a/versions/v2.9/modules/en/pages/installation-and-upgrade/requirements/port-requirements.adoc
+++ b/versions/v2.9/modules/en/pages/installation-and-upgrade/requirements/port-requirements.adoc
@@ -75,7 +75,9 @@ The following tables break down the port requirements for inbound and outbound t
 
 | TCP
 | 443
-| <ul><li>server nodes</li><li>agent nodes</li><li>hosted/registered Kubernetes</li><li>any source that needs to be able to use the Rancher UI or API</li></ul>
+a| * K3s server and agent nodes
+* Hosted/Registered Kubernetes
+* Any source that needs to be able to use the Rancher UI or API
 | Rancher agent, Rancher UI/API, kubectl
 
 | TCP
@@ -296,7 +298,8 @@ The VXLAN port on nodes should not be exposed to the world as it opens up your c
 
 | HTTPS
 | 443
-| <ul><li>hosted/registered Kubernetes</li><li>any source that needs to be able to use the Rancher UI or API</li></ul>
+a| * Hosted/Registered Kubernetes
+* Any source that needs to be able to use the Rancher UI or API
 | Rancher agent, Rancher UI/API, kubectl. Not needed if you have a load balancer doing TLS termination.
 |===
 
@@ -321,7 +324,8 @@ The following tables break down the port requirements for Rancher nodes, for inb
 
 | TCP
 | 443
-| <ul><li>hosted/registered Kubernetes</li><li>any source that needs to be able to use the Rancher UI or API</li></ul>
+a| * Hosted/Registered Kubernetes
+* Any source that needs to be able to use the Rancher UI or API
 | Rancher agent, Rancher UI/API, kubectl
 |===
 

--- a/versions/v2.9/modules/en/pages/observability/istio/rbac.adoc
+++ b/versions/v2.9/modules/en/pages/observability/istio/rbac.adoc
@@ -48,20 +48,41 @@ Istio creates three `ClusterRoles` and adds Istio CRD access to the following de
 
 Rancher will continue to use cluster-owner, cluster-member, project-owner, project-member, etc as role names, but will utilize default roles to determine access. For each default K8s `ClusterRole` there are different Istio CRD permissions and K8s actions (Create ( C ), Get ( G ), List ( L ), Watch ( W ), Update ( U ), Patch ( P ), Delete( D ), All ( * )) that can be performed.
 
+[cols="2,1,1,1"]
 |===
 | CRDs | Admin | Edit | View
 
-| <ul><li>``config.istio.io``</li><ul><li>``adapters``</li><li>``attributemanifests``</li><li>``handlers``</li><li>``httpapispecbindings``</li><li>``httpapispecs``</li><li>``instances``</li><li>``quotaspecbindings``</li><li>``quotaspecs``</li><li>``rules``</li><li>``templates``</li></ul></ul>
+a| * ``config.istio.io``
+** ``adapters``
+** ``attributemanifests``
+** ``handlers``
+** ``httpapispecbindings``
+** ``httpapispecs``
+** ``instances``
+** ``quotaspecbindings``
+** ``quotaspecs``
+** ``rules``
+** ``templates``
 | GLW
 | GLW
 | GLW
 
-| <ul><li>``networking.istio.io``</li><ul><li>``destinationrules``</li><li>``envoyfilters``</li><li>``gateways``</li><li>``serviceentries``</li><li>``sidecars``</li><li>``virtualservices``</li><li>``workloadentries``</li></ul></ul>
+a| * ``networking.istio.io``
+** ``destinationrules``
+** ``envoyfilters``
+** ``gateways``
+** ``serviceentries``
+** ``sidecars``
+** ``virtualservices``
+** ``workloadentries``
 | *
 | *
 | GLW
 
-| <ul><li>``security.istio.io``</li><ul><li>``authorizationpolicies``</li><li>``peerauthentications``</li><li>``requestauthentications``</li></ul></ul>
+a| * ``security.istio.io``
+** ``authorizationpolicies``
+** ``peerauthentications``
+** ``requestauthentications``
 | *
 | *
 | GLW

--- a/versions/v2.9/modules/en/pages/observability/monitoring-and-dashboards/rbac-for-monitoring.adoc
+++ b/versions/v2.9/modules/en/pages/observability/monitoring-and-dashboards/rbac-for-monitoring.adoc
@@ -32,7 +32,7 @@ The `rancher-monitoring` chart installs the following three `ClusterRoles`. By d
 | `edit`
 
 | `monitoring-view`
-| `view `
+| `view`
 |===
 
 These `ClusterRoles` provide different levels of access to the Monitoring CRDs based on the actions that can be performed:
@@ -40,12 +40,15 @@ These `ClusterRoles` provide different levels of access to the Monitoring CRDs b
 |===
 | CRDs (monitoring.coreos.com) | Admin | Edit | View
 
-| <ul><li>``prometheuses``</li><li>``alertmanagers``</li></ul>
+a| * ``prometheuses``
+* ``alertmanagers``
 | Get, List, Watch
 | Get, List, Watch
 | Get, List, Watch
 
-| <ul><li>``servicemonitors``</li><li>``podmonitors``</li><li>``prometheusrules``</li></ul>
+a| * ``servicemonitors``
+* ``podmonitors``
+* ``prometheusrules``
 | *
 | *
 | Get, List, Watch
@@ -315,7 +318,8 @@ If cluster-admins would like to provide additional admin/edit access to users ou
 | No
 | User will be able to define the configuration of new cluster-level Alertmanager deployments that should be created in the cluster. Note: if you just want to allow users to configure settings like Routes and Receivers, you should just provide access to the Alertmanager Config Secret instead.
 
-| <ul><li>``servicemonitors``</li><li>``podmonitors``</li></ul>
+a| * ``servicemonitors``
+* ``podmonitors``
 | No, not by default; this is configurable via `ignoreNamespaceSelectors` on the Prometheus CR.
 | User will be able to set up scrapes by Prometheus on endpoints exposed by Services / Pods within the namespace they are given this permission in.
 
@@ -327,12 +331,14 @@ If cluster-admins would like to provide additional admin/edit access to users ou
 |===
 | k8s Resources | Namespace | Can it cause impact outside of a namespace / project? | Impact
 
-| <ul><li>``secrets``</li><li>``configmaps``</li></ul>
+a| * ``secrets``
+* ``configmaps``
 | `cattle-monitoring-system`
 | Yes, Configs and Secrets in this namespace can impact the entire monitoring / alerting pipeline.
 | User will be able to create or edit Secrets / ConfigMaps such as the Alertmanager Config, Prometheus Adapter Config, TLS secrets, additional Grafana datasources, etc. This can have broad impact on all cluster monitoring / alerting.
 
-| <ul><li>``secrets``</li><li>``configmaps``</li></ul>
+a| * ``secrets``
+* ``configmaps``
 | `cattle-dashboards`
 | Yes, Configs and Secrets in this namespace can create dashboards that make queries on all metrics collected at a cluster-level.
 | User will be able to create Secrets / ConfigMaps that persist new Grafana Dashboards only.


### PR DESCRIPTION
### Description
This PR fixes #1242 issue where nested HTML lists (`<ul>`, `<li>`) inside table cells were displaying as raw, unrendered text on the documentation site. 

**Changes made:**
* Converted raw HTML lists to standard AsciiDoc list syntax (`*`, `**`) across all affected active version directories.
* Configured the affected table cells to parse block-level AsciiDoc elements using the `a|` operator.
* Adjusted column widths (`[cols="..."]`) in the Istio RBAC tables to prevent long CRD names from wrapping awkwardly.
* Cleaned up minor trailing whitespace inside inline code blocks.

**Files updated across versions:**
* `installation-and-upgrade/requirements/port-requirements.adoc`
* `observability/istio/rbac.adoc`
* `observability/monitoring-and-dashboards/rbac-for-monitoring.adoc`
* `security/compliance-scans/rbac-for-compliance-scans.ado`