### PR TITLE
2.15 RN - updating RKE2/K3s K8s version

### DIFF
--- a/versions/v2.15/modules/en/pages/release-notes/v2.15.0.adoc
+++ b/versions/v2.15/modules/en/pages/release-notes/v2.15.0.adoc
@@ -1,6 +1,6 @@
 = Release {release-version}
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-08-05
+:revdate: 2026-08-12
 :page-revdate: {revdate}
 :release-version: v2.15.0
 :rn-component-version: v2.15
@@ -287,8 +287,8 @@ Image artifact digests are renamed in Rancher v2.12.0, v2.11.4 and v2.10.8. Up u
 [#_kubernetes_versions_for_rke2_k3s]
 === Kubernetes Versions for RKE2/K3s
 
-* v1.36.3 (Default)
-* v1.35.7
+* v1.36.1 (Default)
+* v1.35.5
 * v1.34.9
 
 === Rancher Helm Chart Versions


### PR DESCRIPTION
Updating RKE2/K3s K8s version per Slack thread, sourced from https://github.com/rancher/rancher/issues/55099.