### PR TITLE
update(docs): Correct Etcd Data Path Guidance for RKE2/K3s #342

### DIFF
--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/best-practices/tuning-etcd-for-large-installs.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/best-practices/tuning-etcd-for-large-installs.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2026-07-14
+:revdate: 2026-08-03
 :page-revdate: {revdate}
 :community-path: how-to-guides/advanced-user-guides/tune-etcd-for-large-installs.adoc 
 :product-path: installation-and-upgrade/best-practices/tuning-etcd-for-large-installs.adoc
@@ -15,7 +15,7 @@ endif::[]
 
 When Rancher is used to manage {xref-install-reqs}[a large infrastructure] it is recommended to increase the default keyspace for etcd from the default 2 GB. The maximum setting is 8 GB and the host should have enough RAM to keep the entire dataset in memory. When increasing this value you should also increase the size of the host. The keyspace size can also be adjusted in smaller installations if you anticipate a high rate of change of pods during the garbage collection interval.
 
-The etcd data set is automatically cleaned up on a five-minute interval by Kubernetes. There are situations, e.g. deployment thrashing, where enough events could be written to etcd and deleted before garbage collection occurs and cleans things up causing the keyspace to fill up. If you see `mvcc: database space exceeded` errors, in the etcd logs or Kubernetes API server logs, you should consider increasing the keyspace size. This can be accomplished by setting the https://etcd.io/docs/v3.5/op-guide/maintenance/#space-quota[quota-backend-bytes] setting on the etcd servers.
+The etcd data set is automatically cleaned up on a five-minute interval by Kubernetes. There are situations, e.g. deployment thrashing, where enough events could be written to etcd and deleted before garbage collection occurs and cleans things up causing the keyspace to fill up. If you see `mvcc: database space exceeded` errors, in the etcd logs or Kubernetes API server logs, you should consider increasing the keyspace size. This can be accomplished by setting the https://etcd.io/docs/latest/op-guide/maintenance/#space-quota[quota-backend-bytes] setting on the etcd servers.
 
 == Example: This Snippet of the RKE2/K3s config.yaml file Increases the Keyspace Size to 5GB
 
@@ -29,17 +29,38 @@ etcd-arg:
 
 == Scaling etcd Disk Performance
 
-You can follow the recommendations from https://etcd.io/docs/v3.5/tuning/#disk[the etcd docs] on how to tune the disk priority on the host.
+For RKE2 and K3s-based Rancher management clusters, achieving optimal etcd performance and stability is paramount. It is highly recommended to mount a dedicated, high-performance flash device (SSD or NVMe) at the database path. This volume should be formatted with a robust, high-performance filesystem such as XFS. This configuration isolates critical etcd I/O operations from the host operating system and any other applications, which is a foundational best practice for preventing I/O contention and ensuring low-latency writes.
 
-Additionally, to reduce IO contention on the disks for etcd, you can use a dedicated device for the data and wal directory. Based on etcd best practices, mirroring RAID configurations are unnecessary because etcd replicates data between the nodes in the cluster. You can use striping RAID configurations to increase available IOPS.
+* For RKE2, the path is `/var/lib/rancher/rke2/server/db`.
+* For K3s, the path is `/var/lib/rancher/k3s/server/db`.
 
-To implement this solution in an RKE2/K3s cluster, the `/var/lib/etcd/data` and `/var/lib/etcd/wal` directories will need to have disks mounted and formatted on the underlying host. In the `extra_args` directive of the `etcd` service, you must include the `wal_dir` directory. Without specifying the `wal_dir`, etcd process will try to manipulate the underlying `wal` mount with insufficient permissions.
+[WARNING]
+====
+Do not attempt to change the default etcd data directory using etcd-arg or other configuration flags. RKE2 and K3s require the etcd database to remain at its default location. Modifying this path will break built-in cluster operations, such as snapshots and restores. To utilize dedicated storage, you must mount the device directly to the default paths listed above.
+====
+
+Additionally, you can follow the recommendations from https://etcd.io/docs/latest/tuning/#disk[the etcd docs] on how to tune the disk priority on the host.
+
+=== Advanced WAL Separation
+
+Based on etcd best practices, mirroring RAID configurations are unnecessary because etcd replicates data between the nodes in the cluster. You can use striping RAID configurations to increase available IOPS.
+
+If you are using dedicated devices to separate the data and `wal` directories, you must mount your `wal` disk to the default `wal` path and explicitly declare the `wal-dir` in your configuration file using that default path (as shown in the examples below). Without specifying it, the etcd process will try to manipulate the underlying `wal` mount with insufficient permissions.
 
 [,yaml]
-.RKE2/K3s config.yaml
+.RKE2 config.yaml
 [,shell]
 ----
 etcd-arg:
-  - "data-dir=/var/lib/etcd/data"
-  - "wal-dir=/var/lib/etcd/wal"
+  - "data-dir=/var/lib/rancher/rke2/server/db/etcd"
+  - "wal-dir=/var/lib/rancher/rke2/server/db/etcd/wal"
+----
+
+[,yaml]
+.K3s config.yaml
+[,shell]
+----
+etcd-arg:
+  - "data-dir=/var/lib/rancher/k3s/server/db/etcd"
+  - "wal-dir=/var/lib/rancher/k3s/server/db/etcd/wal"
 ----

--- a/versions/v2.13/modules/en/pages/installation-and-upgrade/best-practices/tuning-etcd-for-large-installs.adoc
+++ b/versions/v2.13/modules/en/pages/installation-and-upgrade/best-practices/tuning-etcd-for-large-installs.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2026-07-14
+:revdate: 2026-08-03
 :page-revdate: {revdate}
 :community-path: how-to-guides/advanced-user-guides/tune-etcd-for-large-installs.adoc 
 :product-path: installation-and-upgrade/best-practices/tuning-etcd-for-large-installs.adoc
@@ -15,7 +15,7 @@ endif::[]
 
 When Rancher is used to manage {xref-install-reqs}[a large infrastructure] it is recommended to increase the default keyspace for etcd from the default 2 GB. The maximum setting is 8 GB and the host should have enough RAM to keep the entire dataset in memory. When increasing this value you should also increase the size of the host. The keyspace size can also be adjusted in smaller installations if you anticipate a high rate of change of pods during the garbage collection interval.
 
-The etcd data set is automatically cleaned up on a five-minute interval by Kubernetes. There are situations, e.g. deployment thrashing, where enough events could be written to etcd and deleted before garbage collection occurs and cleans things up causing the keyspace to fill up. If you see `mvcc: database space exceeded` errors, in the etcd logs or Kubernetes API server logs, you should consider increasing the keyspace size. This can be accomplished by setting the https://etcd.io/docs/v3.5/op-guide/maintenance/#space-quota[quota-backend-bytes] setting on the etcd servers.
+The etcd data set is automatically cleaned up on a five-minute interval by Kubernetes. There are situations, e.g. deployment thrashing, where enough events could be written to etcd and deleted before garbage collection occurs and cleans things up causing the keyspace to fill up. If you see `mvcc: database space exceeded` errors, in the etcd logs or Kubernetes API server logs, you should consider increasing the keyspace size. This can be accomplished by setting the https://etcd.io/docs/latest/op-guide/maintenance/#space-quota[quota-backend-bytes] setting on the etcd servers.
 
 == Example: This Snippet of the RKE2/K3s config.yaml file Increases the Keyspace Size to 5GB
 
@@ -29,17 +29,38 @@ etcd-arg:
 
 == Scaling etcd Disk Performance
 
-You can follow the recommendations from https://etcd.io/docs/v3.5/tuning/#disk[the etcd docs] on how to tune the disk priority on the host.
+For RKE2 and K3s-based Rancher management clusters, achieving optimal etcd performance and stability is paramount. It is highly recommended to mount a dedicated, high-performance flash device (SSD or NVMe) at the database path. This volume should be formatted with a robust, high-performance filesystem such as XFS. This configuration isolates critical etcd I/O operations from the host operating system and any other applications, which is a foundational best practice for preventing I/O contention and ensuring low-latency writes.
 
-Additionally, to reduce IO contention on the disks for etcd, you can use a dedicated device for the data and wal directory. Based on etcd best practices, mirroring RAID configurations are unnecessary because etcd replicates data between the nodes in the cluster. You can use striping RAID configurations to increase available IOPS.
+* For RKE2, the path is `/var/lib/rancher/rke2/server/db`.
+* For K3s, the path is `/var/lib/rancher/k3s/server/db`.
 
-To implement this solution in an RKE2/K3s cluster, the `/var/lib/etcd/data` and `/var/lib/etcd/wal` directories will need to have disks mounted and formatted on the underlying host. In the `extra_args` directive of the `etcd` service, you must include the `wal_dir` directory. Without specifying the `wal_dir`, etcd process will try to manipulate the underlying `wal` mount with insufficient permissions.
+[WARNING]
+====
+Do not attempt to change the default etcd data directory using etcd-arg or other configuration flags. RKE2 and K3s require the etcd database to remain at its default location. Modifying this path will break built-in cluster operations, such as snapshots and restores. To utilize dedicated storage, you must mount the device directly to the default paths listed above.
+====
+
+Additionally, you can follow the recommendations from https://etcd.io/docs/latest/tuning/#disk[the etcd docs] on how to tune the disk priority on the host.
+
+=== Advanced WAL Separation
+
+Based on etcd best practices, mirroring RAID configurations are unnecessary because etcd replicates data between the nodes in the cluster. You can use striping RAID configurations to increase available IOPS.
+
+If you are using dedicated devices to separate the data and `wal` directories, you must mount your `wal` disk to the default `wal` path and explicitly declare the `wal-dir` in your configuration file using that default path (as shown in the examples below). Without specifying it, the etcd process will try to manipulate the underlying `wal` mount with insufficient permissions.
 
 [,yaml]
-.RKE2/K3s config.yaml
+.RKE2 config.yaml
 [,shell]
 ----
 etcd-arg:
-  - "data-dir=/var/lib/etcd/data"
-  - "wal-dir=/var/lib/etcd/wal"
+  - "data-dir=/var/lib/rancher/rke2/server/db/etcd"
+  - "wal-dir=/var/lib/rancher/rke2/server/db/etcd/wal"
+----
+
+[,yaml]
+.K3s config.yaml
+[,shell]
+----
+etcd-arg:
+  - "data-dir=/var/lib/rancher/k3s/server/db/etcd"
+  - "wal-dir=/var/lib/rancher/k3s/server/db/etcd/wal"
 ----

--- a/versions/v2.14/modules/en/pages/installation-and-upgrade/best-practices/tuning-etcd-for-large-installs.adoc
+++ b/versions/v2.14/modules/en/pages/installation-and-upgrade/best-practices/tuning-etcd-for-large-installs.adoc
@@ -1,6 +1,6 @@
 = Tuning etcd for Large Installations
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-07-14
+:revdate: 2026-08-03
 :page-revdate: {revdate}
 :community-path: how-to-guides/advanced-user-guides/tune-etcd-for-large-installs.adoc 
 :product-path: installation-and-upgrade/best-practices/tuning-etcd-for-large-installs.adoc
@@ -13,7 +13,7 @@ endif::[]
 
 When Rancher is used to manage {xref-install-reqs}[a large infrastructure] it is recommended to increase the default keyspace for etcd from the default 2 GB. The maximum setting is 8 GB and the host should have enough RAM to keep the entire dataset in memory. When increasing this value you should also increase the size of the host. The keyspace size can also be adjusted in smaller installations if you anticipate a high rate of change of pods during the garbage collection interval.
 
-The etcd data set is automatically cleaned up on a five-minute interval by Kubernetes. There are situations, e.g. deployment thrashing, where enough events could be written to etcd and deleted before garbage collection occurs and cleans things up causing the keyspace to fill up. If you see `mvcc: database space exceeded` errors, in the etcd logs or Kubernetes API server logs, you should consider increasing the keyspace size. This can be accomplished by setting the https://etcd.io/docs/v3.5/op-guide/maintenance/#space-quota[quota-backend-bytes] setting on the etcd servers.
+The etcd data set is automatically cleaned up on a five-minute interval by Kubernetes. There are situations, e.g. deployment thrashing, where enough events could be written to etcd and deleted before garbage collection occurs and cleans things up causing the keyspace to fill up. If you see `mvcc: database space exceeded` errors, in the etcd logs or Kubernetes API server logs, you should consider increasing the keyspace size. This can be accomplished by setting the https://etcd.io/docs/latest/op-guide/maintenance/#space-quota[quota-backend-bytes] setting on the etcd servers.
 
 [#_example_this_snippet_of_the_rke2_k3s_config_yaml_file_increases_the_keyspace_size_to_5gb]
 == Example: This Snippet of the RKE2/K3s config.yaml file Increases the Keyspace Size to 5GB
@@ -29,17 +29,38 @@ etcd-arg:
 [#_scaling_etcd_disk_performance]
 == Scaling etcd Disk Performance
 
-You can follow the recommendations from https://etcd.io/docs/v3.5/tuning/#disk[the etcd docs] on how to tune the disk priority on the host.
+For RKE2 and K3s-based Rancher management clusters, achieving optimal etcd performance and stability is paramount. It is highly recommended to mount a dedicated, high-performance flash device (SSD or NVMe) at the database path. This volume should be formatted with a robust, high-performance filesystem such as XFS. This configuration isolates critical etcd I/O operations from the host operating system and any other applications, which is a foundational best practice for preventing I/O contention and ensuring low-latency writes.
 
-Additionally, to reduce IO contention on the disks for etcd, you can use a dedicated device for the data and wal directory. Based on etcd best practices, mirroring RAID configurations are unnecessary because etcd replicates data between the nodes in the cluster. You can use striping RAID configurations to increase available IOPS.
+* For RKE2, the path is `/var/lib/rancher/rke2/server/db`.
+* For K3s, the path is `/var/lib/rancher/k3s/server/db`.
 
-To implement this solution in an RKE2/K3s cluster, the `/var/lib/etcd/data` and `/var/lib/etcd/wal` directories will need to have disks mounted and formatted on the underlying host. In the `extra_args` directive of the `etcd` service, you must include the `wal_dir` directory. Without specifying the `wal_dir`, etcd process will try to manipulate the underlying `wal` mount with insufficient permissions.
+[WARNING]
+====
+Do not attempt to change the default etcd data directory using etcd-arg or other configuration flags. RKE2 and K3s require the etcd database to remain at its default location. Modifying this path will break built-in cluster operations, such as snapshots and restores. To utilize dedicated storage, you must mount the device directly to the default paths listed above.
+====
+
+Additionally, you can follow the recommendations from https://etcd.io/docs/latest/tuning/#disk[the etcd docs] on how to tune the disk priority on the host.
+
+=== Advanced WAL Separation
+
+Based on etcd best practices, mirroring RAID configurations are unnecessary because etcd replicates data between the nodes in the cluster. You can use striping RAID configurations to increase available IOPS.
+
+If you are using dedicated devices to separate the data and `wal` directories, you must mount your `wal` disk to the default `wal` path and explicitly declare the `wal-dir` in your configuration file using that default path (as shown in the examples below). Without specifying it, the etcd process will try to manipulate the underlying `wal` mount with insufficient permissions.
 
 [,yaml]
-.RKE2/K3s config.yaml
+.RKE2 config.yaml
 [,shell]
 ----
 etcd-arg:
-  - "data-dir=/var/lib/etcd/data"
-  - "wal-dir=/var/lib/etcd/wal"
+  - "data-dir=/var/lib/rancher/rke2/server/db/etcd"
+  - "wal-dir=/var/lib/rancher/rke2/server/db/etcd/wal"
+----
+
+[,yaml]
+.K3s config.yaml
+[,shell]
+----
+etcd-arg:
+  - "data-dir=/var/lib/rancher/k3s/server/db/etcd"
+  - "wal-dir=/var/lib/rancher/k3s/server/db/etcd/wal"
 ----

--- a/versions/v2.15/modules/en/pages/installation-and-upgrade/best-practices/tuning-etcd-for-large-installs.adoc
+++ b/versions/v2.15/modules/en/pages/installation-and-upgrade/best-practices/tuning-etcd-for-large-installs.adoc
@@ -1,6 +1,6 @@
 = Tuning etcd for Large Installations
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-07-14
+:revdate: 2026-08-03
 :page-revdate: {revdate}
 :community-path: how-to-guides/advanced-user-guides/tune-etcd-for-large-installs.adoc 
 :product-path: installation-and-upgrade/best-practices/tuning-etcd-for-large-installs.adoc
@@ -13,7 +13,7 @@ endif::[]
 
 When Rancher is used to manage {xref-install-reqs}[a large infrastructure] it is recommended to increase the default keyspace for etcd from the default 2 GB. The maximum setting is 8 GB and the host should have enough RAM to keep the entire dataset in memory. When increasing this value you should also increase the size of the host. The keyspace size can also be adjusted in smaller installations if you anticipate a high rate of change of pods during the garbage collection interval.
 
-The etcd data set is automatically cleaned up on a five-minute interval by Kubernetes. There are situations, e.g. deployment thrashing, where enough events could be written to etcd and deleted before garbage collection occurs and cleans things up causing the keyspace to fill up. If you see `mvcc: database space exceeded` errors, in the etcd logs or Kubernetes API server logs, you should consider increasing the keyspace size. This can be accomplished by setting the https://etcd.io/docs/v3.5/op-guide/maintenance/#space-quota[quota-backend-bytes] setting on the etcd servers.
+The etcd data set is automatically cleaned up on a five-minute interval by Kubernetes. There are situations, e.g. deployment thrashing, where enough events could be written to etcd and deleted before garbage collection occurs and cleans things up causing the keyspace to fill up. If you see `mvcc: database space exceeded` errors, in the etcd logs or Kubernetes API server logs, you should consider increasing the keyspace size. This can be accomplished by setting the https://etcd.io/docs/latest/op-guide/maintenance/#space-quota[quota-backend-bytes] setting on the etcd servers.
 
 [#_example_this_snippet_of_the_rke2_k3s_config_yaml_file_increases_the_keyspace_size_to_5gb]
 == Example: This Snippet of the RKE2/K3s config.yaml file Increases the Keyspace Size to 5GB
@@ -29,17 +29,38 @@ etcd-arg:
 [#_scaling_etcd_disk_performance]
 == Scaling etcd Disk Performance
 
-You can follow the recommendations from https://etcd.io/docs/v3.5/tuning/#disk[the etcd docs] on how to tune the disk priority on the host.
+For RKE2 and K3s-based Rancher management clusters, achieving optimal etcd performance and stability is paramount. It is highly recommended to mount a dedicated, high-performance flash device (SSD or NVMe) at the database path. This volume should be formatted with a robust, high-performance filesystem such as XFS. This configuration isolates critical etcd I/O operations from the host operating system and any other applications, which is a foundational best practice for preventing I/O contention and ensuring low-latency writes.
 
-Additionally, to reduce IO contention on the disks for etcd, you can use a dedicated device for the data and wal directory. Based on etcd best practices, mirroring RAID configurations are unnecessary because etcd replicates data between the nodes in the cluster. You can use striping RAID configurations to increase available IOPS.
+* For RKE2, the path is `/var/lib/rancher/rke2/server/db`.
+* For K3s, the path is `/var/lib/rancher/k3s/server/db`.
 
-To implement this solution in an RKE2/K3s cluster, the `/var/lib/etcd/data` and `/var/lib/etcd/wal` directories will need to have disks mounted and formatted on the underlying host. In the `extra_args` directive of the `etcd` service, you must include the `wal_dir` directory. Without specifying the `wal_dir`, etcd process will try to manipulate the underlying `wal` mount with insufficient permissions.
+[WARNING]
+====
+Do not attempt to change the default etcd data directory using etcd-arg or other configuration flags. RKE2 and K3s require the etcd database to remain at its default location. Modifying this path will break built-in cluster operations, such as snapshots and restores. To utilize dedicated storage, you must mount the device directly to the default paths listed above.
+====
+
+Additionally, you can follow the recommendations from https://etcd.io/docs/latest/tuning/#disk[the etcd docs] on how to tune the disk priority on the host.
+
+=== Advanced WAL Separation
+
+Based on etcd best practices, mirroring RAID configurations are unnecessary because etcd replicates data between the nodes in the cluster. You can use striping RAID configurations to increase available IOPS.
+
+If you are using dedicated devices to separate the data and `wal` directories, you must mount your `wal` disk to the default `wal` path and explicitly declare the `wal-dir` in your configuration file using that default path (as shown in the examples below). Without specifying it, the etcd process will try to manipulate the underlying `wal` mount with insufficient permissions.
 
 [,yaml]
-.RKE2/K3s config.yaml
+.RKE2 config.yaml
 [,shell]
 ----
 etcd-arg:
-  - "data-dir=/var/lib/etcd/data"
-  - "wal-dir=/var/lib/etcd/wal"
+  - "data-dir=/var/lib/rancher/rke2/server/db/etcd"
+  - "wal-dir=/var/lib/rancher/rke2/server/db/etcd/wal"
+----
+
+[,yaml]
+.K3s config.yaml
+[,shell]
+----
+etcd-arg:
+  - "data-dir=/var/lib/rancher/k3s/server/db/etcd"
+  - "wal-dir=/var/lib/rancher/k3s/server/db/etcd/wal"
 ----


### PR DESCRIPTION
 ### Description
Fixes: #342 and implements the warning to not change the default dir mentioned in rke2-docs https://github.com/rancher/rke2-docs/issues/244 

### Changes
From the GH issue, I did my best to relay the proposed wording while adjusting what was already in the doc. I also updated the data dirs to reflect RKE2 and K3s etcd db paths for version 2.12 (where rke1 is deprecated) to the latest version v2.15. Please provide feedback and I'll be happy to adjust. Thanks

### Stakeholders:
@moio: architecture
@pdaigle: PM
@brandond: SME
@kinarashah: architect of RKE1 removal
@snasovich: management contact