### PR TITLE
2.15 monitoring v2 deprecation notice

### DIFF
--- a/community-docs/v2.15/modules/ROOT/pages/how-to-guides/advanced-user-guides/monitoring-alerting-guides/index.adoc
+++ b/community-docs/v2.15/modules/ROOT/pages/how-to-guides/advanced-user-guides/monitoring-alerting-guides/index.adoc
@@ -2,10 +2,20 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2026-02-11
+:revdate: 2026-08-05
 :page-revdate: {revdate}
 :community-path: how-to-guides/advanced-user-guides/monitoring-alerting-guides/monitoring-alerting-guides
 :product-path:
+
+[CAUTION]
+.Deprecation Notice
+====
+Rancher Monitoring v2 is deprecated.
+
+New monitoring installations use the decoupled `rancher-monitoring-dashboards` chart.
+
+Rancher maintains the legacy `rancher-monitoring` chart to support existing deployments, but it does not receive new updates. Use the `rancher-monitoring-dashboards` chart for ongoing updates and support. Refer to the xref:integrations-in-rancher/monitoring-and-alerting/index.adoc#_migrating_from_rancher-monitoring_to_rancher_monitoring_dashboards[Migrating from `rancher-monitoring` to `rancher-monitoring-dashboards` guide] for more information on migrating to the new chart.
+====
 
 * xref:how-to-guides/advanced-user-guides/monitoring-alerting-guides/enable-monitoring.adoc[Enable monitoring]
 * xref:how-to-guides/advanced-user-guides/monitoring-alerting-guides/uninstall-monitoring.adoc[Uninstall monitoring]

--- a/community-docs/v2.15/modules/ROOT/pages/how-to-guides/advanced-user-guides/monitoring-alerting-guides/index.adoc
+++ b/community-docs/v2.15/modules/ROOT/pages/how-to-guides/advanced-user-guides/monitoring-alerting-guides/index.adoc
@@ -2,18 +2,12 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2026-08-05
+:revdate: 2026-08-06
 :page-revdate: {revdate}
 :community-path: how-to-guides/advanced-user-guides/monitoring-alerting-guides/monitoring-alerting-guides
 :product-path:
 
-[CAUTION]
-.Deprecation Notice
-====
-Rancher Monitoring v2 (`rancher-monitoring`) is deprecated and no longer receives updates. Rancher maintains the legacy chart only to support existing deployments. For new installations, ongoing updates, and support, use the decoupled `rancher-monitoring-dashboards` chart.
-
-For instructions on migrating, see xref:integrations-in-rancher/monitoring-and-alerting/index.adoc#_migrating_from_rancher-monitoring_to_rancher_monitoring_dashboards[Migrating from `rancher-monitoring` to `rancher-monitoring-dashboards`].
-====
+include::shared:ROOT:partial$en/deprecation-monitoring-v2.adoc[]
 
 * xref:how-to-guides/advanced-user-guides/monitoring-alerting-guides/enable-monitoring.adoc[Enable monitoring]
 * xref:how-to-guides/advanced-user-guides/monitoring-alerting-guides/uninstall-monitoring.adoc[Uninstall monitoring]

--- a/community-docs/v2.15/modules/ROOT/pages/how-to-guides/advanced-user-guides/monitoring-alerting-guides/index.adoc
+++ b/community-docs/v2.15/modules/ROOT/pages/how-to-guides/advanced-user-guides/monitoring-alerting-guides/index.adoc
@@ -10,11 +10,9 @@ endif::[]
 [CAUTION]
 .Deprecation Notice
 ====
-Rancher Monitoring v2 is deprecated.
+Rancher Monitoring v2 (`rancher-monitoring`) is deprecated and no longer receives updates. Rancher maintains the legacy chart only to support existing deployments. For new installations, ongoing updates, and support, use the decoupled `rancher-monitoring-dashboards` chart.
 
-New monitoring installations use the decoupled `rancher-monitoring-dashboards` chart.
-
-Rancher maintains the legacy `rancher-monitoring` chart to support existing deployments, but it does not receive new updates. Use the `rancher-monitoring-dashboards` chart for ongoing updates and support. Refer to the xref:integrations-in-rancher/monitoring-and-alerting/index.adoc#_migrating_from_rancher-monitoring_to_rancher_monitoring_dashboards[Migrating from `rancher-monitoring` to `rancher-monitoring-dashboards` guide] for more information on migrating to the new chart.
+For instructions on migrating, see xref:integrations-in-rancher/monitoring-and-alerting/index.adoc#_migrating_from_rancher-monitoring_to_rancher_monitoring_dashboards[Migrating from `rancher-monitoring` to `rancher-monitoring-dashboards`].
 ====
 
 * xref:how-to-guides/advanced-user-guides/monitoring-alerting-guides/enable-monitoring.adoc[Enable monitoring]

--- a/shared/modules/ROOT/partials/en/deprecation-monitoring-v2.adoc
+++ b/shared/modules/ROOT/partials/en/deprecation-monitoring-v2.adoc
@@ -1,0 +1,13 @@
+ifeval::["{build-type}" != "community"]
+:xref-monitoring-v2-configuration: xref:observability/monitoring-and-dashboards/monitoring-and-dashboards.adoc#_migrating_from_rancher-monitoring_to_rancher_monitoring_dashboards
+endif::[]
+ifeval::["{build-type}" == "community"]
+:xref-monitoring-v2-configuration: xref:integrations-in-rancher/monitoring-and-alerting/index.adoc#_migrating_from_rancher-monitoring_to_rancher_monitoring_dashboards
+endif::[]
+
+[CAUTION]
+.Deprecation Notice
+====
+Rancher Monitoring v2 (`rancher-monitoring`) is deprecated and no longer receives updates. Rancher maintains the legacy chart only to support existing deployments. For new installations, ongoing updates, and support, use the decoupled `rancher-monitoring-dashboards` chart.
+For instructions on migrating, see {xref-monitoring-v2-configuration}[Migrating from `rancher-monitoring` to `rancher-monitoring-dashboards`].
+====

--- a/shared/modules/ROOT/partials/zh/deprecation-monitoring-v2.adoc
+++ b/shared/modules/ROOT/partials/zh/deprecation-monitoring-v2.adoc
@@ -1,0 +1,13 @@
+ifeval::["{build-type}" != "community"]
+:xref-monitoring-v2-configuration: xref:observability/monitoring-and-dashboards/monitoring-and-dashboards.adoc#_migrating_from_rancher-monitoring_to_rancher_monitoring_dashboards
+endif::[]
+ifeval::["{build-type}" == "community"]
+:xref-monitoring-v2-configuration: xref:integrations-in-rancher/monitoring-and-alerting/index.adoc#_migrating_from_rancher-monitoring_to_rancher_monitoring_dashboards
+endif::[]
+
+[CAUTION]
+.Deprecation Notice
+====
+Rancher Monitoring v2 (`rancher-monitoring`) is deprecated and no longer receives updates. Rancher maintains the legacy chart only to support existing deployments. For new installations, ongoing updates, and support, use the decoupled `rancher-monitoring-dashboards` chart.
+For instructions on migrating, see {xref-monitoring-v2-configuration}[Migrating from `rancher-monitoring` to `rancher-monitoring-dashboards`].
+====

--- a/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/best-practices.adoc
+++ b/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/best-practices.adoc
@@ -1,6 +1,6 @@
 = Monitoring Best Practices
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-07-14
+:revdate: 2026-08-06
 :page-revdate: {revdate}
 :community-path: reference-guides/best-practices/rancher-managed-clusters/monitoring-best-practices.adoc 
 :product-path: observability/monitoring-and-dashboards/best-practices.adoc
@@ -14,6 +14,8 @@ ifeval::["{build-type}" == "community"]
 :xref-monitoring-and-dashboards: xref:integrations-in-rancher/monitoring-and-alerting/index.adoc
 :xref-compliance-scans-howto: xref:how-to-guides/advanced-user-guides/compliance-scan-guides/index.adoc
 endif::[]
+
+include::shared:ROOT:partial$en/deprecation-monitoring-v2.adoc[]
 
 Configuring sensible monitoring and alerting rules is vital for running any production workloads securely and reliably. This is not different when using Kubernetes and Rancher. Fortunately the integrated monitoring and alerting functionality makes this whole process a lot easier.
 

--- a/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/built-in-dashboards.adoc
+++ b/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/built-in-dashboards.adoc
@@ -1,6 +1,6 @@
 = Built-in Dashboards
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2025-08-05
+:revdate: 2026-08-06
 :page-revdate: {revdate}
 :community-path: integrations-in-rancher/monitoring-and-alerting/built-in-dashboards.adoc 
 :product-path: observability/monitoring-and-dashboards/built-in-dashboards.adoc
@@ -16,6 +16,8 @@ ifeval::["{build-type}" == "community"]
 :xref-prometheusrules: xref:how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/advanced-configuration/prometheusrules.adoc
 :xref-create-persistent-grafana-dashboard: xref:how-to-guides/advanced-user-guides/monitoring-alerting-guides/create-persistent-grafana-dashboard.adoc
 endif::[]
+
+include::shared:ROOT:partial$en/deprecation-monitoring-v2.adoc[]
 
 [#_grafana_ui]
 == Grafana UI

--- a/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/configuration/advanced/advanced.adoc
+++ b/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/configuration/advanced/advanced.adoc
@@ -1,6 +1,6 @@
 = Advanced Configuration
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2025-08-05
+:revdate: 2026-08-06
 :page-revdate: {revdate}
 :community-path: how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/advanced-configuration/index.adoc 
 :product-path: observability/monitoring-and-dashboards/configuration/advanced/advanced.adoc
@@ -14,6 +14,8 @@ ifeval::["{build-type}" == "community"]
 :xref-prometheusrules: xref:how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/advanced-configuration/prometheusrules.adoc
 :xref-prometheus: xref:how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/advanced-configuration/prometheus.adoc
 endif::[]
+
+include::shared:ROOT:partial$en/deprecation-monitoring-v2.adoc[]
 
 [#_alertmanager]
 == Alertmanager

--- a/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/configuration/advanced/alertmanager.adoc
+++ b/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/configuration/advanced/alertmanager.adoc
@@ -1,6 +1,6 @@
 = Alertmanager Configuration
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2025-08-05
+:revdate: 2026-08-06
 :page-revdate: {revdate}
 :community-path: how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/advanced-configuration/alertmanager.adoc 
 :product-path: observability/monitoring-and-dashboards/configuration/advanced/alertmanager.adoc
@@ -10,6 +10,8 @@ endif::[]
 ifeval::["{build-type}" == "community"]
 :xref-how-monitoring-works: xref:integrations-in-rancher/monitoring-and-alerting/how-monitoring-works.adoc
 endif::[]
+
+include::shared:ROOT:partial$en/deprecation-monitoring-v2.adoc[]
 
 It is usually not necessary to directly edit the Alertmanager custom resource. For most use cases, you will only need to edit the Receivers and Routes to configure notifications.
 

--- a/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/configuration/advanced/prometheus.adoc
+++ b/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/configuration/advanced/prometheus.adoc
@@ -1,6 +1,6 @@
 = Prometheus Configuration
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2025-08-05
+:revdate: 2026-08-06
 :page-revdate: {revdate}
 :community-path: how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/advanced-configuration/prometheus.adoc 
 :product-path: observability/monitoring-and-dashboards/configuration/advanced/prometheus.adoc
@@ -10,6 +10,8 @@ endif::[]
 ifeval::["{build-type}" == "community"]
 :xref-how-monitoring-works: xref:integrations-in-rancher/monitoring-and-alerting/how-monitoring-works.adoc
 endif::[]
+
+include::shared:ROOT:partial$en/deprecation-monitoring-v2.adoc[]
 
 It is usually not necessary to directly edit the Prometheus custom resource because the monitoring application automatically updates it based on changes to ServiceMonitors and PodMonitors.
 

--- a/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/configuration/advanced/prometheusrules.adoc
+++ b/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/configuration/advanced/prometheusrules.adoc
@@ -1,6 +1,6 @@
 = Configuring PrometheusRules
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2025-08-05
+:revdate: 2026-08-06
 :page-revdate: {revdate}
 :community-path: how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/advanced-configuration/prometheusrules.adoc 
 :product-path: observability/monitoring-and-dashboards/configuration/advanced/prometheusrules.adoc
@@ -13,6 +13,8 @@ ifeval::["{build-type}" == "community"]
 :xref-how-monitoring-works: xref:integrations-in-rancher/monitoring-and-alerting/how-monitoring-works.adoc
 :xref-promql-expressions: xref:integrations-in-rancher/monitoring-and-alerting/promql-expressions.adoc
 endif::[]
+
+include::shared:ROOT:partial$en/deprecation-monitoring-v2.adoc[]
 
 A PrometheusRule defines a group of Prometheus alerting and/or recording rules.
 

--- a/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/configuration/configuration.adoc
+++ b/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/configuration/configuration.adoc
@@ -1,11 +1,10 @@
 = Monitoring Configuration Guides
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-08-05
+:revdate: 2026-08-06
 :page-revdate: {revdate}
 :community-path: how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/index.adoc 
 :product-path: observability/monitoring-and-dashboards/configuration/configuration.adoc
 ifeval::["{build-type}" != "community"]
-:xref-monitoring-v2-configuration: xref:observability/monitoring-and-dashboards/monitoring-and-dashboards.adoc#_migrating_from_rancher-monitoring_to_rancher_monitoring_dashboards
 :xref-receivers: xref:observability/monitoring-and-dashboards/configuration/receivers.adoc
 :xref-configure-alertmanager: xref:observability/monitoring-and-dashboards/configuration/advanced/alertmanager.adoc
 :xref-prometheus: xref:observability/monitoring-and-dashboards/configuration/advanced/prometheus.adoc
@@ -14,7 +13,6 @@ ifeval::["{build-type}" != "community"]
 :xref-helm-chart-options: xref:observability/monitoring-and-dashboards/configuration/helm-chart-options.adoc
 endif::[]
 ifeval::["{build-type}" == "community"]
-:xref-monitoring-v2-configuration: xref:integrations-in-rancher/monitoring-and-alerting/index.adoc#_migrating_from_rancher-monitoring_to_rancher_monitoring_dashboards
 :xref-receivers: xref:reference-guides/monitoring-v2-configuration/receivers.adoc
 :xref-configure-alertmanager: xref:how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/advanced-configuration/alertmanager.adoc
 :xref-prometheus: xref:how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/advanced-configuration/prometheus.adoc
@@ -23,13 +21,7 @@ ifeval::["{build-type}" == "community"]
 :xref-helm-chart-options: xref:reference-guides/monitoring-v2-configuration/helm-chart-options.adoc
 endif::[]
 
-[CAUTION]
-.Deprecation Notice
-====
-Rancher Monitoring v2 (`rancher-monitoring`) is deprecated and no longer receives updates. Rancher maintains the legacy chart only to support existing deployments. For new installations, ongoing updates, and support, use the decoupled `rancher-monitoring-dashboards` chart.
-
-For instructions on migrating, see {xref-monitoring-v2-configuration}[Migrating from `rancher-monitoring` to `rancher-monitoring-dashboards`].
-====
+include::shared:ROOT:partial$en/deprecation-monitoring-v2.adoc[]
 
 This page captures some of the most important options for configuring Monitoring v2 in the Rancher UI.
 

--- a/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/configuration/configuration.adoc
+++ b/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/configuration/configuration.adoc
@@ -23,7 +23,6 @@ ifeval::["{build-type}" == "community"]
 :xref-helm-chart-options: xref:reference-guides/monitoring-v2-configuration/helm-chart-options.adoc
 endif::[]
 
-ifeval::["{build-type}" == "community"]
 [CAUTION]
 .Deprecation Notice
 ====
@@ -31,7 +30,6 @@ Rancher Monitoring v2 (`rancher-monitoring`) is deprecated and no longer receive
 
 For instructions on migrating, see {xref-monitoring-v2-configuration}[Migrating from `rancher-monitoring` to `rancher-monitoring-dashboards`].
 ====
-endif::[]
 
 This page captures some of the most important options for configuring Monitoring v2 in the Rancher UI.
 

--- a/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/configuration/configuration.adoc
+++ b/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/configuration/configuration.adoc
@@ -1,10 +1,11 @@
 = Monitoring Configuration Guides
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2025-08-05
+:revdate: 2026-08-05
 :page-revdate: {revdate}
 :community-path: how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/index.adoc 
 :product-path: observability/monitoring-and-dashboards/configuration/configuration.adoc
 ifeval::["{build-type}" != "community"]
+:xref-monitoring-v2-configuration: xref:observability/monitoring-and-dashboards/monitoring-and-dashboards.adoc#_migrating_from_rancher-monitoring_to_rancher_monitoring_dashboards
 :xref-receivers: xref:observability/monitoring-and-dashboards/configuration/receivers.adoc
 :xref-configure-alertmanager: xref:observability/monitoring-and-dashboards/configuration/advanced/alertmanager.adoc
 :xref-prometheus: xref:observability/monitoring-and-dashboards/configuration/advanced/prometheus.adoc
@@ -13,6 +14,7 @@ ifeval::["{build-type}" != "community"]
 :xref-helm-chart-options: xref:observability/monitoring-and-dashboards/configuration/helm-chart-options.adoc
 endif::[]
 ifeval::["{build-type}" == "community"]
+:xref-monitoring-v2-configuration: xref:integrations-in-rancher/monitoring-and-alerting/index.adoc#_migrating_from_rancher-monitoring_to_rancher_monitoring_dashboards
 :xref-receivers: xref:reference-guides/monitoring-v2-configuration/receivers.adoc
 :xref-configure-alertmanager: xref:how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/advanced-configuration/alertmanager.adoc
 :xref-prometheus: xref:how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/advanced-configuration/prometheus.adoc
@@ -21,7 +23,19 @@ ifeval::["{build-type}" == "community"]
 :xref-helm-chart-options: xref:reference-guides/monitoring-v2-configuration/helm-chart-options.adoc
 endif::[]
 
-This page captures some of the most important options for configuring Monitoring V2 in the Rancher UI.
+ifeval::["{build-type}" == "community"]
+[CAUTION]
+.Deprecation Notice
+====
+Rancher Monitoring v2 is deprecated.
+
+New monitoring installations use the decoupled `rancher-monitoring-dashboards` chart.
+
+Rancher maintains the legacy `rancher-monitoring` chart to support existing deployments, but it does not receive new updates. Use the `rancher-monitoring-dashboards` chart for ongoing updates and support. Refer to the {xref-monitoring-v2-configuration}[Migrating from `rancher-monitoring` to `rancher-monitoring-dashboards` guide] for more information on migrating to the new chart.
+====
+endif::[]
+
+This page captures some of the most important options for configuring Monitoring v2 in the Rancher UI.
 
 For information on configuring custom scrape targets and rules for Prometheus, please refer to the upstream documentation for the https://github.com/prometheus-operator/prometheus-operator[Prometheus Operator.] Some of the most important custom resources are explained in the Prometheus Operator https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/getting-started/design.md[design documentation.] The Prometheus Operator documentation can help also you set up RBAC, Thanos, or custom configuration.
 

--- a/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/configuration/configuration.adoc
+++ b/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/configuration/configuration.adoc
@@ -27,11 +27,9 @@ ifeval::["{build-type}" == "community"]
 [CAUTION]
 .Deprecation Notice
 ====
-Rancher Monitoring v2 is deprecated.
+Rancher Monitoring v2 (`rancher-monitoring`) is deprecated and no longer receives updates. Rancher maintains the legacy chart only to support existing deployments. For new installations, ongoing updates, and support, use the decoupled `rancher-monitoring-dashboards` chart.
 
-New monitoring installations use the decoupled `rancher-monitoring-dashboards` chart.
-
-Rancher maintains the legacy `rancher-monitoring` chart to support existing deployments, but it does not receive new updates. Use the `rancher-monitoring-dashboards` chart for ongoing updates and support. Refer to the {xref-monitoring-v2-configuration}[Migrating from `rancher-monitoring` to `rancher-monitoring-dashboards` guide] for more information on migrating to the new chart.
+For instructions on migrating, see {xref-monitoring-v2-configuration}[Migrating from `rancher-monitoring` to `rancher-monitoring-dashboards`].
 ====
 endif::[]
 

--- a/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/configuration/debug-high-memory-usage.adoc
+++ b/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/configuration/debug-high-memory-usage.adoc
@@ -1,9 +1,11 @@
 = Debugging High Memory Usage
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2025-08-05
+:revdate: 2026-08-06
 :page-revdate: {revdate}
 :community-path: how-to-guides/advanced-user-guides/monitoring-alerting-guides/debug-high-memory-usage.adoc 
 :product-path: observability/monitoring-and-dashboards/configuration/debug-high-memory-usage.adoc
+
+include::shared:ROOT:partial$en/deprecation-monitoring-v2.adoc[]
 
 Every time series in Prometheus is uniquely identified by its https://prometheus.io/docs/practices/naming/#metric-names[metric name] and optional key-value pairs called https://prometheus.io/docs/practices/naming/#labels[labels.]
 

--- a/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/configuration/examples.adoc
+++ b/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/configuration/examples.adoc
@@ -1,9 +1,11 @@
 = Monitoring Configuration Examples
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2025-08-05
+:revdate: 2026-08-06
 :page-revdate: {revdate}
 :community-path: reference-guides/monitoring-v2-configuration/examples.adoc 
 :product-path: observability/monitoring-and-dashboards/configuration/examples.adoc
+
+include::shared:ROOT:partial$en/deprecation-monitoring-v2.adoc[]
 
 [#_servicemonitor]
 == ServiceMonitor

--- a/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/configuration/helm-chart-options.adoc
+++ b/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/configuration/helm-chart-options.adoc
@@ -1,6 +1,6 @@
 = Helm Chart Options
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-07-14
+:revdate: 2026-08-06
 :page-revdate: {revdate}
 :community-path: reference-guides/monitoring-v2-configuration/helm-chart-options.adoc 
 :product-path: observability/monitoring-and-dashboards/configuration/helm-chart-options.adoc
@@ -13,6 +13,8 @@ ifeval::["{build-type}" == "community"]
 :xref-configure-alertmanager: xref:how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/advanced-configuration/alertmanager.adoc
 :xref-selectors-and-scrape-configurations: xref:integrations-in-rancher/istio/configuration-options/selectors-and-scrape-configurations.adoc
 endif::[]
+
+include::shared:ROOT:partial$en/deprecation-monitoring-v2.adoc[]
 
 [#_configuring_resource_limits_and_requests]
 == Configuring Resource Limits and Requests

--- a/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/configuration/receivers.adoc
+++ b/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/configuration/receivers.adoc
@@ -1,6 +1,6 @@
 = Receiver Configuration
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2025-08-18
+:revdate: 2026-08-06
 :page-revdate: {revdate}
 :community-path: reference-guides/monitoring-v2-configuration/receivers.adoc 
 :product-path: observability/monitoring-and-dashboards/configuration/receivers.adoc
@@ -13,6 +13,8 @@ ifeval::["{build-type}" == "community"]
 :xref-how-monitoring-works: xref:integrations-in-rancher/monitoring-and-alerting/how-monitoring-works.adoc
 :xref-compliance-enable-alerting: xref:how-to-guides/advanced-user-guides/compliance-scan-guides/enable-alerting-for-rancher-compliance.adoc
 endif::[]
+
+include::shared:ROOT:partial$en/deprecation-monitoring-v2.adoc[]
 
 The https://prometheus.io/docs/alerting/latest/configuration/#configuration-file[Alertmanager Config] Secret contains the configuration of an Alertmanager instance that sends out notifications based on alerts it receives from Prometheus.
 

--- a/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/configuration/routes.adoc
+++ b/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/configuration/routes.adoc
@@ -1,6 +1,6 @@
 = Route Configuration
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2025-08-05
+:revdate: 2026-08-06
 :page-revdate: {revdate}
 :community-path: reference-guides/monitoring-v2-configuration/routes.adoc 
 :product-path: observability/monitoring-and-dashboards/configuration/routes.adoc
@@ -12,6 +12,8 @@ ifeval::["{build-type}" == "community"]
 :xref-how-monitoring-works: xref:integrations-in-rancher/monitoring-and-alerting/how-monitoring-works.adoc
 :xref-receivers: xref:reference-guides/monitoring-v2-configuration/receivers.adoc
 endif::[]
+
+include::shared:ROOT:partial$en/deprecation-monitoring-v2.adoc[]
 
 The route configuration is the section of the Alertmanager custom resource that controls how the alerts fired by Prometheus are grouped and filtered before they reach the receiver.
 

--- a/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/configuration/servicemonitors-and-podmonitors.adoc
+++ b/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/configuration/servicemonitors-and-podmonitors.adoc
@@ -1,6 +1,6 @@
 = ServiceMonitor and PodMonitor Configuration
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2025-08-05
+:revdate: 2026-08-06
 :page-revdate: {revdate}
 :community-path: reference-guides/monitoring-v2-configuration/servicemonitors-and-podmonitors.adoc 
 :product-path: observability/monitoring-and-dashboards/configuration/servicemonitors-and-podmonitors.adoc
@@ -10,6 +10,8 @@ endif::[]
 ifeval::["{build-type}" == "community"]
 :xref-how-monitoring-works: xref:integrations-in-rancher/monitoring-and-alerting/how-monitoring-works.adoc
 endif::[]
+
+include::shared:ROOT:partial$en/deprecation-monitoring-v2.adoc[]
 
 ServiceMonitors and PodMonitors are both pseudo-CRDs that map the scrape configuration of the Prometheus custom resource.
 

--- a/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/customizing-dashboard/create-persistent-grafana-dashboard.adoc
+++ b/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/customizing-dashboard/create-persistent-grafana-dashboard.adoc
@@ -1,6 +1,6 @@
 = Persistent Grafana Dashboards
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-07-14
+:revdate: 2026-08-06
 :page-revdate: {revdate}
 :community-path: how-to-guides/advanced-user-guides/monitoring-alerting-guides/create-persistent-grafana-dashboard.adoc 
 :product-path: observability/monitoring-and-dashboards/customizing-dashboard/create-persistent-grafana-dashboard.adoc
@@ -10,6 +10,8 @@ endif::[]
 ifeval::["{build-type}" == "community"]
 :xref-rancher-monitoring-rbac: xref:integrations-in-rancher/monitoring-and-alerting/rbac-for-monitoring.adoc
 endif::[]
+
+include::shared:ROOT:partial$en/deprecation-monitoring-v2.adoc[]
 
 To allow the Grafana dashboard to persist after the Grafana instance restarts, add the dashboard configuration JSON into a ConfigMap. ConfigMaps also allow the dashboards to be deployed with a GitOps or CD based approach. This allows the dashboard to be put under version control.
 

--- a/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/customizing-dashboard/customize-grafana-dashboard.adoc
+++ b/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/customizing-dashboard/customize-grafana-dashboard.adoc
@@ -1,6 +1,6 @@
 = Customizing Grafana Dashboards
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-07-14
+:revdate: 2026-08-06
 :page-revdate: {revdate}
 :community-path: how-to-guides/advanced-user-guides/monitoring-alerting-guides/customize-grafana-dashboard.adoc 
 :product-path: observability/monitoring-and-dashboards/customizing-dashboard/customize-grafana-dashboard.adoc
@@ -11,6 +11,8 @@ endif::[]
 ifeval::["{build-type}" == "community"]
 :xref-rancher-monitoring-rbac: xref:integrations-in-rancher/monitoring-and-alerting/rbac-for-monitoring.adoc
 endif::[]
+
+include::shared:ROOT:partial$en/deprecation-monitoring-v2.adoc[]
 
 In this section, you'll learn how to customize the Grafana dashboard to show metrics that apply to a certain container.
 

--- a/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/enable-monitoring.adoc
+++ b/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/enable-monitoring.adoc
@@ -1,6 +1,6 @@
 = Enable Monitoring
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2025-09-29
+:revdate: 2026-08-06
 :page-revdate: {revdate}
 :community-path: how-to-guides/advanced-user-guides/monitoring-alerting-guides/enable-monitoring.adoc 
 :product-path: observability/monitoring-and-dashboards/enable-monitoring.adoc
@@ -21,6 +21,8 @@ ifeval::["{build-type}" == "community"]
 :xref-receivers: xref:reference-guides/monitoring-v2-configuration/receivers.adoc
 :xref-how-monitoring-works: xref:integrations-in-rancher/monitoring-and-alerting/how-monitoring-works.adoc
 endif::[]
+
+include::shared:ROOT:partial$en/deprecation-monitoring-v2.adoc[]
 
 As an {xref-global-permissions}[administrator] or {xref-cluster-project-roles}#_cluster_roles[cluster owner], you can configure Rancher to deploy Prometheus to monitor your Kubernetes cluster.
 

--- a/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/how-monitoring-works.adoc
+++ b/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/how-monitoring-works.adoc
@@ -1,6 +1,6 @@
 = How Monitoring Works
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-03-23
+:revdate: 2026-08-06
 :page-revdate: {revdate}
 :community-path: integrations-in-rancher/monitoring-and-alerting/how-monitoring-works.adoc 
 :product-path: observability/monitoring-and-dashboards/how-monitoring-works.adoc
@@ -10,6 +10,8 @@ endif::[]
 ifeval::["{build-type}" == "community"]
 :xref-receivers: xref:reference-guides/monitoring-v2-configuration/receivers.adoc
 endif::[]
+
+include::shared:ROOT:partial$en/deprecation-monitoring-v2.adoc[]
 
 [#_1_architecture_overview]
 == 1. Architecture Overview

--- a/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/prometheus-federator/customize-grafana-dashboards.adoc
+++ b/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/prometheus-federator/customize-grafana-dashboards.adoc
@@ -1,6 +1,6 @@
 = Customizing Grafana Dashboards
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2025-08-05
+:revdate: 2026-08-06
 :page-revdate: {revdate}
 :community-path: how-to-guides/advanced-user-guides/monitoring-alerting-guides/prometheus-federator-guides/customize-grafana-dashboards.adoc 
 :product-path: observability/monitoring-and-dashboards/prometheus-federator/customize-grafana-dashboards.adoc
@@ -10,6 +10,8 @@ endif::[]
 ifeval::["{build-type}" == "community"]
 :xref-customize-grafana-dashboard: xref:how-to-guides/advanced-user-guides/monitoring-alerting-guides/customize-grafana-dashboard.adoc
 endif::[]
+
+include::shared:ROOT:partial$en/deprecation-monitoring-v2.adoc[]
 
 Grafana dashboards are customized the same way whether it's for rancher-monitoring or for Prometheus Federator.
 

--- a/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/prometheus-federator/enable-prometheus-federator.adoc
+++ b/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/prometheus-federator/enable-prometheus-federator.adoc
@@ -1,6 +1,6 @@
 = Enable Prometheus Federator
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-07-14
+:revdate: 2026-08-06
 :page-revdate: {revdate}
 :community-path: how-to-guides/advanced-user-guides/monitoring-alerting-guides/prometheus-federator-guides/enable-prometheus-federator.adoc 
 :product-path: observability/monitoring-and-dashboards/prometheus-federator/enable-prometheus-federator.adoc
@@ -13,6 +13,8 @@ ifeval::["{build-type}" == "community"]
 :xref-monitoring-and-dashboards: xref:integrations-in-rancher/monitoring-and-alerting/index.adoc
 :xref-enable-monitoring: xref:how-to-guides/advanced-user-guides/monitoring-alerting-guides/enable-monitoring.adoc
 endif::[]
+
+include::shared:ROOT:partial$en/deprecation-monitoring-v2.adoc[]
 
 [#_requirements]
 == Requirements

--- a/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/prometheus-federator/install-project-monitors.adoc
+++ b/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/prometheus-federator/install-project-monitors.adoc
@@ -1,10 +1,12 @@
 = Installing Project Monitors
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2025-08-05
+:revdate: 2026-08-06
 :page-revdate: {revdate}
 :community-path: how-to-guides/advanced-user-guides/monitoring-alerting-guides/prometheus-federator-guides/project-monitors.adoc 
 :product-path: observability/monitoring-and-dashboards/prometheus-federator/install-project-monitors.adoc
 :experimental:
+
+include::shared:ROOT:partial$en/deprecation-monitoring-v2.adoc[]
 
 Install *Project Monitors* in each project where you want to enable project monitoring.
 

--- a/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/prometheus-federator/prometheus-federator.adoc
+++ b/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/prometheus-federator/prometheus-federator.adoc
@@ -1,6 +1,6 @@
 = Prometheus Federator
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-07-15
+:revdate: 2026-08-06
 :page-revdate: {revdate}
 :community-path: reference-guides/prometheus-federator/index.adoc 
 :product-path: observability/monitoring-and-dashboards/prometheus-federator/prometheus-federator.adoc
@@ -10,6 +10,8 @@ endif::[]
 ifeval::["{build-type}" == "community"]
 :xref-prometheus-federator-rbac: xref:reference-guides/prometheus-federator/rbac.adoc
 endif::[]
+
+include::shared:ROOT:partial$en/deprecation-monitoring-v2.adoc[]
 
 Prometheus Federator, also referred to as Project Monitoring v2, deploys a Helm Project Operator (based on the https://github.com/rancher/helm-project-operator[rancher/helm-project-operator]), an operator that manages deploying Helm charts each containing a Project Monitoring Stack, where each stack contains:
 

--- a/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/prometheus-federator/rbac.adoc
+++ b/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/prometheus-federator/rbac.adoc
@@ -1,6 +1,6 @@
 = Role-Based Access Control
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2025-08-05
+:revdate: 2026-08-06
 :page-revdate: {revdate}
 :community-path: reference-guides/prometheus-federator/rbac.adoc 
 :product-path: observability/monitoring-and-dashboards/prometheus-federator/rbac.adoc
@@ -10,6 +10,8 @@ endif::[]
 ifeval::["{build-type}" == "community"]
 :xref-prometheus-federator: xref:reference-guides/prometheus-federator/index.adoc
 endif::[]
+
+include::shared:ROOT:partial$en/deprecation-monitoring-v2.adoc[]
 
 This section describes the expectations for Role-Based Access Control (RBAC) for Prometheus Federator.
 

--- a/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/prometheus-federator/set-up-workloads.adoc
+++ b/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/prometheus-federator/set-up-workloads.adoc
@@ -1,6 +1,6 @@
 = Setting up Prometheus Federator for a Workload
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2025-08-05
+:revdate: 2026-08-06
 :page-revdate: {revdate}
 :community-path: how-to-guides/advanced-user-guides/monitoring-alerting-guides/prometheus-federator-guides/set-up-workloads.adoc 
 :product-path: observability/monitoring-and-dashboards/prometheus-federator/set-up-workloads.adoc
@@ -10,6 +10,8 @@ endif::[]
 ifeval::["{build-type}" == "community"]
 :xref-rancher-workload-monitoring: xref:how-to-guides/advanced-user-guides/monitoring-alerting-guides/set-up-monitoring-for-workloads.adoc
 endif::[]
+
+include::shared:ROOT:partial$en/deprecation-monitoring-v2.adoc[]
 
 [#_display_cpu_and_memory_metrics_for_a_workload]
 == Display CPU and Memory Metrics for a Workload

--- a/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/prometheus-federator/uninstall-prometheus-federator.adoc
+++ b/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/prometheus-federator/uninstall-prometheus-federator.adoc
@@ -1,9 +1,11 @@
 = Uninstall Prometheus Federator
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2025-08-05
+:revdate: 2026-08-06
 :page-revdate: {revdate}
 :community-path: how-to-guides/advanced-user-guides/monitoring-alerting-guides/prometheus-federator-guides/uninstall-prometheus-federator.adoc 
 :product-path: observability/monitoring-and-dashboards/prometheus-federator/uninstall-prometheus-federator.adoc
+
+include::shared:ROOT:partial$en/deprecation-monitoring-v2.adoc[]
 
 . Click *☰ > Cluster Management*.
 . Go to the cluster that you created and click *Explore*.

--- a/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/promql-expressions.adoc
+++ b/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/promql-expressions.adoc
@@ -1,9 +1,11 @@
 = PromQL Expression Reference
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2025-08-05
+:revdate: 2026-08-06
 :page-revdate: {revdate}
 :community-path: integrations-in-rancher/monitoring-and-alerting/promql-expressions.adoc 
 :product-path: observability/monitoring-and-dashboards/promql-expressions.adoc
+
+include::shared:ROOT:partial$en/deprecation-monitoring-v2.adoc[]
 
 The PromQL expressions in this doc can be used to configure alerts.
 

--- a/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/rbac-for-monitoring.adoc
+++ b/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/rbac-for-monitoring.adoc
@@ -1,9 +1,11 @@
 = Role-based Access Control
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-07-15
+:revdate: 2026-08-06
 :page-revdate: {revdate}
 :community-path: integrations-in-rancher/monitoring-and-alerting/rbac-for-monitoring.adoc 
 :product-path: observability/monitoring-and-dashboards/rbac-for-monitoring.adoc
+
+include::shared:ROOT:partial$en/deprecation-monitoring-v2.adoc[]
 
 This section describes the expectations for RBAC for Rancher Monitoring.
 

--- a/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/set-up-monitoring-for-workloads.adoc
+++ b/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/set-up-monitoring-for-workloads.adoc
@@ -1,6 +1,6 @@
 = Setting up Monitoring for a Workload
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2025-08-05
+:revdate: 2026-08-06
 :page-revdate: {revdate}
 :community-path: how-to-guides/advanced-user-guides/monitoring-alerting-guides/set-up-monitoring-for-workloads.adoc 
 :product-path: observability/monitoring-and-dashboards/set-up-monitoring-for-workloads.adoc
@@ -10,6 +10,8 @@ endif::[]
 ifeval::["{build-type}" == "community"]
 :xref-promql-expressions: xref:integrations-in-rancher/monitoring-and-alerting/promql-expressions.adoc
 endif::[]
+
+include::shared:ROOT:partial$en/deprecation-monitoring-v2.adoc[]
 
 If you only need CPU and memory time series for the workload, you don't need to deploy a ServiceMonitor or PodMonitor because the monitoring application already collects metrics data on resource usage by default.
 

--- a/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/uninstall-monitoring.adoc
+++ b/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/uninstall-monitoring.adoc
@@ -1,9 +1,11 @@
 = Uninstall Monitoring
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2025-08-05
+:revdate: 2026-08-06
 :page-revdate: {revdate}
 :community-path: how-to-guides/advanced-user-guides/monitoring-alerting-guides/uninstall-monitoring.adoc 
 :product-path: observability/monitoring-and-dashboards/uninstall-monitoring.adoc
+
+include::shared:ROOT:partial$en/deprecation-monitoring-v2.adoc[]
 
 . Click *☰ > Cluster Management*.
 . Go to the cluster that you created and click *Explore*.

--- a/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/windows-support.adoc
+++ b/versions/v2.15/modules/en/pages/observability/monitoring-and-dashboards/windows-support.adoc
@@ -1,9 +1,11 @@
 = Windows Cluster Support for Monitoring V2
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2025-08-25
+:revdate: 2026-08-06
 :page-revdate: {revdate}
 :community-path: integrations-in-rancher/monitoring-and-alerting/windows-support.adoc 
 :product-path: observability/monitoring-and-dashboards/windows-support.adoc
+
+include::shared:ROOT:partial$en/deprecation-monitoring-v2.adoc[]
 
 Monitoring V2 can be deployed on a Windows cluster to scrape metrics from Windows nodes using https://github.com/prometheus-community/windows_exporter[prometheus-community/windows_exporter] (previously named `wmi_exporter`).
 

--- a/versions/v2.15/modules/en/pages/release-notes/v2.15.0.adoc
+++ b/versions/v2.15/modules/en/pages/release-notes/v2.15.0.adoc
@@ -1,6 +1,6 @@
 = Release {release-version}
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-07-31
+:revdate: 2026-08-05
 :page-revdate: {revdate}
 :release-version: v2.15.0
 :rn-component-version: v2.15
@@ -122,7 +122,7 @@ The `rancher-monitoring-dashboards` chart provides Grafana dashboards and Ranche
 * *No bundled runtime:* Operates without depending on Rancher-shipped `kube-prometheus-stack` images or components. It operates independently and does not require installing the legacy `rancher-monitoring` chart. It installs a dashboard-only version of `rancher-monitoring`.
 * *Prerequisites:* Requires uninstalling the `rancher-monitoring` chart and using a Prometheus infrastructure. Although several configurations are supported, installing `kube-prometheus-stack` is the simplest method.
 
-For more detailed information about installation and migrations, check the {rn-monitoring-dashboards}[Monitoring and Dashboards] documentation. See https://github.com/rancher/ob-team-charts/issues/221[#221] and https://github.com/rancher/ob-team-charts/issues/265[#265].
+For more detailed information regarding installation and migrations check the {rn-monitoring-dashboards}[Monitoring and Dashboards] documentation, and refer to the https://www.suse.com/c/the-path-to-modern-observability-why-were-evolving-the-suse-rancher-observability-stack/[evolution of SUSE Rancher Observability] blog post for further context. See https://github.com/rancher/ob-team-charts/issues/221[#221] and https://github.com/rancher/ob-team-charts/issues/265[#265].
 
 [#_behavior_changes_rancher_app_global_ui]
 === Behavior Changes


### PR DESCRIPTION
Adding deprecation notice info to 2.15 Rancher monitoring v2 community pages. The product pages structure has the information consolidated under the updated information, however the community structure requires further notices due to its structure being more partitioned with information presented.

Also updated the release note syncing with community notes on adding the blog post for more context, please let me know if edits are needed, thank you.