### PR TITLE
Fix links/conditionals

### DIFF
--- a/community-docs/latest/antora.yml
+++ b/community-docs/latest/antora.yml
@@ -11,7 +11,7 @@ asciidoc:
     current-patch-version: 2.15.0
     # docs links
     harvester-docs-version: v1.7
-    longhorn-docs-version: 1.11.0
+    longhorn-docs-version: 1.11.3
     neuvector-docs-version: 5.4
     kubewarden-docs-version: 1.31
     elemental-docs-version: 1.7

--- a/community-docs/latest/antora.yml
+++ b/community-docs/latest/antora.yml
@@ -11,7 +11,7 @@ asciidoc:
     current-patch-version: 2.15.0
     # docs links
     harvester-docs-version: v1.7
-    longhorn-docs-version: 1.10.0
+    longhorn-docs-version: 1.11.0
     neuvector-docs-version: 5.4
     kubewarden-docs-version: 1.31
     elemental-docs-version: 1.7

--- a/community-docs/v2.11/antora.yml
+++ b/community-docs/v2.11/antora.yml
@@ -10,7 +10,7 @@ asciidoc:
     current-patch-version: "2.11.3"
     # docs links
     harvester-docs-version: v1.5
-    longhorn-docs-version: 1.8.0
+    longhorn-docs-version: 1.11.0
     neuvector-docs-version: 5.4
     kubewarden-docs-version: 1.31
     elemental-docs-version: 1.6

--- a/community-docs/v2.11/antora.yml
+++ b/community-docs/v2.11/antora.yml
@@ -10,7 +10,7 @@ asciidoc:
     current-patch-version: "2.11.3"
     # docs links
     harvester-docs-version: v1.5
-    longhorn-docs-version: 1.11.0
+    longhorn-docs-version: 1.11.2
     neuvector-docs-version: 5.4
     kubewarden-docs-version: 1.31
     elemental-docs-version: 1.6

--- a/community-docs/v2.12/antora.yml
+++ b/community-docs/v2.12/antora.yml
@@ -10,7 +10,7 @@ asciidoc:
     current-patch-version: "2.12.3"
     # docs links
     harvester-docs-version: v1.6
-    longhorn-docs-version: 1.9.0
+    longhorn-docs-version: 1.11.0
     neuvector-docs-version: 5.4
     kubewarden-docs-version: 1.31
     elemental-docs-version: 1.7

--- a/community-docs/v2.12/antora.yml
+++ b/community-docs/v2.12/antora.yml
@@ -10,7 +10,7 @@ asciidoc:
     current-patch-version: "2.12.3"
     # docs links
     harvester-docs-version: v1.6
-    longhorn-docs-version: 1.11.0
+    longhorn-docs-version: 1.11.2
     neuvector-docs-version: 5.4
     kubewarden-docs-version: 1.31
     elemental-docs-version: 1.7

--- a/community-docs/v2.13/antora.yml
+++ b/community-docs/v2.13/antora.yml
@@ -10,7 +10,7 @@ asciidoc:
     current-patch-version: "2.13.3"
     # docs links
     harvester-docs-version: v1.7
-    longhorn-docs-version: 1.11.0
+    longhorn-docs-version: 1.11.3
     neuvector-docs-version: 5.4
     kubewarden-docs-version: 1.31
     elemental-docs-version: 1.7

--- a/community-docs/v2.13/antora.yml
+++ b/community-docs/v2.13/antora.yml
@@ -10,7 +10,7 @@ asciidoc:
     current-patch-version: "2.13.3"
     # docs links
     harvester-docs-version: v1.7
-    longhorn-docs-version: 1.10.0
+    longhorn-docs-version: 1.11.0
     neuvector-docs-version: 5.4
     kubewarden-docs-version: 1.31
     elemental-docs-version: 1.7

--- a/community-docs/v2.14/antora.yml
+++ b/community-docs/v2.14/antora.yml
@@ -10,7 +10,7 @@ asciidoc:
     current-patch-version: 2.14.3
     # docs links
     harvester-docs-version: v1.7
-    longhorn-docs-version: 1.10.0
+    longhorn-docs-version: 1.11.0
     neuvector-docs-version: 5.4
     kubewarden-docs-version: 1.31
     elemental-docs-version: 1.7

--- a/community-docs/v2.14/antora.yml
+++ b/community-docs/v2.14/antora.yml
@@ -10,7 +10,7 @@ asciidoc:
     current-patch-version: 2.14.3
     # docs links
     harvester-docs-version: v1.7
-    longhorn-docs-version: 1.11.0
+    longhorn-docs-version: 1.11.3
     neuvector-docs-version: 5.4
     kubewarden-docs-version: 1.31
     elemental-docs-version: 1.7

--- a/community-docs/v2.15/antora.yml
+++ b/community-docs/v2.15/antora.yml
@@ -10,7 +10,7 @@ asciidoc:
     current-patch-version: 2.15.0
     # docs links
     harvester-docs-version: v1.7
-    longhorn-docs-version: 1.11.0
+    longhorn-docs-version: 1.11.3
     neuvector-docs-version: 5.4
     kubewarden-docs-version: 1.31
     elemental-docs-version: 1.7

--- a/community-docs/v2.15/antora.yml
+++ b/community-docs/v2.15/antora.yml
@@ -10,7 +10,7 @@ asciidoc:
     current-patch-version: 2.15.0
     # docs links
     harvester-docs-version: v1.7
-    longhorn-docs-version: 1.10.0
+    longhorn-docs-version: 1.11.0
     neuvector-docs-version: 5.4
     kubewarden-docs-version: 1.31
     elemental-docs-version: 1.7

--- a/versions/v2.11/antora.yml
+++ b/versions/v2.11/antora.yml
@@ -11,7 +11,7 @@ asciidoc:
     current-patch-version: 2.11.16
     # docs links
     harvester-docs-version: v1.5
-    longhorn-docs-version: 1.8
+    longhorn-docs-version: "1.10"
     neuvector-docs-version: 5.4
     kubewarden-docs-version: 1.31
     elemental-docs-version: 1.6

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/upgrades.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/upgrades.adoc
@@ -1,5 +1,5 @@
 = Upgrades
-:revdate: 2026-08-03
+:revdate: 2026-08-06
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/upgrades.adoc 
 :product-path: installation-and-upgrade/upgrades.adoc
@@ -58,7 +58,7 @@ helm repo update
 ----
 
 ifeval::["{build-type}" != "community"]
-. Search for available versions in your specific repository (e.g., rancher-prime):
+. Search for available versions in the repository:
 +
 [,sh]
 ----
@@ -66,7 +66,7 @@ helm search repo rancher-prime/rancher --versions
 ----
 endif::[]
 ifeval::["{build-type}" == "community"]
-. Search for available versions in your xref:getting-started/installation-and-upgrade/resources/choose-a-rancher-version.adoc#_helm_chart_repositories[specific repository] (e.g., rancher-stable):
+. Search for available versions in your xref:getting-started/installation-and-upgrade/resources/choose-a-rancher-version.adoc#_helm_chart_repositories[specific repository] (e.g., rancher-latest):
 +
 [,sh]
 ----

--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/upgrades.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/upgrades.adoc
@@ -1,5 +1,5 @@
 = Upgrades
-:revdate: 2026-07-20
+:revdate: 2026-08-03
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/upgrades.adoc 
 :product-path: installation-and-upgrade/upgrades.adoc
@@ -57,12 +57,22 @@ You can query the available chart versions with the Helm CLI:
 helm repo update
 ----
 
+ifeval::["{build-type}" != "community"]
+. Search for available versions in your specific repository (e.g., rancher-prime):
++
+[,sh]
+----
+helm search repo rancher-prime/rancher --versions
+----
+endif::[]
+ifeval::["{build-type}" == "community"]
 . Search for available versions in your xref:getting-started/installation-and-upgrade/resources/choose-a-rancher-version.adoc#_helm_chart_repositories[specific repository] (e.g., rancher-stable):
 +
 [,sh]
 ----
 helm search repo rancher-<CHART_REPO>/rancher --versions
 ----
+endif::[]
 
 If your installation is not on the latest patch version of the current minor release, you must upgrade to that version before proceeding to the next minor version.
 ====

--- a/versions/v2.12/antora-yml/antora-product.yml
+++ b/versions/v2.12/antora-yml/antora-product.yml
@@ -11,7 +11,7 @@ asciidoc:
     current-patch-version: 2.12.12
     # docs links
     harvester-docs-version: v1.6
-    longhorn-docs-version: 1.9
+    longhorn-docs-version: "1.10"
     neuvector-docs-version: 5.4
     kubewarden-docs-version: 1.31
     elemental-docs-version: 1.7

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/upgrades.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/upgrades.adoc
@@ -1,5 +1,5 @@
 = Upgrades
-:revdate: 2026-08-03
+:revdate: 2026-08-06
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/upgrades.adoc 
 :product-path: installation-and-upgrade/upgrades.adoc
@@ -56,7 +56,7 @@ helm repo update
 ----
 
 ifeval::["{build-type}" != "community"]
-. Search for available versions in your specific repository (e.g., rancher-prime):
+. Search for available versions in the repository:
 +
 [,sh]
 ----
@@ -64,7 +64,7 @@ helm search repo rancher-prime/rancher --versions
 ----
 endif::[]
 ifeval::["{build-type}" == "community"]
-. Search for available versions in your xref:getting-started/installation-and-upgrade/resources/choose-a-rancher-version.adoc#_helm_chart_repositories[specific repository] (e.g., rancher-stable):
+. Search for available versions in your xref:getting-started/installation-and-upgrade/resources/choose-a-rancher-version.adoc#_helm_chart_repositories[specific repository] (e.g., rancher-latest):
 +
 [,sh]
 ----

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/upgrades.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/upgrades.adoc
@@ -1,5 +1,5 @@
 = Upgrades
-:revdate: 2026-07-20
+:revdate: 2026-08-03
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/upgrades.adoc 
 :product-path: installation-and-upgrade/upgrades.adoc
@@ -55,12 +55,22 @@ You can query the available chart versions with the Helm CLI:
 helm repo update
 ----
 
+ifeval::["{build-type}" != "community"]
+. Search for available versions in your specific repository (e.g., rancher-prime):
++
+[,sh]
+----
+helm search repo rancher-prime/rancher --versions
+----
+endif::[]
+ifeval::["{build-type}" == "community"]
 . Search for available versions in your xref:getting-started/installation-and-upgrade/resources/choose-a-rancher-version.adoc#_helm_chart_repositories[specific repository] (e.g., rancher-stable):
 +
 [,sh]
 ----
 helm search repo rancher-<CHART_REPO>/rancher --versions
 ----
+endif::[]
 
 If your installation is not on the latest patch version of the current minor release, you must upgrade to that version before proceeding to the next minor version.
 ====

--- a/versions/v2.13/antora-yml/antora-product.yml
+++ b/versions/v2.13/antora-yml/antora-product.yml
@@ -11,7 +11,7 @@ asciidoc:
     current-patch-version: 2.13.8
     # docs links
     harvester-docs-version: v1.7
-    longhorn-docs-version: "1.10"
+    longhorn-docs-version: 1.11
     neuvector-docs-version: 5.4
     kubewarden-docs-version: 1.31
     elemental-docs-version: 1.7

--- a/versions/v2.13/modules/en/pages/installation-and-upgrade/upgrades.adoc
+++ b/versions/v2.13/modules/en/pages/installation-and-upgrade/upgrades.adoc
@@ -1,5 +1,5 @@
 = Upgrades
-:revdate: 2026-08-03
+:revdate: 2026-08-06
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/upgrades.adoc 
 :product-path: installation-and-upgrade/upgrades.adoc
@@ -56,7 +56,7 @@ helm repo update
 ----
 
 ifeval::["{build-type}" != "community"]
-. Search for available versions in your specific repository (e.g., rancher-prime):
+. Search for available versions in the repository:
 +
 [,sh]
 ----
@@ -64,7 +64,7 @@ helm search repo rancher-prime/rancher --versions
 ----
 endif::[]
 ifeval::["{build-type}" == "community"]
-. Search for available versions in your xref:getting-started/installation-and-upgrade/resources/choose-a-rancher-version.adoc#_helm_chart_repositories[specific repository] (e.g., rancher-stable):
+. Search for available versions in your xref:getting-started/installation-and-upgrade/resources/choose-a-rancher-version.adoc#_helm_chart_repositories[specific repository] (e.g., rancher-latest):
 +
 [,sh]
 ----

--- a/versions/v2.13/modules/en/pages/installation-and-upgrade/upgrades.adoc
+++ b/versions/v2.13/modules/en/pages/installation-and-upgrade/upgrades.adoc
@@ -1,5 +1,5 @@
 = Upgrades
-:revdate: 2026-07-20
+:revdate: 2026-08-03
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/upgrades.adoc 
 :product-path: installation-and-upgrade/upgrades.adoc
@@ -55,12 +55,22 @@ You can query the available chart versions with the Helm CLI:
 helm repo update
 ----
 
+ifeval::["{build-type}" != "community"]
+. Search for available versions in your specific repository (e.g., rancher-prime):
++
+[,sh]
+----
+helm search repo rancher-prime/rancher --versions
+----
+endif::[]
+ifeval::["{build-type}" == "community"]
 . Search for available versions in your xref:getting-started/installation-and-upgrade/resources/choose-a-rancher-version.adoc#_helm_chart_repositories[specific repository] (e.g., rancher-stable):
 +
 [,sh]
 ----
 helm search repo rancher-<CHART_REPO>/rancher --versions
 ----
+endif::[]
 
 If your installation is not on the latest patch version of the current minor release, you must upgrade to that version before proceeding to the next minor version.
 ====

--- a/versions/v2.14/antora-yml/antora-product.yml
+++ b/versions/v2.14/antora-yml/antora-product.yml
@@ -16,7 +16,7 @@ asciidoc:
     current-patch-version: 2.14.4
     # docs links
     harvester-docs-version: v1.7
-    longhorn-docs-version: "1.10"
+    longhorn-docs-version: 1.11
     neuvector-docs-version: 5.4
     kubewarden-docs-version: 1.31
     elemental-docs-version: 1.7

--- a/versions/v2.14/antora-yml/antora-srfa.yml
+++ b/versions/v2.14/antora-yml/antora-srfa.yml
@@ -23,7 +23,7 @@ asciidoc:
     current-patch-version: 2.14.4
     # docs links
     harvester-docs-version: v1.7
-    longhorn-docs-version: "1.10"
+    longhorn-docs-version: 1.11
     neuvector-docs-version: 5.4
     kubewarden-docs-version: 1.31
     elemental-docs-version: 1.7

--- a/versions/v2.14/modules/en/pages/installation-and-upgrade/upgrades.adoc
+++ b/versions/v2.14/modules/en/pages/installation-and-upgrade/upgrades.adoc
@@ -1,6 +1,6 @@
 = Upgrades
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-07-20
+:revdate: 2026-08-03
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/upgrades.adoc 
 :product-path: installation-and-upgrade/upgrades.adoc
@@ -60,12 +60,22 @@ You can query the available chart versions with the Helm CLI:
 helm repo update
 ----
 
+ifeval::["{build-type}" != "community"]
+. Search for available versions in your specific repository (e.g., rancher-prime):
++
+[,sh]
+----
+helm search repo rancher-prime/rancher --versions
+----
+endif::[]
+ifeval::["{build-type}" == "community"]
 . Search for available versions in your xref:getting-started/installation-and-upgrade/resources/choose-a-rancher-version.adoc#_helm_chart_repositories[specific repository] (e.g., rancher-stable):
 +
 [,sh]
 ----
 helm search repo rancher-<CHART_REPO>/rancher --versions
 ----
+endif::[]
 
 If your installation is not on the latest patch version of the current minor release, you must upgrade to that version before proceeding to the next minor version.
 ====

--- a/versions/v2.14/modules/en/pages/installation-and-upgrade/upgrades.adoc
+++ b/versions/v2.14/modules/en/pages/installation-and-upgrade/upgrades.adoc
@@ -1,6 +1,6 @@
 = Upgrades
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-08-03
+:revdate: 2026-08-06
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/upgrades.adoc 
 :product-path: installation-and-upgrade/upgrades.adoc
@@ -61,7 +61,7 @@ helm repo update
 ----
 
 ifeval::["{build-type}" != "community"]
-. Search for available versions in your specific repository (e.g., rancher-prime):
+. Search for available versions in the repository:
 +
 [,sh]
 ----
@@ -69,7 +69,7 @@ helm search repo rancher-prime/rancher --versions
 ----
 endif::[]
 ifeval::["{build-type}" == "community"]
-. Search for available versions in your xref:getting-started/installation-and-upgrade/resources/choose-a-rancher-version.adoc#_helm_chart_repositories[specific repository] (e.g., rancher-stable):
+. Search for available versions in your xref:getting-started/installation-and-upgrade/resources/choose-a-rancher-version.adoc#_helm_chart_repositories[specific repository] (e.g., rancher-latest):
 +
 [,sh]
 ----

--- a/versions/v2.15/antora-yml/antora-product.yml
+++ b/versions/v2.15/antora-yml/antora-product.yml
@@ -17,7 +17,7 @@ asciidoc:
     current-patch-version: 2.15.0
     # docs links
     harvester-docs-version: v1.7
-    longhorn-docs-version: "1.10"
+    longhorn-docs-version: 1.11
     neuvector-docs-version: 5.4
     kubewarden-docs-version: 1.31
     elemental-docs-version: 1.7

--- a/versions/v2.15/antora-yml/antora-srfa.yml
+++ b/versions/v2.15/antora-yml/antora-srfa.yml
@@ -23,7 +23,7 @@ asciidoc:
     current-patch-version: 2.15.0
     # docs links
     harvester-docs-version: v1.7
-    longhorn-docs-version: "1.10"
+    longhorn-docs-version: 1.11
     neuvector-docs-version: 5.4
     kubewarden-docs-version: 1.31
     elemental-docs-version: 1.7

--- a/versions/v2.15/modules/en/pages/installation-and-upgrade/upgrades.adoc
+++ b/versions/v2.15/modules/en/pages/installation-and-upgrade/upgrades.adoc
@@ -1,6 +1,6 @@
 = Upgrades
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-07-20
+:revdate: 2026-08-03
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/upgrades.adoc 
 :product-path: installation-and-upgrade/upgrades.adoc
@@ -60,12 +60,22 @@ You can query the available chart versions with the Helm CLI:
 helm repo update
 ----
 
+ifeval::["{build-type}" != "community"]
+. Search for available versions in your specific repository (e.g., rancher-prime):
++
+[,sh]
+----
+helm search repo rancher-prime/rancher --versions
+----
+endif::[]
+ifeval::["{build-type}" == "community"]
 . Search for available versions in your xref:getting-started/installation-and-upgrade/resources/choose-a-rancher-version.adoc#_helm_chart_repositories[specific repository] (e.g., rancher-stable):
 +
 [,sh]
 ----
 helm search repo rancher-<CHART_REPO>/rancher --versions
 ----
+endif::[]
 
 If your installation is not on the latest patch version of the current minor release, you must upgrade to that version before proceeding to the next minor version.
 ====

--- a/versions/v2.15/modules/en/pages/installation-and-upgrade/upgrades.adoc
+++ b/versions/v2.15/modules/en/pages/installation-and-upgrade/upgrades.adoc
@@ -1,6 +1,6 @@
 = Upgrades
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-08-03
+:revdate: 2026-08-06
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/install-upgrade-on-a-kubernetes-cluster/upgrades.adoc 
 :product-path: installation-and-upgrade/upgrades.adoc
@@ -61,7 +61,7 @@ helm repo update
 ----
 
 ifeval::["{build-type}" != "community"]
-. Search for available versions in your specific repository (e.g., rancher-prime):
+. Search for available versions in the repository:
 +
 [,sh]
 ----
@@ -69,7 +69,7 @@ helm search repo rancher-prime/rancher --versions
 ----
 endif::[]
 ifeval::["{build-type}" == "community"]
-. Search for available versions in your xref:getting-started/installation-and-upgrade/resources/choose-a-rancher-version.adoc#_helm_chart_repositories[specific repository] (e.g., rancher-stable):
+. Search for available versions in your xref:getting-started/installation-and-upgrade/resources/choose-a-rancher-version.adoc#_helm_chart_repositories[specific repository] (e.g., rancher-latest):
 +
 [,sh]
 ----


### PR DESCRIPTION
Updating Longhorn docs links to compatible Rancher version, based on [community 1.11](https://longhorn.io/docs/1.11.0/important-notes/#kubernetes-version-requirement), [product 1.10](https://documentation.suse.com/cloudnative/storage/1.10/en/important-notes.html#_kubernetes_version_requirement), and [product 1.11](https://documentation.suse.com/cloudnative/storage/1.11/en/important-notes.html#_kubernetes_version_requirement).

Also updating upgrades.adoc with missed conditonals from previous [PR](https://github.com/rancher/rancher-product-docs/pull/1252/files#diff-1348210ff51d8a0455f0ffb04df3fb4c57ff004f87385e08731ef973b47beac1). Fixes build errors seen on prod docs but left out v2.10 as will be decommissioned soon due to EOL.

Please let me know if their are any questions.