### PR TITLE
Fix cluster capability partial for SRFA to match it's tracked counterpart

### DIFF
--- a/shared/modules/ROOT/partials/en/cluster-capabilities-updated-table-srfa.adoc
+++ b/shared/modules/ROOT/partials/en/cluster-capabilities-updated-table-srfa.adoc
@@ -13,7 +13,7 @@
 | ✓
 | ✓
 
-| xref:cluster-admin/manage-clusters/nodes-and-node-pools.adoc[Managing Nodes]
+| xref:cluster-admin/manage-clusters/nodes-and-machine-pools.adoc[Managing Nodes]
 | ✓
 | ✓
 


### PR DESCRIPTION
The counterpart being [shared/modules/ROOT/partials/en/cluster-capabilities-updated-table.adoc](https://github.com/rancher/rancher-product-docs/blob/main/shared/modules/ROOT/partials/en/cluster-capabilities-updated-table.adoc) (applicable to 2.12+) being updated in https://github.com/rancher/rancher-product-docs/pull/1023, but forgot about the SRFA version of the file.