### PR TITLE
fix(docs): fix unescaped comma in Helm install-rancher-ha

### DIFF
--- a/versions/v2.15/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
+++ b/versions/v2.15/modules/en/pages/installation-and-upgrade/other-installation-methods/air-gapped/install-rancher-ha.adoc
@@ -490,7 +490,7 @@ helm install rancher ./rancher-<VERSION>.tgz \
   --set hostname=<RANCHER.YOURDOMAIN.COM> \
   --set systemDefaultRegistry=<REGISTRY.YOURDOMAIN.COM:PORT> \
   --set extraEnv[0].name=CATTLE_BASE_REGISTRY_PULL_SECRETS \
-  --set extraEnv[0].value='<SECRET1>,<SECRET2>' \
+  --set extraEnv[0].value='<SECRET1>\,<SECRET2>' \
   --set useBundledSystemChart=true
 ----
 


### PR DESCRIPTION
### Description
Fixes: https://github.com/rancher/rancher-docs/issues/2334

### Summary
Found this new example in versioned docs v2.15 where the set ENV command has a missing escaped comma.