### PR TITLE
Update the split brain link to official etcd documentation

### DIFF
--- a/versions/v2.11/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/set-up-infrastructure.adoc
+++ b/versions/v2.11/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/set-up-infrastructure.adoc
@@ -1,6 +1,6 @@
 = 1. Set up Infrastructure
 :page-languages: [en, zh]
-:revdate: 2026-07-15
+:revdate: 2026-08-11
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/set-up-infrastructure.adoc 
 :product-path: installation-and-upgrade/other-installation-methods/http-proxy/set-up-infrastructure.adoc
@@ -33,9 +33,8 @@ These nodes must be in the same region/data center. You may place these servers 
 
 == Why Three Nodes?
 
-In an RKE cluster, Rancher server data is stored on etcd. This etcd database runs on all three nodes.
+Achieving fault tolerance in a high-availability (HA) RKE2/K3s setup requires a minimum of three etcd nodes. Adding an even node (e.g., expanding from 3 to 4 nodes) increases the required quorum from 2 to 3 without increasing fault tolerance - both configurations can only tolerate a single node failure. A 3-node cluster is the baseline for high availability because if one node fails, the remaining two maintain a majority quorum (N / 2+1) to elect aleader and maintain quorum, per the [etcd documentation](https://etcd.io/docs/v3.6/faq/#why-an-odd-number-of-cluster-members).
 
-The etcd database requires an odd number of nodes so that it can always elect a leader with a majority of the etcd cluster. If the etcd database cannot elect a leader, etcd can suffer from https://www.quora.com/What-is-split-brain-in-distributed-systems[split brain], requiring the cluster to be restored from backup. If one of the three etcd nodes fails, the two remaining nodes can elect a leader because they have the majority of the total number of etcd nodes.
 
 == 1. Set up Linux Nodes
 

--- a/versions/v2.12/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/set-up-infrastructure.adoc
+++ b/versions/v2.12/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/set-up-infrastructure.adoc
@@ -35,9 +35,8 @@ These nodes must be in the same region/data center. You may place these servers 
 
 == Why Three Nodes?
 
-In an RKE2/K3s cluster, Rancher server data is stored on etcd. This etcd database runs on all three nodes.
+Achieving fault tolerance in a high-availability (HA) RKE2/K3s setup requires a minimum of three etcd nodes. Adding an even node (e.g., expanding from 3 to 4 nodes) increases the required quorum from 2 to 3 without increasing fault tolerance - both configurations can only tolerate a single node failure. A 3-node cluster is the baseline for high availability because if one node fails, the remaining two maintain a majority quorum (N / 2+1) to elect aleader and maintain quorum, per the [etcd documentation](https://etcd.io/docs/v3.6/faq/#why-an-odd-number-of-cluster-members).
 
-The etcd database requires an odd number of nodes so that it can always elect a leader with a majority of the etcd cluster. If the etcd database cannot elect a leader, etcd can suffer from https://www.quora.com/What-is-split-brain-in-distributed-systems[split brain], requiring the cluster to be restored from backup. If one of the three etcd nodes fails, the two remaining nodes can elect a leader because they have the majority of the total number of etcd nodes.
 
 == 1. Set up Linux Nodes
 

--- a/versions/v2.13/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/set-up-infrastructure.adoc
+++ b/versions/v2.13/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/set-up-infrastructure.adoc
@@ -2,7 +2,7 @@
 ifeval::["{build-type}" != "srfa"]
 :page-languages: [en, zh]
 endif::[]
-:revdate: 2026-07-15
+:revdate: 2026-08-11
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/set-up-infrastructure.adoc 
 :product-path: installation-and-upgrade/other-installation-methods/http-proxy/set-up-infrastructure.adoc
@@ -35,9 +35,8 @@ These nodes must be in the same region/data center. You may place these servers 
 
 == Why Three Nodes?
 
-In an RKE2/K3s cluster, Rancher server data is stored on etcd. This etcd database runs on all three nodes.
+Achieving fault tolerance in a high-availability (HA) RKE2/K3s setup requires a minimum of three etcd nodes. Adding an even node (e.g., expanding from 3 to 4 nodes) increases the required quorum from 2 to 3 without increasing fault tolerance - both configurations can only tolerate a single node failure. A 3-node cluster is the baseline for high availability because if one node fails, the remaining two maintain a majority quorum (N / 2+1) to elect aleader and maintain quorum, per the [etcd documentation](https://etcd.io/docs/v3.6/faq/#why-an-odd-number-of-cluster-members).
 
-The etcd database requires an odd number of nodes so that it can always elect a leader with a majority of the etcd cluster. If the etcd database cannot elect a leader, etcd can suffer from https://www.quora.com/What-is-split-brain-in-distributed-systems[split brain], requiring the cluster to be restored from backup. If one of the three etcd nodes fails, the two remaining nodes can elect a leader because they have the majority of the total number of etcd nodes.
 
 == 1. Set up Linux Nodes
 

--- a/versions/v2.14/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/set-up-infrastructure.adoc
+++ b/versions/v2.14/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/set-up-infrastructure.adoc
@@ -1,6 +1,6 @@
 = 1. Set up Infrastructure
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-07-15
+:revdate: 2026-08-11
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/set-up-infrastructure.adoc 
 :product-path: installation-and-upgrade/other-installation-methods/http-proxy/set-up-infrastructure.adoc
@@ -34,9 +34,8 @@ These nodes must be in the same region/data center. You may place these servers 
 [#_why_three_nodes]
 == Why Three Nodes?
 
-In an RKE2/K3s cluster, Rancher server data is stored on etcd. This etcd database runs on all three nodes.
+Achieving fault tolerance in a high-availability (HA) RKE2/K3s setup requires a minimum of three etcd nodes. Adding an even node (e.g., expanding from 3 to 4 nodes) increases the required quorum from 2 to 3 without increasing fault tolerance - both configurations can only tolerate a single node failure. A 3-node cluster is the baseline for high availability because if one node fails, the remaining two maintain a majority quorum (N / 2+1) to elect aleader and maintain quorum, per the [etcd documentation](https://etcd.io/docs/v3.6/faq/#why-an-odd-number-of-cluster-members).
 
-The etcd database requires an odd number of nodes so that it can always elect a leader with a majority of the etcd cluster. If the etcd database cannot elect a leader, etcd can suffer from https://www.quora.com/What-is-split-brain-in-distributed-systems[split brain], requiring the cluster to be restored from backup. If one of the three etcd nodes fails, the two remaining nodes can elect a leader because they have the majority of the total number of etcd nodes.
 
 [#_1_set_up_linux_nodes]
 == 1. Set up Linux Nodes

--- a/versions/v2.15/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/set-up-infrastructure.adoc
+++ b/versions/v2.15/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/set-up-infrastructure.adoc
@@ -1,6 +1,6 @@
 = 1. Set up Infrastructure
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-07-15
+:revdate: 2026-08-07
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/set-up-infrastructure.adoc 
 :product-path: installation-and-upgrade/other-installation-methods/http-proxy/set-up-infrastructure.adoc
@@ -36,7 +36,7 @@ These nodes must be in the same region/data center. You may place these servers 
 
 In an RKE2/K3s cluster, Rancher server data is stored on etcd. This etcd database runs on all three nodes.
 
-The etcd database requires an odd number of nodes so that it can always elect a leader with a majority of the etcd cluster. If the etcd database cannot elect a leader, etcd can suffer from https://www.quora.com/What-is-split-brain-in-distributed-systems[split brain], requiring the cluster to be restored from backup. If one of the three etcd nodes fails, the two remaining nodes can elect a leader because they have the majority of the total number of etcd nodes.
+The etcd database requires an odd number of nodes so that it can always elect a leader with a majority of the etcd cluster. If the etcd database cannot elect a leader, etcd can suffer from https://etcd.io/docs/v3.6/faq/#why-an-odd-number-of-cluster-members[split brain], requiring the cluster to be restored from backup. If one of the three etcd nodes fails, the two remaining nodes can elect a leader because they have the majority of the total number of etcd nodes.
 
 [#_1_set_up_linux_nodes]
 == 1. Set up Linux Nodes

--- a/versions/v2.15/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/set-up-infrastructure.adoc
+++ b/versions/v2.15/modules/en/pages/installation-and-upgrade/other-installation-methods/http-proxy/set-up-infrastructure.adoc
@@ -1,6 +1,6 @@
 = 1. Set up Infrastructure
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-08-07
+:revdate: 2026-08-11
 :page-revdate: {revdate}
 :community-path: getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/set-up-infrastructure.adoc 
 :product-path: installation-and-upgrade/other-installation-methods/http-proxy/set-up-infrastructure.adoc
@@ -34,9 +34,7 @@ These nodes must be in the same region/data center. You may place these servers 
 [#_why_three_nodes]
 == Why Three Nodes?
 
-In an RKE2/K3s cluster, Rancher server data is stored on etcd. This etcd database runs on all three nodes.
-
-The etcd database requires an odd number of nodes so that it can always elect a leader with a majority of the etcd cluster. If the etcd database cannot elect a leader, etcd can suffer from https://etcd.io/docs/v3.6/faq/#why-an-odd-number-of-cluster-members[split brain], requiring the cluster to be restored from backup. If one of the three etcd nodes fails, the two remaining nodes can elect a leader because they have the majority of the total number of etcd nodes.
+Achieving fault tolerance in a high-availability (HA) RKE2/K3s setup requires a minimum of three etcd nodes. Adding an even node (e.g., expanding from 3 to 4 nodes) increases the required quorum from 2 to 3 without increasing fault tolerance - both configurations can only tolerate a single node failure. A 3-node cluster is the baseline for high availability because if one node fails, the remaining two maintain a majority quorum (N / 2+1) to elect aleader and maintain quorum, per the [etcd documentation](https://etcd.io/docs/v3.6/faq/#why-an-odd-number-of-cluster-members).
 
 [#_1_set_up_linux_nodes]
 == 1. Set up Linux Nodes


### PR DESCRIPTION
We are referring to Quora link to explain the split-brain scenario: https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/rancher-behind-an-http-proxy/set-up-infrastructure#_why_three_nodes.
==> "The etcd database requires an odd number of nodes so that it can always elect a leader with a majority of the etcd cluster. If the etcd database cannot elect a leader, etcd can suffer from [**split brain](https://www.quora.com/What-is-split-brain-in-distributed-systems),**"
It would be much more accurate to use the official etcd or raft docs as source:
- https://etcd.io/docs/v3.3/faq/#why-an-odd-number-of-cluster-members
- https://raft.github.io/