### PR TITLE
Update 2.15 release notes - RKE2 known issue

### DIFF
--- a/versions/v2.15/modules/en/pages/release-notes/v2.15.0.adoc
+++ b/versions/v2.15/modules/en/pages/release-notes/v2.15.0.adoc
@@ -92,6 +92,11 @@ To improve repository performance, Rancher is introducing a lifecycle management
 
 * Fixed an issue where `rancher-save-images.sh` failed to pull OCI-based Helm charts when the local Docker daemon was configured to use the `overlay2` storage driver. See https://github.com/rancher/rancher/issues/55068[#55068].
 
+[#_known_issues_rancher_general]
+=== Known Issues
+
+* A known issue exists with Rancher v2.15 and Kubernetes v1.36 clusters where **Rancher Backups** is not listed under the **Cluster Tools** due to a Backups chart issue. This issue is resolved in the upcoming Rancher v2.15.1 release.
+
 [#_rancher_app_global_ui]
 == Rancher App (Global UI)
 
@@ -148,7 +153,6 @@ To improve repository performance, Rancher is introducing a lifecycle management
 === Known Issues
 
 * A known issue exists related to CAPI infrastructure providers within Rancher’s V2 provisioning framework. Creating or editing v2prov clusters with native infrastructure providers (such as CAPA or CAPV) from the UI can under some failure conditions leave unused, orphaned infrastructure resources (e.g., `AWSMachineTemplate` or `AWSCluster`) in the management cluster which need to be cleaned up manually. See https://github.com/rancher/rancher/issues/55752[#55752].
-* A known issue exists on RKE2 v1.3.6 clusters where **Rancher Backups** is not listed under the **Cluster Tools**. This issue is resolved in the upcoming Rancher v2.15.1 release.
 
 [#_continuous_delivery_fleet]
 == Continuous Delivery (Fleet)

--- a/versions/v2.15/modules/en/pages/release-notes/v2.15.0.adoc
+++ b/versions/v2.15/modules/en/pages/release-notes/v2.15.0.adoc
@@ -1,6 +1,6 @@
 = Release {release-version}
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-07-30
+:revdate: 2026-07-31
 :page-revdate: {revdate}
 :release-version: v2.15.0
 :rn-component-version: v2.15
@@ -148,6 +148,7 @@ To improve repository performance, Rancher is introducing a lifecycle management
 === Known Issues
 
 * A known issue exists related to CAPI infrastructure providers within Rancher’s V2 provisioning framework. Creating or editing v2prov clusters with native infrastructure providers (such as CAPA or CAPV) from the UI can under some failure conditions leave unused, orphaned infrastructure resources (e.g., `AWSMachineTemplate` or `AWSCluster`) in the management cluster which need to be cleaned up manually. See https://github.com/rancher/rancher/issues/55752[#55752].
+* A known issue exists on RKE2 v1.3.6 clusters where **Rancher Backups** is not listed under the **Cluster Tools**. This issue is resolved in the upcoming Rancher v2.15.1 release.
 
 [#_continuous_delivery_fleet]
 == Continuous Delivery (Fleet)

--- a/versions/v2.15/modules/en/pages/release-notes/v2.15.0.adoc
+++ b/versions/v2.15/modules/en/pages/release-notes/v2.15.0.adoc
@@ -95,7 +95,7 @@ To improve repository performance, Rancher is introducing a lifecycle management
 [#_known_issues_rancher_general]
 === Known Issues
 
-* A known issue exists with Rancher v2.15 and Kubernetes v1.36 clusters where **Rancher Backups** is not listed under the **Cluster Tools** due to a Backups chart issue. This issue is resolved in the upcoming Rancher v2.15.1 release.
+* A known issue exists with Rancher v2.15 and Kubernetes v1.36 clusters where **Rancher Backups** is not listed under the **Cluster Tools** due to a Backups chart issue.
 
 [#_rancher_app_global_ui]
 == Rancher App (Global UI)

--- a/versions/v2.15/modules/en/pages/release-notes/v2.15.0.adoc
+++ b/versions/v2.15/modules/en/pages/release-notes/v2.15.0.adoc
@@ -95,7 +95,7 @@ To improve repository performance, Rancher is introducing a lifecycle management
 [#_known_issues_rancher_general]
 === Known Issues
 
-* A known issue exists with Rancher v2.15 and Kubernetes v1.36 clusters where **Rancher Backups** is not listed under the **Cluster Tools** due to a Backups chart issue.
+* A known issue exists with Rancher v2.15 and Kubernetes v1.36 clusters where **Rancher Backups** is not listed under the **Cluster Tools** due to a Backups chart issue. See https://github.com/rancher/backup-restore-operator/pull/1055[#1055].
 
 [#_rancher_app_global_ui]
 == Rancher App (Global UI)


### PR DESCRIPTION
Update known issue - RKE2 not listing Rancher Backups.