### PR TITLE
Recommend 3-node cluster setup for Rancher installation

### DIFF
--- a/versions/v2.14/modules/en/pages/installation-and-upgrade/install-rancher.adoc
+++ b/versions/v2.14/modules/en/pages/installation-and-upgrade/install-rancher.adoc
@@ -54,6 +54,9 @@ Set up the Rancher server's local Kubernetes cluster.
 
 Rancher can be installed on any Kubernetes cluster. This cluster can use upstream Kubernetes, or it can use one of Rancher's Kubernetes distributions, or it can be a managed Kubernetes cluster from a provider such as Amazon EKS.
 
+For maximum uptime and stability, the cluster should be composed of 3 nodes, each with all roles (etcd, control plane, and worker).  See: [Tuning and Best Practices for SUSE Rancher Prime at Scale
+](https://documentation.suse.com/cloudnative/rancher-manager/v2.14/en/installation-and-upgrade/best-practices/tuning-rancher-at-scale.html) for more details
+
 For help setting up a Kubernetes cluster, we provide these tutorials:
 
 * *K3s:* For the tutorial to install a K3s Kubernetes cluster, refer to {xref-k3s-for-rancher}[this page.] For help setting up the infrastructure for a high-availability K3s cluster, refer to {xref-ha-k3s}[this page.]


### PR DESCRIPTION
Added recommendation for a 3-node cluster setup for maximum uptime and stability.