### PR TITLE
update(docs): update rancher charts link for useBundledSystemChart

### DIFF
--- a/versions/v2.10/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
+++ b/versions/v2.10/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -1,8 +1,8 @@
 = 4. Install {rancher-product-name}
 :page-languages: [en, zh]
-:revdate: 2026-07-14
+:revdate: 2026-08-03
 :page-revdate: {revdate}
-:community-path: getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/install-rancher-ha.adoc 
+:community-path: getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/install-rancher-ha.adoc
 :product-path: installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
 ifeval::["{build-type}" != "community"]
 :xref-helm-chart-options: xref:installation-and-upgrade/references/helm-chart-options.adoc
@@ -170,7 +170,7 @@ When setting up the Rancher Helm template, there are several options in the Helm
 
 | `useBundledSystemChart`
 | `true`
-| Configure Rancher server to use the packaged copy of Helm system charts. The https://github.com/rancher/system-charts[system charts] repository contains all the catalog items required for features such as monitoring, logging, alerting and global DNS. These https://github.com/rancher/system-charts[Helm charts] are located in GitHub, but since you are in an air gapped environment, using the charts that are bundled within Rancher is much easier than setting up a Git mirror.
+| Configure Rancher server to use the packaged copy of Helm charts. The charts repository contains all the catalog items required for features such as monitoring, logging, alerting, and global DNS. These Helm charts are located in the https://github.com/rancher/charts[Rancher Charts GitHub repository] or served via the https://git.rancher.io/charts[Main mirror]. In an air-gapped environment, using the bundled charts within Rancher is much easier than setting up a Git mirror.
 |===
 
 === 3. Fetch the Cert-Manager Chart

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -1,8 +1,8 @@
 = 4. Install {rancher-product-name}
 :page-languages: [en, zh]
-:revdate: 2026-07-14
+:revdate: 2026-08-03
 :page-revdate: {revdate}
-:community-path: getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/install-rancher-ha.adoc 
+:community-path: getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/install-rancher-ha.adoc
 :product-path: installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
 ifeval::["{build-type}" != "community"]
 :xref-helm-chart-options: xref:installation-and-upgrade/references/helm-chart-options.adoc
@@ -170,7 +170,7 @@ When setting up the Rancher Helm template, there are several options in the Helm
 
 | `useBundledSystemChart`
 | `true`
-| Configure Rancher server to use the packaged copy of Helm system charts. The https://github.com/rancher/system-charts[system charts] repository contains all the catalog items required for features such as monitoring, logging, alerting and global DNS. These https://github.com/rancher/system-charts[Helm charts] are located in GitHub, but since you are in an air gapped environment, using the charts that are bundled within Rancher is much easier than setting up a Git mirror.
+| Configure Rancher server to use the packaged copy of Helm charts. The charts repository contains all the catalog items required for features such as monitoring, logging, alerting, and global DNS. These Helm charts are located in the https://github.com/rancher/charts[Rancher Charts GitHub repository] or served via the https://git.rancher.io/charts[Main mirror]. In an air-gapped environment, using the bundled charts within Rancher is much easier than setting up a Git mirror.
 |===
 
 === 3. Fetch the Cert-Manager Chart

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -2,9 +2,9 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2026-07-14
+:revdate: 2026-08-03
 :page-revdate: {revdate}
-:community-path: getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/install-rancher-ha.adoc 
+:community-path: getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/install-rancher-ha.adoc
 :product-path: installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
 ifeval::["{build-type}" != "community"]
 :xref-helm-chart-options: xref:installation-and-upgrade/references/helm-chart-options.adoc
@@ -172,7 +172,7 @@ When setting up the Rancher Helm template, there are several options in the Helm
 
 | `useBundledSystemChart`
 | `true`
-| Configure Rancher server to use the packaged copy of Helm system charts. The https://github.com/rancher/system-charts[system charts] repository contains all the catalog items required for features such as monitoring, logging, alerting and global DNS. These https://github.com/rancher/system-charts[Helm charts] are located in GitHub, but since you are in an air gapped environment, using the charts that are bundled within Rancher is much easier than setting up a Git mirror.
+| Configure Rancher server to use the packaged copy of Helm charts. The charts repository contains all the catalog items required for features such as monitoring, logging, alerting, and global DNS. These Helm charts are located in the https://github.com/rancher/charts[Rancher Charts GitHub repository] or served via the https://git.rancher.io/charts[Main mirror]. In an air-gapped environment, using the bundled charts within Rancher is much easier than setting up a Git mirror.
 |===
 
 === 3. Fetch the Cert-Manager Chart

--- a/versions/v2.13/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
+++ b/versions/v2.13/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -2,9 +2,9 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2026-07-14
+:revdate: 2026-08-03
 :page-revdate: {revdate}
-:community-path: getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/install-rancher-ha.adoc 
+:community-path: getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/install-rancher-ha.adoc
 :product-path: installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
 ifeval::["{build-type}" != "community"]
 :xref-helm-chart-options: xref:installation-and-upgrade/references/helm-chart-options.adoc
@@ -162,7 +162,7 @@ When setting up the Rancher Helm template, there are several options in the Helm
 
 | `useBundledSystemChart`
 | `true`
-| Configure Rancher server to use the packaged copy of Helm system charts. The https://github.com/rancher/system-charts[system charts] repository contains all the catalog items required for features such as monitoring, logging, alerting and global DNS. These https://github.com/rancher/system-charts[Helm charts] are located in GitHub, but since you are in an air gapped environment, using the charts that are bundled within Rancher is much easier than setting up a Git mirror.
+| Configure Rancher server to use the packaged copy of Helm charts. The charts repository contains all the catalog items required for features such as monitoring, logging, alerting, and global DNS. These Helm charts are located in the https://github.com/rancher/charts[Rancher Charts GitHub repository] or served via the https://git.rancher.io/charts[Main mirror]. In an air-gapped environment, using the bundled charts within Rancher is much easier than setting up a Git mirror.
 |===
 
 === 3. Fetch the Cert-Manager Chart

--- a/versions/v2.14/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
+++ b/versions/v2.14/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -1,8 +1,8 @@
 = 4. Install {rancher-product-name}
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-07-20
+:revdate: 2026-08-03
 :page-revdate: {revdate}
-:community-path: getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/install-rancher-ha.adoc 
+:community-path: getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/install-rancher-ha.adoc
 :product-path: installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
 ifeval::["{build-type}" != "community"]
 :xref-helm-chart-options: xref:installation-and-upgrade/references/helm-chart-options.adoc
@@ -158,7 +158,7 @@ When setting up the Rancher Helm template, there are several options in the Helm
 
 | `useBundledSystemChart`
 | `true`
-| Configure Rancher server to use the packaged copy of Helm system charts. The https://github.com/rancher/system-charts[system charts] repository contains all the catalog items required for features such as monitoring, logging, alerting and global DNS. These https://github.com/rancher/system-charts[Helm charts] are located in GitHub, but since you are in an air gapped environment, using the charts that are bundled within Rancher is much easier than setting up a Git mirror.
+| Configure Rancher server to use the packaged copy of Helm charts. The charts repository contains all the catalog items required for features such as monitoring, logging, alerting, and global DNS. These Helm charts are located in the https://github.com/rancher/charts[Rancher Charts GitHub repository] or served via the https://git.rancher.io/charts[Main mirror]. In an air-gapped environment, using the bundled charts within Rancher is much easier than setting up a Git mirror.
 |===
 
 [#_3_fetch_the_cert_manager_chart]

--- a/versions/v2.15/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
+++ b/versions/v2.15/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -1,8 +1,8 @@
 = 4. Install {rancher-product-name}
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-07-15
+:revdate: 2026-08-03
 :page-revdate: {revdate}
-:community-path: getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/install-rancher-ha.adoc 
+:community-path: getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/install-rancher-ha.adoc
 :product-path: installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
 ifeval::["{build-type}" != "community"]
 :xref-helm-chart-options: xref:installation-and-upgrade/references/helm-chart-options.adoc
@@ -164,7 +164,7 @@ When setting up the Rancher Helm template, there are several options in the Helm
 
 | `useBundledSystemChart`
 | `true`
-| Configure Rancher server to use the packaged copy of Helm system charts. The https://github.com/rancher/system-charts[system charts] repository contains all the catalog items required for features such as monitoring, logging, alerting and global DNS. These https://github.com/rancher/system-charts[Helm charts] are located in GitHub, but since you are in an air gapped environment, using the charts that are bundled within Rancher is much easier than setting up a Git mirror.
+| Configure Rancher server to use the packaged copy of Helm charts. The charts repository contains all the catalog items required for features such as monitoring, logging, alerting, and global DNS. These Helm charts are located in the https://github.com/rancher/charts[Rancher Charts GitHub repository] or served via the https://git.rancher.io/charts[Main mirror]. In an air-gapped environment, using the bundled charts within Rancher is much easier than setting up a Git mirror.
 |===
 
 [#_3_fetch_the_cert_manager_chart]


### PR DESCRIPTION
### Description:
Fixes: https://github.com/rancher/rancher-docs/issues/2287

Re-worded the paragraph and updated links to the active development repo and Prod mirror.

```diff
- | Configure Rancher server to use the packaged copy of Helm system charts. The https://github.com/rancher/system-charts[system charts] repository contains all the catalog items required for features such as monitoring, logging, alerting and global DNS. These https://github.com/rancher/system-charts[Helm charts] are located in GitHub, but since you are in an air gapped environment, using the charts that are bundled within Rancher is much easier than setting up a Git mirror.
+ | Configure Rancher server to use the packaged copy of Helm charts. The charts repository contains all the catalog items required for features such as monitoring, logging, alerting, and global DNS. These Helm charts are located in the https://github.com/rancher/charts[Rancher Charts GitHub repository] or served via the https://git.rancher.io/charts[Main mirror]. In an air-gapped environment, using the bundled charts within Rancher is much easier than setting up a Git mirror.
```