### PR TITLE
Updating Feature Flags

### DIFF
--- a/versions/v2.13/modules/en/pages/installation-and-upgrade/references/feature-flags.adoc
+++ b/versions/v2.13/modules/en/pages/installation-and-upgrade/references/feature-flags.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2025-11-27
+:revdate: 2026-07-30
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/installation-references/feature-flags.adoc 
 :product-path: installation-and-upgrade/references/feature-flags.adoc
@@ -46,6 +46,7 @@ The following is a list of feature flags available in Rancher. If you've upgrade
 * `aggregated-roletemplates`: Use cluster role aggregation architecture for RoleTemplates, ProjectRoleTemplateBindings, and ClusterRoleTemplateBindings. See {xref-role-template-aggregation}[RoleTemplate Aggregation] for more information.
 * `clean-stale-secrets`: Removes stale secrets from the `cattle-impersonation-system` namespace. This slowly cleans up old secrets which are no longer being used by the impersonation system.
 * `continuous-delivery`: Allows Fleet GitOps to be disabled separately from Fleet. See {xref-continuous-delivery}[Continuous Delivery.] for more information.
+* `crt-token-ttl-rotation`: This feature flag enables automatic CRT token expiration and rotation, configurable via `CRTDefaultTTL`/`CRTDefaultGracePeriod` settings or per-CRT overrides. On expiry, a new token is generated; both old and new tokens remain valid during the grace period giving agents time to pick up the new credential. Rotation is paired with new detection logic in `clusterDeploy` that recognizes when a cluster's token has changed and automatically redeploys the cluster agent with the new credential. Token rotation alone would otherwise never reach a running agent. The feature flag is opt-in for 2.13 and 2.14, and enabled by default starting in 2.15.
 * `fleet`: The Rancher provisioning framework in v2.6 and later requires Fleet. The flag will be automatically enabled when you upgrade, even if you disabled this flag in an earlier version of Rancher. See {xref-fleet}[Continuous Delivery with Fleet] for more information.
 * `harvester`: Manages access to the Virtualization Management page, where users can navigate directly to Harvester clusters and access the Harvester UI. See {xref-harvester-overview}[{harvester-product-name} Integration Overview] for more information.
 * `imperative-api-extension`: Enables Rancher's https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation/[extension API server] to register new APIs to Kubernetes. This flag is enabled by default. See the xref:api/extension-apiserver.adoc[Extension API Server] page for more information.
@@ -101,6 +102,12 @@ The following table shows the availability and default values for some feature f
 | GA
 | v2.6.0
 |
+
+| `crt-token-ttl-rotation`
+| `Disabled`
+| GA
+| v2.13.8
+| 
 
 | `external-rules`
 | v2.7.14: `Disabled`, v2.8.5: `Active`

--- a/versions/v2.14/modules/en/pages/installation-and-upgrade/references/feature-flags.adoc
+++ b/versions/v2.14/modules/en/pages/installation-and-upgrade/references/feature-flags.adoc
@@ -1,6 +1,6 @@
 = Feature Flags
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2025-11-27
+:revdate: 2026-07-30
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/installation-references/feature-flags.adoc 
 :product-path: installation-and-upgrade/references/feature-flags.adoc
@@ -44,6 +44,7 @@ The following is a list of feature flags available in Rancher. If you've upgrade
 * `aggregated-roletemplates`: Use cluster role aggregation architecture for RoleTemplates, ProjectRoleTemplateBindings, and ClusterRoleTemplateBindings. See {xref-role-template-aggregation}[RoleTemplate Aggregation] for more information.
 * `clean-stale-secrets`: Removes stale secrets from the `cattle-impersonation-system` namespace. This slowly cleans up old secrets which are no longer being used by the impersonation system.
 * `continuous-delivery`: Allows Fleet GitOps to be disabled separately from Fleet. See {xref-continuous-delivery}[Continuous Delivery.] for more information.
+* `crt-token-ttl-rotation`: This feature flag enables automatic CRT token expiration and rotation, configurable via `CRTDefaultTTL`/`CRTDefaultGracePeriod` settings or per-CRT overrides. On expiry, a new token is generated; both old and new tokens remain valid during the grace period giving agents time to pick up the new credential. Rotation is paired with new detection logic in `clusterDeploy` that recognizes when a cluster's token has changed and automatically redeploys the cluster agent with the new credential. Token rotation alone would otherwise never reach a running agent. The feature flag is opt-in for 2.13 and 2.14, and enabled by default starting in 2.15.
 * `fleet`: The Rancher provisioning framework in v2.6 and later requires Fleet. The flag will be automatically enabled when you upgrade, even if you disabled this flag in an earlier version of Rancher. See {xref-fleet}[Continuous Delivery with Fleet] for more information.
 * `harvester`: Manages access to the Virtualization Management page, where users can navigate directly to Harvester clusters and access the Harvester UI. See {xref-harvester-overview}[{harvester-product-name} Integration Overview] for more information.
 * `imperative-api-extension`: Enables Rancher's https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation/[extension API server] to register new APIs to Kubernetes. This flag is enabled by default. See the xref:api/extension-apiserver.adoc[Extension API Server] page for more information.
@@ -99,6 +100,12 @@ The following table shows the availability and default values for some feature f
 | GA
 | v2.6.0
 |
+
+| `crt-token-ttl-rotation`
+| `Disabled`
+| GA
+| v2.14.4
+| 
 
 | `external-rules`
 | v2.7.14: `Disabled`, v2.8.5: `Active`

--- a/versions/v2.15/modules/en/pages/installation-and-upgrade/references/feature-flags.adoc
+++ b/versions/v2.15/modules/en/pages/installation-and-upgrade/references/feature-flags.adoc
@@ -1,6 +1,6 @@
 = Feature Flags
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-07-29
+:revdate: 2026-07-30
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/installation-references/feature-flags.adoc 
 :product-path: installation-and-upgrade/references/feature-flags.adoc
@@ -47,8 +47,10 @@ The following is a list of feature flags available in Rancher. If you've upgrade
 * `clean-stale-secrets`: Removes stale secrets from the `cattle-impersonation-system` namespace. This slowly cleans up old secrets which are no longer being used by the impersonation system.
 * `cluster-shell`: Enables the Rancher cluster shell feature, which allows users to access a kubectl shell directly from the Rancher UI to manage cluster resources.
 * `continuous-delivery`: Allows Fleet GitOps to be disabled separately from Fleet. See {xref-continuous-delivery}[Continuous Delivery.] for more information.
+* `crt-token-ttl-rotation`: This feature flag enables automatic CRT token expiration and rotation, configurable via `CRTDefaultTTL`/`CRTDefaultGracePeriod` settings or per-CRT overrides. On expiry, a new token is generated; both old and new tokens remain valid during the grace period giving agents time to pick up the new credential. Rotation is paired with new detection logic in `clusterDeploy` that recognizes when a cluster's token has changed and automatically redeploys the cluster agent with the new credential. Token rotation alone would otherwise never reach a running agent. The feature flag is opt-in for 2.13 and 2.14, and enabled by default starting in 2.15.
 * `fleet`: The Rancher provisioning framework in v2.6 and later requires Fleet. The flag will be automatically enabled when you upgrade, even if you disabled this flag in an earlier version of Rancher. See {xref-fleet}[Continuous Delivery with Fleet] for more information.
 * `harvester`: Manages access to the Virtualization Management page, where users can navigate directly to Harvester clusters and access the Harvester UI. See {xref-harvester-overview}[{harvester-product-name} Integration Overview] for more information.
+* `harvester-baremetal-container-workload`: This feature flag is disabled by default. When enabled the Rancher UI stops filtering out Harvester clusters, allowing Fleet bundles and applications to target and deploy container workloads directly to them. After enabling the `harvester-baremetal-container-workload` feature flag, please validate existing Fleet Bundles to ensure they now select, or don't select, the required clusters. When disabled, the UI maintains the default behavior and excludes Harvester clusters from Fleet targets.
 * `hide-local-auth-provider`: When enabled, hides the local auth provider from users if one or more external auth providers are configured and active. This prevents login through the UI, API, and CLI. It does not revoke API keys that were already issued for `local-auth-provider` users. Creation or editing of `local-auth-provider users` in the UI is also disabled, administrators and users with the `manage-users` permission will continue to be able to create or edit users via API or CLI. This flag is disabled by default.
 +
 [#hide-local-auth-provider-warning]
@@ -119,6 +121,12 @@ The following table shows the availability and default values for some feature f
 | v2.6.0
 |
 
+| `crt-token-ttl-rotation`
+| `Enabled`
+| GA
+| v2.15.0
+| 
+
 | `external-rules`
 | v2.7.14: `Disabled`, v2.8.5: `Active`
 | Removed
@@ -142,6 +150,12 @@ The following table shows the availability and default values for some feature f
 | Experimental
 | v2.6.1
 |
+
+| `harvester-baremetal-container-workload`
+| `Disabled`
+| GA
+| v2.15.0
+| 
 
 | `hide-local-auth-provider`
 | `Disabled`


### PR DESCRIPTION
Updating feature flag pages with new flags:
crt-token-ttl-rotation - tied to CVE
harvester-baremetal-container-workload - added in 2.15 only, new FF

Related to v2.15.0, v2.14.4, v2.13.8.