### PR TITLE
Updates to .github/workflows/draft-release-notes.yml & friends

### DIFF
--- a/.github/instructions/RN-MINOR-VERSION.instructions.md
+++ b/.github/instructions/RN-MINOR-VERSION.instructions.md
@@ -1,0 +1,24 @@
+---
+applyTo: "app/models/**/*.0.adoc"
+---
+@copilot
+
+* First, clean up the `__VERSION__.adoc` files in this PR:
+  * Remove the entire `Security Fixes for Vulnerabilities` section if found.
+  * Remove any bug fix release notes listed under `Major Bug Fixes` sections.
+  * Remove any feature enhancements release notes listed under `Features and Enhancements` sections.
+  * Move the issues listed under `Behavior Changes` and `Known Issues` sections to later in the document, to sections `Previous Rancher Behavior Changes` and `Long-standing Known Issues`. Older issues are listed with their respective categories, for example issued originally under `Cluster Provisioning` are moved to the `Long-standing Known Issues - Cluster Provisioning` section.
+    * For each moved issue, list it under the release it was introduced in, for example `Rancher v2.13.1:`, following the format of other old issues.
+* Next, use the search queries in the PR body to search for the issues labeled as `release-note` or `release-note-prime`.
+* For each found issue, scan the body, comments, referenced Pull Requests and GitHub issues and labels to understand the full context of the Rancher __VERSION__ release and the status of the issue.
+  * Summarize the scanned contents as a release note, following the format found in the `__VERSION__.adoc` files.
+  * If the issue is a backport/forwardport, the issue will reference another issue that it is backported/forwardported from. Check the referenced issue to see if it has a `release-note` or `release-note-prime` label. If it does, reuse the existing description.
+  * If the issue has a comment containing a Release Notes summary of the issue, reuse that as the description.
+  * Update reused descriptions for clarity and grammar as needed.
+*  Update the `__VERSION__.adoc` files with the summarized release notes, placing them under the correct section in the document. Attempt to determine the correct section by scanning issue labels for relevant areas and teams. If no suitable section can be determined, place the issue under `Rancher General`.
+* For each issue under the specific section, determine the release note type of each issue and place it under the correct subsection category of `Features and Enhancements`, `Behavior Changes`, `Major Bug Fixes`, or `Known Issues`.
+* Post a comment summarizing found issues, formatted as separate tables for each search query. Each table should also contain the determined category and found references to related issues or PRs.
+* Scan issues found in the `Long-standing Known Issues` section in the `__VERSION__.adoc` files, follow the referenced links and list issues closed in the past 45 days in a table in the comment, including the date and a summary of the latest updates made to the issue. Ignore any closed as not planned issues.
+  * If the scanned long-standing known issues contain a comment with either a `/backport __VERSION__` or `/forwardport __VERSION__` in it, report this in the summary.
+  * Then search for any `[backport]` or `[forwardport]` link references to determine the status of the long-standing known issue and update the summary and the document accordingly.
+* Finally, remove empty placeholder sections in the document.

--- a/.github/instructions/RN-MINOR-VERSION.instructions.md
+++ b/.github/instructions/RN-MINOR-VERSION.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "**/*.0.adoc,**/*.1.adoc"
+applyTo: "**/release-notes/*.0.adoc,**/release-notes/*.1.adoc"
 ---
 @copilot
 

--- a/.github/instructions/RN-MINOR-VERSION.instructions.md
+++ b/.github/instructions/RN-MINOR-VERSION.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "app/models/**/*.0.adoc"
+applyTo: "**/*.0.adoc,**/*.1.adoc"
 ---
 @copilot
 

--- a/.github/instructions/RN-PATCH-VERSION.instructions.md
+++ b/.github/instructions/RN-PATCH-VERSION.instructions.md
@@ -1,9 +1,10 @@
 ---
-applyTo: "app/models/**/*.adoc"
+applyTo: "**/*.adoc"
 ---
 @copilot
 
 * First, clean up the `__VERSION__.adoc` files in this PR:
+  * Remove the entire `What's New - SUSE Rancher Prime` section if found.
   * Remove the entire `Security Fixes for Vulnerabilities` section if found.
   * Remove any bug fix release notes listed under `Major Bug Fixes` sections.
   * Remove any feature enhancements release notes listed under `Features and Enhancements` sections.

--- a/.github/instructions/RN-PATCH-VERSION.instructions.md
+++ b/.github/instructions/RN-PATCH-VERSION.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "**/*.adoc"
+applyTo: "**/release-notes/*.adoc"
 ---
 @copilot
 

--- a/.github/instructions/RN-PATCH-VERSION.instructions.md
+++ b/.github/instructions/RN-PATCH-VERSION.instructions.md
@@ -1,0 +1,24 @@
+---
+applyTo: "app/models/**/*.adoc"
+---
+@copilot
+
+* First, clean up the `__VERSION__.adoc` files in this PR:
+  * Remove the entire `Security Fixes for Vulnerabilities` section if found.
+  * Remove any bug fix release notes listed under `Major Bug Fixes` sections.
+  * Remove any feature enhancements release notes listed under `Features and Enhancements` sections.
+  * Move the issues listed under `Behavior Changes` and `Known Issues` sections to later in the document, to sections `Previous Rancher Behavior Changes` and `Long-standing Known Issues`. Older issues are listed with their respective categories, for example issued originally under `Cluster Provisioning` are moved to the `Long-standing Known Issues - Cluster Provisioning` section.
+    * For each moved issue, list it under the release it was introduced in, for example `Rancher v2.13.1:`, following the format of other old issues.
+* Next, use the search queries in the PR body to search for the issues labeled as `release-note` or `release-note-prime`.
+* For each found issue, scan the body, comments, referenced Pull Requests and GitHub issues and labels to understand the full context of the Rancher __VERSION__ release and the status of the issue.
+  * Summarize the scanned contents as a release note, following the format found in the `__VERSION__.adoc` files.
+  * If the issue is a backport/forwardport, the issue will reference another issue that it is backported/forwardported from. Check the referenced issue to see if it has a `release-note` or `release-note-prime` label. If it does, reuse the existing description.
+  * If the issue has a comment containing a Release Notes summary of the issue, reuse that as the description.
+  * Update reused descriptions for clarity and grammar as needed.
+*  Update the `__VERSION__.adoc` files with the summarized release notes, placing them under the correct section in the document. Attempt to determine the correct section by scanning issue labels for relevant areas and teams. If no suitable section can be determined, place the issue under `Rancher General`.
+* For each issue under the specific section, determine the release note type of each issue and place it under the correct subsection category of `Features and Enhancements`, `Behavior Changes`, `Major Bug Fixes`, or `Known Issues`.
+* Post a comment summarizing found issues, formatted as separate tables for each search query. Each table should also contain the determined category and found references to related issues or PRs.
+* Scan issues found in the `Long-standing Known Issues` section in the `__VERSION__.adoc` files, follow the referenced links and list issues closed in the past 45 days in a table in the comment, including the date and a summary of the latest updates made to the issue. Ignore any closed as not planned issues.
+  * If the scanned long-standing known issues contain a comment with either a `/backport __VERSION__` or `/forwardport __VERSION__` in it, report this in the summary.
+  * Then search for any `[backport]` or `[forwardport]` link references to determine the status of the long-standing known issue and update the summary and the document accordingly.
+* Finally, remove empty placeholder sections in the document.

--- a/.github/workflows/draft-release-notes.yml
+++ b/.github/workflows/draft-release-notes.yml
@@ -68,7 +68,7 @@ jobs:
           BRANCH_NAME="release-notes-${VERSION}"
 
           # Determine the correct instructions file based on the version
-          if [[ "$VERSION" == *.0 ]]; then
+          if [[ "$VERSION" == *.0 || "$VERSION" == *.1 ]]; then
             INSTRUCTIONS_FILE=".github/instructions/RN-MINOR-VERSION.instructions.md"
           else
             INSTRUCTIONS_FILE=".github/instructions/RN-PATCH-VERSION.instructions.md"

--- a/.github/workflows/draft-release-notes.yml
+++ b/.github/workflows/draft-release-notes.yml
@@ -50,24 +50,7 @@ jobs:
             <summary>copilot prompt template</summary>
 
             ```text
-            @copilot
-
-            * First, clean up the `__VERSION__.adoc` files in this PR:
-              * Remove any bug fix release notes listed under `Major Bug Fixes` sections.
-              * Remove any feature enhancements release notes listed under `Features and Enhancements` sections.
-              * Move the issues listed under `Behavior Changes` and `Known Issues` sections to later in the document, to sections `Previous Rancher Behavior Changes` and `Long-standing Known Issues`. Older issues are listed with their respective categories, for example issued originally under `Cluster Provisioning` are moved to the `Long-standing Known Issues - Cluster Provisioning` section.
-                * For each moved issue, list it under the release it was introduced in, for example `Rancher v2.13.1:`, following the format of other old issues.
-            * Next, use the search queries in the PR body to search for the issues labeled as `release-note` or `release-note-prime`.
-            * For each found issue, scan the body, comments, referenced Pull Requests and GitHub issues and labels to understand the full context of the Rancher __VERSION__ release and the status of the issue.
-              * Summarize the scanned contents as a release note, following the format found in the `__VERSION__.adoc` files.
-              * If the issue is a backport/forwardport, the issue will reference another issue that it is backported/forwardported from. Check the referenced issue to see if it has a `release-note` or `release-note-prime` label. If it does, reuse the existing description.
-              * If the issue has a comment containing a Release Notes summary of the issue, reuse that as the description.
-              * Update reused descriptions for clarity and grammar as needed.
-            *  Update the `__VERSION__.adoc` files with the summarized release notes, placing them under the correct section in the document. Attempt to determine the correct section by scanning issue labels for relevant areas and teams. If no suitable section can be determined, place the issue under `Rancher General`.
-            * For each issue under the specific section, determine the release note type of each issue and place it under the correct subsection category of `Features and Enhancements`, `Behavior Changes`, `Major Bug Fixes`, or `Known Issues`.
-            * Post a comment summarizing found issues, formatted as separate tables for each search query. Each table should also contain the determined category and found references to related issues or PRs.
-            * Scan issues found in the `Long-standing Known Issues` section in the `__VERSION__.adoc` files, follow the referenced links and list issues closed in the past 45 days in a table in the comment, including the date and a summary of the latest updates made to the issue. Ignore any closed as not planned issues.
-            * Finally, remove empty placeholder sections in the document.
+            __INSTRUCTIONS__
             ```
             </details>
         run: |
@@ -75,6 +58,15 @@ jobs:
           VERSION=${VERSION%%-*}
           MINOR_VERSION=${VERSION%.*}
           BRANCH_NAME="release-notes-${VERSION}"
+
+          # Determine the correct instructions file based on the version
+          if [[ "$VERSION" == *.0 ]]; then
+            INSTRUCTIONS_FILE=".github/instructions/RN-MINOR-VERSION.instructions.md"
+          else
+            INSTRUCTIONS_FILE=".github/instructions/RN-PATCH-VERSION.instructions.md"
+          fi
+          # Strip the YAML front matter
+          INSTRUCTIONS=$(sed '1,/^---$/d' "$INSTRUCTIONS_FILE")
 
           if git ls-remote --heads origin "$VERSION" | grep -q "$VERSION"; then
             BASE_BRANCH="$VERSION"
@@ -95,7 +87,10 @@ jobs:
           git push -f origin "$BRANCH_NAME"
 
           PR_NUMBER=$(gh pr list --head "$BRANCH_NAME" --base "$BASE_BRANCH" --json number --jq '.[0].number')
-          PR_BODY="${PR_BODY_TEMPLATE//__VERSION__/$VERSION}"
+          
+          # Inject instructions first so __VERSION__ strings inside the instructions are updated too
+          PR_BODY="${PR_BODY_TEMPLATE//__INSTRUCTIONS__/$INSTRUCTIONS}"
+          PR_BODY="${PR_BODY//__VERSION__/$VERSION}"
           PR_BODY="${PR_BODY//__MINOR_VERSION__/$MINOR_VERSION}"
 
           if [[ -n "$PR_NUMBER" && "$PR_NUMBER" != "null" ]]; then

--- a/.github/workflows/draft-release-notes.yml
+++ b/.github/workflows/draft-release-notes.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       version:
         description: 'The release version (e.g., v2.13.4)'
-        required: true
+        required: false
 
 jobs:
   draft-and-commit:
@@ -19,8 +19,19 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - name: Determine Version
+        run: |
+          if [[ -n "${{ inputs.version }}" ]]; then
+            echo "VERSION=${{ inputs.version }}" >> "$GITHUB_ENV"
+          elif [[ "${{ github.ref_name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then
+            echo "VERSION=${{ github.ref_name }}" >> "$GITHUB_ENV"
+          else
+            echo "Error: Could not determine release version. Please provide it manually as an input, or run the workflow from a branch matching the version schema (e.g., v2.13.4)."
+            exit 1
+          fi
+
       - name: Generate Release Notes Draft
-        run: ./scripts/draft-release-notes.sh "${{ inputs.version }}"
+        run: ./scripts/draft-release-notes.sh "$VERSION"
 
       - name: Load App Credentials from Vault
         uses: rancher-eio/read-vault-secrets@7282bf97898cd1c16c89f837e0bb442e6d384c89 # main
@@ -32,7 +43,6 @@ jobs:
       - name: Create Pull Request
         env:
           GH_TOKEN: ${{ env.GH_TOKEN || github.token }}
-          VERSION: ${{ inputs.version }}
           PR_BODY_TEMPLATE: |
             - [ ] Remove the old info, issues listed as Bug Fixes and Features, move previous 'Known Issues' and 'Behavior Changes' to 'Long-standing Known Issues' and 'Previous Rancher Behavior Changes' section.
             - [ ] New issues for __VERSION__:
@@ -43,8 +53,6 @@ jobs:
               - [ ] [rancher/backup-restore-operator](https://github.com/rancher/backup-restore-operator/issues?q=is%3Aissue%20state%3Aopen%20label%3Arelease-note%20milestone%3A__VERSION__)
             - [ ] Existing Known Issues
             - [ ] Updated K8s versions
-
-            Also, the `versions/__MINOR_VERSION__/modules/zh/pages/release-notes/__VERSION__.adoc` file is just a copy of `versions/__MINOR_VERSION__/modules/en/pages/release-notes/__VERSION__.adoc` atm and does not need to be reviewed.
 
             <details>
             <summary>copilot prompt template</summary>

--- a/.github/workflows/draft-release-notes.yml
+++ b/.github/workflows/draft-release-notes.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'The release version (e.g., v2.13.4)'
+        description: 'Optional: The release version (e.g., v2.13.4)'
         required: false
 
 jobs:

--- a/.github/workflows/generate-release-notes.yml
+++ b/.github/workflows/generate-release-notes.yml
@@ -1,10 +1,15 @@
 name: Generate and Store Release Notes
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'versions/*/modules/en/pages/release-notes/v*.[0-3].adoc'
   workflow_dispatch:
     inputs:
       version:
-        description: 'Optional: the patch release version (e.g., v2.13.1)'
+        description: 'Optional: The patch release version (e.g., v2.13.1)'
         required: false
         default: ''
 

--- a/scripts/draft-release-notes.sh
+++ b/scripts/draft-release-notes.sh
@@ -310,7 +310,22 @@ if [ -f "$NAV_FILE" ]; then
             print new_entry
             inserted = 1
         }
+        /^\* xref:release-notes\.adoc\[.*\]/ {
+            print
+            in_rn = 1
+            next
+        }
+        !inserted && in_rn && /^\* / {
+            print new_entry
+            inserted = 1
+            in_rn = 0
+        }
         { print }
+        END {
+            if (in_rn && !inserted) {
+                print new_entry
+            }
+        }
         ' "$NAV_FILE" > "${NAV_FILE}.tmp" && mv "${NAV_FILE}.tmp" "$NAV_FILE"
     fi
 else
@@ -334,7 +349,22 @@ for LOCALE_DIR in "$VERSIONS_DIR/modules/"*; do
                 print new_entry
                 inserted = 1
             }
+            /^\* xref:release-notes\.adoc\[.*\]/ {
+                print
+                in_rn = 1
+                next
+            }
+            !inserted && in_rn && /^\* / {
+                print new_entry
+                inserted = 1
+                in_rn = 0
+            }
             { print }
+            END {
+                if (in_rn && !inserted) {
+                    print new_entry
+                }
+            }
             ' "$LOCALE_NAV_FILE" > "${LOCALE_NAV_FILE}.tmp" && mv "${LOCALE_NAV_FILE}.tmp" "$LOCALE_NAV_FILE"
         fi
     else


### PR DESCRIPTION
- [Add Copilot instructions for minor & patch ver](https://github.com/rancher/rancher-product-docs/commit/9be8d458e39411226965db06a6097951c87efcf0)
  - based on https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/add-custom-instructions/add-repository-instructions
  - updated based on feedback from previous agentic sessions
  - mostly a proof of concept for now but the instructions are expected to diverge as we learn more about RN prompts
- [Determine release version dynamically](https://github.com/rancher/rancher-product-docs/commit/67d8305fa6e076686b5a37423adeaf0d99667885)
- [Also run when release-notes/v*.[0-3].adoc is touched](https://github.com/rancher/rancher-product-docs/commit/ff73b708d16367176584402c6769075bc227fa7d)
- [Fix updating nav files for .0 version](https://github.com/rancher/rancher-product-docs/commit/8fd04706b51f3e6d4fa57efebf95c6810abd638a)

Test PR: https://github.com/pmkovar/rancher-product-docs/pull/43