### PR TITLE
Resolve `skipping reference to missing attribute: tenantid` error

### DIFF
--- a/versions/v2.15/modules/en/pages/rancher-admin/users/authn-and-authz/configure-azure-ad.adoc
+++ b/versions/v2.15/modules/en/pages/rancher-admin/users/authn-and-authz/configure-azure-ad.adoc
@@ -266,8 +266,8 @@ If recovery or secret rotation is required post-migration:
 | Field | Legacy Endpoint (Deprecated) | New Endpoint (Microsoft Graph)
 
 | Auth Endpoint
-| `\https://login.microsoftonline.com/{tenantID}/oauth2/authorize`
-| `\https://login.microsoftonline.com/{tenantID}/oauth2/v2.0/authorize`
+| `https://login.microsoftonline.com/\{tenantID}/oauth2/authorize`
+| `\https://login.microsoftonline.com/\{tenantID}/oauth2/v2.0/authorize`
 
 | Endpoint
 | `\https://login.microsoftonline.com/`
@@ -278,8 +278,8 @@ If recovery or secret rotation is required post-migration:
 | `\https://graph.microsoft.com`
 
 | Token Endpoint
-| `\https://login.microsoftonline.com/{tenantID}/oauth2/token`
-| `\https://login.microsoftonline.com/{tenantID}/oauth2/v2.0/token`
+| `\https://login.microsoftonline.com/\{tenantID}/oauth2/token`
+| `\https://login.microsoftonline.com/\{tenantID}/oauth2/v2.0/token`
 |===
 
 ==== Endpoint Reference (China)
@@ -288,8 +288,8 @@ If recovery or secret rotation is required post-migration:
 | Field | Legacy Endpoint (Deprecated) | New Endpoint (Microsoft Graph)
 
 | Auth Endpoint
-| `\https://login.chinacloudapi.cn/{tenantID}/oauth2/authorize`
-| `\https://login.partner.microsoftonline.cn/{tenantID}/oauth2/v2.0/authorize`
+| `\https://login.chinacloudapi.cn/\{tenantID}/oauth2/authorize`
+| `\https://login.partner.microsoftonline.cn/\{tenantID}/oauth2/v2.0/authorize`
 
 | Endpoint
 | `\https://login.chinacloudapi.cn/`
@@ -300,8 +300,8 @@ If recovery or secret rotation is required post-migration:
 | `\https://microsoftgraph.chinacloudapi.cn`
 
 | Token Endpoint
-| `\https://login.chinacloudapi.cn/{tenantID}/oauth2/token`
-| `\https://login.partner.microsoftonline.cn/{tenantID}/oauth2/v2.0/token`
+| `\https://login.chinacloudapi.cn/\{tenantID}/oauth2/token`
+| `\https://login.partner.microsoftonline.cn/\{tenantID}/oauth2/v2.0/token`
 |===
 
 [#_filtering_users_by_azure_ad_auth_group_memberships]

--- a/versions/v2.15/modules/en/pages/rancher-admin/users/authn-and-authz/configure-azure-ad.adoc
+++ b/versions/v2.15/modules/en/pages/rancher-admin/users/authn-and-authz/configure-azure-ad.adoc
@@ -266,7 +266,7 @@ If recovery or secret rotation is required post-migration:
 | Field | Legacy Endpoint (Deprecated) | New Endpoint (Microsoft Graph)
 
 | Auth Endpoint
-| `https://login.microsoftonline.com/\{tenantID}/oauth2/authorize`
+| `\https://login.microsoftonline.com/\{tenantID}/oauth2/authorize`
 | `\https://login.microsoftonline.com/\{tenantID}/oauth2/v2.0/authorize`
 
 | Endpoint


### PR DESCRIPTION
Resolve `skipping reference to missing attribute: tenantid` error on `configure-azure-ad.adoc`.