### PR TITLE
Fixes issues with audit-logs in documentation

### DIFF
--- a/versions/v2.14/modules/en/pages/cluster-deployment/configuration/rke2.adoc
+++ b/versions/v2.14/modules/en/pages/cluster-deployment/configuration/rke2.adoc
@@ -592,7 +592,7 @@ kind: Cluster
 spec:
   rkeConfig:
     machineGlobalConfig:
-      audit-policy-file:
+      audit-policy-file: |
         apiVersion: audit.k8s.io/v1
         kind: Policy
         rules:

--- a/versions/v2.15/modules/en/pages/cluster-deployment/configuration/rke2.adoc
+++ b/versions/v2.15/modules/en/pages/cluster-deployment/configuration/rke2.adoc
@@ -592,7 +592,7 @@ kind: Cluster
 spec:
   rkeConfig:
     machineGlobalConfig:
-      audit-policy-file:
+      audit-policy-file: |
         apiVersion: audit.k8s.io/v1
         kind: Policy
         rules:


### PR DESCRIPTION
The described example doesn't work. I've fixed the documentation according to https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/enable-api-audit-log-in-downstream-clusters

