### PR TITLE
Highlight external vs local auth provider usage

### DIFF
--- a/versions/v2.15/modules/en/pages/rancher-admin/users/authn-and-authz/authn-and-authz.adoc
+++ b/versions/v2.15/modules/en/pages/rancher-admin/users/authn-and-authz/authn-and-authz.adoc
@@ -52,9 +52,13 @@ This centralized user authentication is accomplished using the Rancher authentic
 The account used to enable the external provider will be granted admin permissions. If you use a test account or non-admin account, that account will still be granted admin-level permissions. See <<_external_authentication_configuration_and_principal_users,External Authentication Configuration and Principal Users>> to understand why.
 ====
 
-
 [#_external_vs_local_authentication]
 == External vs. Local Authentication
+
+External authentication provides centralized, enterprise-grade security through a third-party identity provider, while local authentication serves small test environments.
+
+* *External Authentication (Recommended for Production)*: The primary and preferred method for managing user access. External providers offer the robust security controls, strict password requirements, and centralized identity management necessary for enterprise environments.
+* *Local Authentication (Small Deployments)*: Rancher also provides {xref-local-users}[local authentication]. This is a built-in provider active by default. It is intended strictly for small deployments and testing. In production environments, local authentication should only be used as an emergency backup to ensure you can access Rancher if your external authentication provider goes down.
 
 The Rancher authentication proxy integrates with the following external authentication services.
 
@@ -76,10 +80,6 @@ The Rancher authentication proxy integrates with the following external authenti
 | {xref-configure-generic-oidc}[Generic (OIDC)]
 |===
 
-However, Rancher also provides {xref-local-users}[local authentication].
-
-In most cases, you should use an external authentication service over local authentication, as external authentication allows user management from a central location. However, you may want a few local authentication users for managing Rancher under rare circumstances, such as if your external authentication provider is unavailable or undergoing maintenance.
-
 [#_users_and_groups]
 == Users and Groups
 
@@ -91,7 +91,7 @@ In most cases, you should use an external authentication service over local auth
 
 Rancher relies on users and groups to determine who is allowed to log in to Rancher and which resources they can access. When authenticating with an external provider, groups are provided from the external provider based on the user. These users and groups are given specific roles to resources like clusters and projects. When you give access to a group, all users who are a member of that group in the authentication provider will be able to access the resource with the permissions that you've specified. For more information on roles and permissions, see {xref-manage-rbac}[Role Based Access Control].
 
-For more information, see {xref-users-and-groups}[Users and Groups]
+For more information, see {xref-users-and-groups}[Users and Groups].
 
 [#_scope_of_rancher_authorization]
 == Scope of Rancher Authorization

--- a/versions/v2.15/modules/en/pages/rancher-admin/users/authn-and-authz/create-local-users.adoc
+++ b/versions/v2.15/modules/en/pages/rancher-admin/users/authn-and-authz/create-local-users.adoc
@@ -4,6 +4,19 @@
 :page-revdate: {revdate}
 :community-path: how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/create-local-users.adoc 
 :product-path: rancher-admin/users/authn-and-authz/create-local-users.adoc
+ifeval::["{build-type}" != "community"]
+:xref-authn-and-authz: xref:rancher-admin/users/authn-and-authz/authn-and-authz.adoc
+endif::[]
+ifeval::["{build-type}" == "community"]
+:xref-authn-and-authz: xref:how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/index.adoc
+endif::[]
+
+[IMPORTANT]
+====
+Rancher's local authentication provider is designed primarily to support small-scale deployments and test environments.
+
+Enterprise customers require stronger security controls, such as advanced password policies and centralized identity management. It is highly recommended to configure an {xref-authn-and-authz}[external authentication] provider as your primary method for managing user access. In production environments, local authentication should only be used as an emergency backup to ensure you can access Rancher if your external authentication provider goes down.
+====
 
 Local authentication is the default until you configure an external authentication provider. Rancher stores user account information, such as usernames and passwords, locally. By default, the `admin` user that logs in to Rancher for the first time is a local user.
 


### PR DESCRIPTION
Related to https://github.com/rancher/rancher-product-docs/issues/1322. 

Highlight external vs local auth provider usage
- Update https://documentation.suse.com/cloudnative/rancher-manager/latest/en/rancher-admin/users/authn-and-authz/create-local-users.html
- Update https://documentation.suse.com/cloudnative/rancher-manager/latest/en/rancher-admin/users/authn-and-authz/authn-and-authz.html


- [ ] Add changes to applicable versions. 